### PR TITLE
spam filter: use sonnet model

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -422,10 +422,10 @@
         "nixpkgs-regression": []
       },
       "locked": {
-        "lastModified": 1759132390,
-        "narHash": "sha256-r/DnL8d2MQtMtduY/pmSkvuRfIC7z2BzTQGwpphLkog=",
+        "lastModified": 1759327090,
+        "narHash": "sha256-8M2vEESBRxX3SyuG1nPiHB55EInGzWNCXukFEfvCpJE=",
         "ref": "refs/heads/main",
-        "rev": "3cbfa0ba0f7404fa3f338f2a897e585ad41cb905",
+        "rev": "b9f021f62ba0b77c5af6f2dee306e68c8c99e075",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/Mic92/nix-1"

--- a/home/.config/afew/afew_filters/claude_spam_filter.py
+++ b/home/.config/afew/afew_filters/claude_spam_filter.py
@@ -305,6 +305,7 @@ indicators, suspicious attachments, etc."""
                     [
                         "claude",
                         "-p",
+                        "--model", "sonnet",
                         "--disallowed-tools",
                         "Bash,Edit,Write,Read,Grep,Glob,Task,WebSearch,WebFetch,TodoWrite,MultiEdit,NotebookEdit,ExitPlanMode,BashOutput,KillBash",
                         prompt,


### PR DESCRIPTION




flake.lock: Update

Flake lock file updates:

• Updated input 'nix':
    'git+https://github.com/Mic92/nix-1?ref=refs/heads/main&rev=3cbfa0ba0f7404fa3f338f2a897e585ad41cb905&shallow=1' (2025-09-29)
  → 'git+https://github.com/Mic92/nix-1?ref=refs/heads/main&rev=b9f021f62ba0b77c5af6f2dee306e68c8c99e075&shallow=1' (2025-10-01)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to explicitly select the Claude model (e.g., via --model), giving users finer control over code operations.
  * When not provided, the existing default remains in effect; specifying a model may produce different results, improving reproducibility and configurability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->