### PR TITLE
eva/telegraf: add aarch64.nixos.community and darwin01.nix-community.org

### DIFF
--- a/nixos/eva/modules/telegraf/nix-community.nix
+++ b/nixos/eva/modules/telegraf/nix-community.nix
@@ -1,9 +1,11 @@
 let
   hosts = [
+    "aarch64.nixos.community"
     "build01.nix-community.org"
     "build02.nix-community.org"
     "build03.nix-community.org"
     "build04.nix-community.org"
+    "darwin01.nix-community.org"
   ];
 in
 {


### PR DESCRIPTION
Useful to know if these are down even if we can't really do anything about it ourselves.