### PR TITLE
Revert "hci-effects: make it fail"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -190,7 +190,6 @@
               hci-effects.mkEffect {
                 effectScript = ''
                   echo "${builtins.toJSON { inherit (herculesCI.config.repo) branch tag rev; }}"
-                  exit 1 # make it fail on purpose for testing
                   ${pkgs.hello}/bin/hello
                 '';
               }


### PR DESCRIPTION

This reverts commit a1f75db57cdf5656f0f7e56005702395b47bdd2f.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented premature failure in the effect script; it now executes fully and returns the underlying command’s exit code for more reliable outcomes.
* **Chores**
  * Updated the effect script to print a JSON payload before running, improving output clarity and consistency.
  * Aligned execution flow to ensure subsequent commands run as expected, reducing unexpected terminations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->