### PR TITLE
refactor: move offline detection from direnv-instant to .direnvrc

### DIFF
--- a/home/.config/afew-cleanup/afew/config
+++ b/home/.config/afew-cleanup/afew/config
@@ -4,7 +4,7 @@
 
 [global]
 # Only run our custom cleanup filters
-filters = Filter.1,Filter.2,Filter.3,Filter.4,Filter.5,Filter.6,Filter.7
+filters = Filter.1,Filter.2,Filter.3,Filter.4,Filter.5,Filter.6,Filter.7,Filter.8
 
 [Filter.1]
 # Clean up old CI failure notifications (older than 2 days)
@@ -46,4 +46,10 @@ tags = +trash
 # Clean up old social notification emails (older than 1 month)
 message = Clean up old social notifications
 query = tag:social-notification AND date:..1month
+tags = +trash
+
+[Filter.8]
+# Clean up bank notifications (older than 1 month)
+message = Clean up old bank notifications
+query = tag:bank-notification AND date:..1month
 tags = +trash

--- a/home/.config/afew/config
+++ b/home/.config/afew/config
@@ -60,6 +60,11 @@ message = Tag social notifications
 query = from:facebookmail.com OR from:notification@slack.com OR from:linkedin.com OR from:twitter.com OR from:info@meetup.com OR from:xing.com OR from:instagram.com OR from:pinterest.com OR from:notifications@vk.com OR from:mastodon OR from:diaspora OR from:matrix.org
 tags = +social-notification
 
+[Filter.10]
+# Tag bank notifications
+query = from:kontowecker.de OR from:noreply@wise.com
+tags = +bank-notification
+
 [MailMover]
 # Define folders to check for moving emails
 folders = thalheim.io

--- a/home/.direnvrc
+++ b/home/.direnvrc
@@ -1,34 +1,52 @@
 # see https://github.com/nix-community/nix-direnv
 
+# Check if we have working network connectivity
+_direnv_has_route() {
+    case "$OSTYPE" in
+        darwin*)
+            command netstat -nr 2>/dev/null | command grep -q '^default'
+            ;;
+        *bsd*)
+            command netstat -rn 2>/dev/null | command grep -q '^default'
+            ;;
+        *)
+            # Linux: try ip command first, fall back to route
+            if command -v ip >/dev/null 2>&1; then
+                command ip -4 route show default 2>/dev/null | command grep -q '^default' || \
+                command ip -6 route show default 2>/dev/null | command grep -q '^default'
+            else
+                command route -n 2>/dev/null | command grep -q '^0\.0\.0\.0'
+            fi
+            ;;
+    esac
+}
+
+_direnv_can_reach_internet() {
+    command -v ping >/dev/null 2>&1 || return 1
+
+    # Try IPv4 first (9.9.9.9 - Quad9 DNS)
+    command ping -c 1 -W 1 9.9.9.9 >/dev/null 2>&1 && return 0
+
+    # Try IPv6 (2620:fe::fe - Quad9 DNS)
+    command ping6 -c 1 -W 1 2620:fe::fe >/dev/null 2>&1 && return 0
+
+    # Some systems use unified ping command for IPv6
+    command ping -c 1 -W 1 2620:fe::fe >/dev/null 2>&1 && return 0
+
+    return 1
+}
+
+_direnv_has_network() {
+    _direnv_has_route && _direnv_can_reach_internet
+}
+
+# Set manual reload flag if no network
+if ! _direnv_has_network; then
+    export _nix_direnv_manual_reload=1
+fi
+
 if [ -f ~/git/nix-direnv/direnvrc ]; then
   source ~/git/nix-direnv/direnvrc
 elif [ -f ~/.nix-profile/share/nix-direnv/direnvrc ]; then
   source ~/.nix-profile/share/nix-direnv/direnvrc
 fi
