### PR TITLE
claude: use nix for python deps

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -11,6 +11,7 @@
 - Write shell scripts that pass `shellcheck`.
 - Write Python code for 3.13 that conforms to `ruff format`, `ruff check` and
   `mypy`
+- Prefer nix to fetch python dependencies
 - Use `$HOME/.claude/outputs` as a scratch directory.
 - In the Bash tool use absolute paths over `cd`
 - Always test/lint/format your code before committing.

--- a/machines/eva/modules/telegraf/private.nix
+++ b/machines/eva/modules/telegraf/private.nix
@@ -220,7 +220,7 @@ in
         response_string_match = "Nextcloud";
       }
       {
-        urls = [ "https://thalheim.io/_matrix/federation/v1/version" ];
+        urls = [ "https://matrix.thalheim.io/_matrix/federation/v1/version" ];
         tags.host = "eve";
         tags.org = "private";
         tags.service = "matrix-federation";

--- a/machines/eve/modules/nginx/homepage.nix
+++ b/machines/eve/modules/nginx/homepage.nix
@@ -18,7 +18,7 @@
       '';
       locations."=/.well-known/matrix/server".extraConfig = ''
         add_header Content-Type application/json;
-        return 200 '{"m.server": "matrix.thalheim.io:443"}';
+        return 200 '{"m.server":"matrix.thalheim.io:443"}';
       '';
       locations."=/.well-known/matrix/client".extraConfig = ''
         add_header Content-Type application/json;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Matrix federation version check to use matrix.thalheim.io endpoint for more accurate monitoring.

* **Documentation**
  * Added guidance to prefer Nix for fetching Python dependencies.

* **Style**
  * Minor formatting tweak to the /.well-known/matrix/server JSON response (no functional change).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->