### PR TITLE
rbw-pinentry: cache password even after error recovery

### DIFF
--- a/pkgs/rbw_pinentry/src/rbw_pinentry/pinentry.py
+++ b/pkgs/rbw_pinentry/src/rbw_pinentry/pinentry.py
@@ -99,7 +99,7 @@ class Pinentry:
         secret_value = self._show_zenity_password_dialog(
             title=title, prompt=prompt, desc=desc, error=error
         )
-        if secret_value and not error:
+        if secret_value:
             try:
                 keyring.set_password(self.service_name, self.rbw_profile, secret_value)
             except keyring.errors.KeyringError as e:


### PR DESCRIPTION

Previously, when an authentication error occurred (wrong cached
password), the user would be prompted for a new password but it
wouldn't be cached in keyring due to the `and not error` condition.
This caused repeated password prompts after every rbw lock timeout
even when the user entered the correct password.
