### PR TITLE
hci-effects: make it fail

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -190,6 +190,7 @@
               hci-effects.mkEffect {
                 effectScript = ''
                   echo "${builtins.toJSON { inherit (herculesCI.config.repo) branch tag rev; }}"
+                  exit 1 # make it fail on purpose for testing
                   ${pkgs.hello}/bin/hello
                 '';
               }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration behavior to terminate one effect step with a non-zero status immediately after emitting its output. This prevents subsequent steps from executing.
  * CI runs on the main branch will now fail at this stage, providing an early signal during the pipeline.
  * No changes to user-facing features or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->