-
-_realpath() {
-    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-}
-
-layout_python-venv() {
-    local python=${1:-python3}
-    [[ $# -gt 0 ]] && shift
-    unset PYTHONHOME
-    if [[ -n $VIRTUAL_ENV ]]; then
-        VIRTUAL_ENV=$(_realpath "${VIRTUAL_ENV}")
-    else
-        local python_version
-        python_version=$("$python" -c "import platform; print(platform.python_version())")
-        if [[ -z $python_version ]]; then
-            log_error "Could not detect Python version"
-            return 1
-        fi
-        VIRTUAL_ENV=$PWD/.direnv/python-venv-$python_version
-    fi
-    export VIRTUAL_ENV
-    if [[ ! -d $VIRTUAL_ENV ]]; then
-        log_status "no venv found; creating $VIRTUAL_ENV"
-        "$python" -m venv "$VIRTUAL_ENV"
-    fi
-    PATH_add "$VIRTUAL_ENV/bin"
-}

--- a/home/bin/email-sync
+++ b/home/bin/email-sync
@@ -35,6 +35,16 @@ afew --move-mails --all
 # After moving emails, we might got rid of spam.
 mbsync thalheim:Spam thalheim:INBOX
 
+# Delete emails in trash older than 3 months
+echo "Deleting old trash emails (older than 3 months)..."
+TRASH_COUNT=$(notmuch count 'folder:Trash AND date:..3months')
+if [ "$TRASH_COUNT" -gt 0 ]; then
+    echo "Deleting $TRASH_COUNT old trash emails..."
+    notmuch search --output=files 'folder:Trash AND date:..3months' | xargs -r rm
+    # Update notmuch database to remove deleted emails
+    notmuch new
+fi
+
 # Send desktop notifications for new emails (if in graphical session)
 if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
     echo "Checking for new email notifications..."

--- a/zsh/direnv-instant.zsh
+++ b/zsh/direnv-instant.zsh
@@ -9,46 +9,6 @@ typeset -g __DIRENV_INSTANT_STDERR_FILE=""
 typeset -g __DIRENV_INSTANT_MONITOR_PID=""
 
 
-_direnv_has_route() {
-    case "$OSTYPE" in
-        darwin*)
-            command netstat -nr 2>/dev/null | command grep -q '^default'
-            ;;
-        *bsd*)
-            command netstat -rn 2>/dev/null | command grep -q '^default'
-            ;;
-        *)
-            # Linux: try ip command first, fall back to route
-            if command -v ip >/dev/null 2>&1; then
-                command ip -4 route show default 2>/dev/null | command grep -q '^default' || \
-                command ip -6 route show default 2>/dev/null | command grep -q '^default'
-            else
-                command route -n 2>/dev/null | command grep -q '^0\.0\.0\.0'
-            fi
-            ;;
-    esac
-}
-
-_direnv_can_reach_internet() {
-    command -v ping >/dev/null 2>&1 || return 1
-
-    # Try IPv4 first (9.9.9.9 - Quad9 DNS)
-    command ping -c 1 -W 1 9.9.9.9 >/dev/null 2>&1 && return 0
-
-    # Try IPv6 (2620:fe::fe - Quad9 DNS)
-    command ping6 -c 1 -W 1 2620:fe::fe >/dev/null 2>&1 && return 0
-
-    # Some systems use unified ping command for IPv6
-    command ping -c 1 -W 1 2620:fe::fe >/dev/null 2>&1 && return 0
-
-    return 1
-}
-
-# Check if we have working network connectivity
-_direnv_has_network() {
-    _direnv_has_route && _direnv_can_reach_internet
-}
-
 # Kill monitor process only
 _direnv_kill_monitor() {
     if [[ -n "$__DIRENV_INSTANT_MONITOR_PID" ]]; then
@@ -83,11 +43,6 @@ _direnv_tmux_manager() {
 
     # Clean up on exit
     trap "command rm -rf '$_temp_file' 2>/dev/null" EXIT INT TERM
-
-    # Set manual reload flag if no network
-    if ! _direnv_has_network; then
-        export _nix_direnv_manual_reload=1
-    fi
 
     # Run direnv with script to capture all output
     # stdout goes to _temp_file, stderr is captured by script (not shown directly)


### PR DESCRIPTION

The network connectivity check for setting _nix_direnv_manual_reload
is now performed directly in .direnvrc instead of direnv-instant.zsh.

- Move network detection functions to ~/.direnvrc
- Remove redundant code from direnv-instant.zsh
- Track .direnvrc in homeshick for version control
