### PR TITLE
networkmanager: add alias

### DIFF
--- a/machines/turingmachine/modules/networkmanager/default.nix
+++ b/machines/turingmachine/modules/networkmanager/default.nix
@@ -49,7 +49,7 @@ in
   # station and screen, since we will not need more than two 1 Gigabyte uplinks
   systemd.network.links."00-docking-station".extraConfig = ''
     [Match]
-    MACAddress = 00:e0:4c:a3:e1:8c 08:3a:88:59:80:71 f4:6b:8c:4a:81:c0 6c:1f:f7:02:91:64 f4:a8:0d:05:55:fd
+    MACAddress = 00:e0:4c:a3:e1:8c 08:3a:88:59:80:71 f4:6b:8c:4a:81:c0 6c:1f:f7:02:91:64 f4:a8:0d:05:55:fd 8c:8c:aa:da:9d:35
 
 
     [Link]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrects matching and configuration of the docking station network interface by adding its MAC address, improving link detection and stability.
  - Reduces connectivity inconsistencies and ensures consistent interface identification across reboots.

- Chores
  - Updates network settings to set a fixed MAC address for the docking station interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->