### PR TITLE
eva/prometheus: disable pushover notifications

### DIFF
--- a/machines/eva/modules/prometheus/default.nix
+++ b/machines/eva/modules/prometheus/default.nix
@@ -248,13 +248,13 @@
         }
         {
           name = "all";
-          pushover_configs = [
-            {
-              user_key = "$PUSHOVER_USER_KEY";
-              token = "$PUSHOVER_TOKEN";
-              priority = "0";
-            }
-          ];
+          # pushover_configs = [
+          #   {
+          #     user_key = "$PUSHOVER_USER_KEY";
+          #     token = "$PUSHOVER_TOKEN";
+          #     priority = "0";
+          #   }
+          # ];
         }
         { name = "default"; }
       ];


### PR DESCRIPTION

Comment out pushover_configs for the "all" receiver to disable
Pushover notifications temporarily.
