### PR TITLE
merge-when-green: wait for required checks to appear before exiting

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -87,9 +87,6 @@
   folder = "Drafts"
 	host = imaps://imap.thalheim.io
   user = joerg@higgsboson.tk
-	authMethod = LOGIN
-	sslverify = false
-	port = 993
 [sendemail]
   from = joerg@thalheim.io <joerg@thalheim.io>
   smtpserver = smtp.thalheim.io
@@ -130,5 +127,3 @@
 	helper = !gh auth git-credential
 [http]
   cookiefile = ~/.gitcookies
-[imapstore "default"]
-	folder = Drafts


### PR DESCRIPTION

- Query branch protection settings to get list of required checks
- Wait for all required checks to appear before checking completion
- Only use 30-second safety wait when no required checks are configured
- Show which required checks are still missing in status output

This prevents the race condition where the script exits before Buildbot
or other CI systems have time to register their checks.

Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
