### PR TITLE
screenshare: add numtide link

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -618,11 +618,11 @@
     },
     "retiolum": {
       "locked": {
-        "lastModified": 1678773616,
-        "narHash": "sha256-POr8rTMNmcnwe2tnWxhXG7T3W4wQp8cjN+TFpwsiLrs=",
+        "lastModified": 1679679300,
+        "narHash": "sha256-iJetVFDjj64yBj7tEyslSWnn+M5bmT5M4BqUVPgxoMk=",
         "ref": "refs/heads/master",
-        "rev": "5492459f4516b89686e1d8086c9b46db39b6902b",
-        "revCount": 289,
+        "rev": "44c871d256c7a99d6aba05bdc43316ff5884b995",
+        "revCount": 290,
         "type": "git",
         "url": "https://git.thalheim.io/Mic92/retiolum"
       },

--- a/nixos/eve/modules/gitea/retiolum-hook.sh
+++ b/nixos/eve/modules/gitea/retiolum-hook.sh
@@ -62,6 +62,7 @@ nix build \
   -I nixos-config=./dummy.nix \
   -I stockholm=./. \
   -f '<nixpkgs/nixos>' \
+  --builders '' \
   config.krebs.tinc.retiolum.hostsArchive
 install -D -m644 result $WEBROOT/tinc-hosts.tar.bz2
 nix build \
@@ -69,6 +70,7 @@ nix build \
   -I nixos-config=./dummy.nix \
   -I stockholm=./. \
   -f '<nixpkgs/nixos>' \
+  --builders '' \
   pkgs.krebs-hosts
 install -D -m644 result $WEBROOT/etc.hosts
 grep -E '^42:|.i |.i$' result >$WEBROOT/etc.hosts-v6only
@@ -76,7 +78,8 @@ grep -E '^42:|.i |.i$' result >$WEBROOT/etc.hosts-v6only
 nix-build ./wiregrill.nix \
   -I secrets=./krebs/0tests/data/secrets \
   -I nixos-config=./dummy.nix \
-  -I stockholm=./.
+  -I stockholm=./. \
+  --option builders ''
 
 jq <result >$WEBROOT/wiregrill.json
 

--- a/nixos/eve/modules/nginx/screenshare/default.nix
+++ b/nixos/eve/modules/nginx/screenshare/default.nix
@@ -17,6 +17,7 @@ in
 {
   services.nginx = {
     virtualHosts."screenshare.thalheim.io" = screenshareWebsite "screenshare";
+    virtualHosts."screenshare-numtide.thalheim.io" = screenshareWebsite "numtide";
     virtualHosts."screenshare2.thalheim.io" = screenshareWebsite "screenshare2";
 
     virtualHosts."www.screenshare.thalheim.io" = {


### PR DESCRIPTION




retiolum-hook: drop remote builders




flake.lock: Update

Flake lock file updates:

• Updated input 'retiolum':
    'git+https://git.thalheim.io/Mic92/retiolum?ref=refs%2fheads%2fmaster&rev=5492459f4516b89686e1d8086c9b46db39b6902b' (2023-03-14)
  → 'git+https://git.thalheim.io/Mic92/retiolum?ref=refs%2fheads%2fmaster&rev=44c871d256c7a99d6aba05bdc43316ff5884b995' (2023-03-24)
bors merge