### PR TITLE
eva/prometheus/alert-rules: remove borgbackup-nixpkgs-update

### DIFF
--- a/nixos/eva/modules/prometheus/alert-rules.nix
+++ b/nixos/eva/modules/prometheus/alert-rules.nix
@@ -94,7 +94,6 @@ lib.mapAttrsToList
     "borgbackup-job-nfs-share.service"
     # TODO: rename
     "borgbackup-matchbox"
-    "borgbackup-nixpkgs-update"
   ]
     (name: {
       condition = ''absent_over_time(task_last_run{name="${name}"}[1d])'';


### PR DESCRIPTION
Not much point in renaming this as it'll be removed anyway.