### PR TITLE
remove dream2nix bot

### DIFF
--- a/nixos/eva/modules/go-neb.nix
+++ b/nixos/eva/modules/go-neb.nix
@@ -57,10 +57,6 @@
             Rooms."!PbtOpdWBSRFbEZRLIf:numtide.com".Repos = {
               "nix-community/infra".Events = [ "push" "issues" "pull_request" ];
             };
-            Rooms."!PrIEtcffTLLzUWvJOS:matrix.org".Repos = {
-              "nix-community/dream2nix".Events = [ "pull_request" ];
-              "nix-community/dreampkgs".Events = [ "pull_request" ];
-            };
           };
         }
         {


### PR DESCRIPTION
It really turns out to be to spammy. It posts every update on a PR