### PR TITLE
neovim: replace nvim-ts-rainbow2 with rainbow-delimiters.nvim

### DIFF
--- a/home-manager/modules/neovim/user/plugins/community.lua
+++ b/home-manager/modules/neovim/user/plugins/community.lua
@@ -17,6 +17,6 @@ return {
  { import = "astrocommunity.pack.yaml" },
  { import = "astrocommunity.pack.nix" },
  { import = "astrocommunity.terminal-integration.vim-tpipeline" },
- { import = "astrocommunity.editing-support.nvim-ts-rainbow2" },
+ { import = "astrocommunity.editing-support.rainbow-delimiters-nvim" },
  { import = "astrocommunity.editing-support.auto-save-nvim" },
 }


### PR DESCRIPTION
neovim: nvim-ts-rainbow2 is now deprecated and needs to be replaced with rainbow-delimiters.nvim