### PR TITLE
no longer set job report limit

### DIFF
--- a/machines/eve/modules/buildbot.nix
+++ b/machines/eve/modules/buildbot.nix
@@ -8,8 +8,6 @@
     enable = true;
     domain = "buildbot.thalheim.io";
 
-    jobReportLimit = 1;
-
     workersFile = config.sops.secrets.buildbot-nix-workers.path;
     buildSystems = [
       "i686-linux"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added.

- Bug Fixes
  - No user-facing bugs addressed.

- Chores
  - Simplified build automation configuration by removing a report limit setting to align with defaults and reduce configuration noise. This change only affects internal CI reporting behavior.

- Impact
  - No changes to product functionality or UI. Performance and reliability unaffected. No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->