### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/nixos/modules/kde/default.nix
+++ b/nixos/modules/kde/default.nix
@@ -4,7 +4,7 @@
   services.displayManager.sddm.enable = true;
   services.desktopManager.plasma6.enable = true;
 
-  # https://nixos.wiki/wiki/KDE#KMail_Renders_Blank_Messages
+  # https://wiki.nixos.org/wiki/KDE#KMail_Renders_Blank_Messages
   environment.sessionVariables = {
     NIX_PROFILES = "${pkgs.lib.concatStringsSep " " (
       pkgs.lib.reverseList config.environment.profiles


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️