### PR TITLE
homeshick: fix home-manager systemd service

### DIFF
--- a/home-manager/modules/homeshick.nix
+++ b/home-manager/modules/homeshick.nix
@@ -12,8 +12,19 @@ in
 
     Service = {
       Type = "oneshot";
-      ExecStart = "${pkgs.bash}/bin/bash -c '${homeshickPath} symlink dotfiles --force'";
+      ExecStart = "${pkgs.bash}/bin/bash -c '${homeshickPath} symlink dotfiles --batch'";
       RemainAfterExit = true;
+      Environment = [
+        "HOME=%h"
+        "PATH=${
+          lib.makeBinPath [
+            pkgs.coreutils
+            pkgs.gitMinimal
+            pkgs.bash
+          ]
+        }"
+      ];
+      WorkingDirectory = "%h";
     };
 
     Install = {
@@ -27,10 +38,19 @@ in
       ProgramArguments = [
         "${pkgs.bash}/bin/bash"
         "-c"
-        "${homeshickPath} symlink dotfiles --force"
+        "${homeshickPath} symlink dotfiles --batch"
       ];
       RunAtLoad = true;
       Label = "org.homeshick.symlink";
+      EnvironmentVariables = {
+        HOME = "/Users/%u";
+        PATH = "${lib.makeBinPath [
+          pkgs.coreutils
+          pkgs.gitMinimal
+          pkgs.bash
+        ]}";
+      };
+      WorkingDirectory = "/Users/%u";
     };
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Homeshick symlink now runs non-interactively (batch mode) to prevent prompts and hangs.
  * Services now set HOME/PATH and a proper working directory on Linux and macOS, improving reliability at login/startup.

* **Chores**
  * Aligned Linux (systemd) and macOS (launchd) service behavior for consistent cross-platform operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->