### PR TITLE
eve: add Pinchflat YouTube downloader behind Authelia

### DIFF
--- a/machines/eve/configuration.nix
+++ b/machines/eve/configuration.nix
@@ -51,6 +51,7 @@
     ./modules/owncast.nix
     ./modules/packages.nix
     ./modules/paperless.nix
+    ./modules/pinchflat.nix
     ./modules/radicle.nix
     ./modules/phpldapadmin.nix
     ./modules/postfix.nix

--- a/machines/eve/modules/authelia.nix
+++ b/machines/eve/modules/authelia.nix
@@ -159,6 +159,12 @@
             policy = "one_factor";
             subject = [ "group:flood" ];
           }
+          # Pinchflat - restrict to pinchflat group members only
+          {
+            domain = "pinchflat.thalheim.io";
+            policy = "one_factor";
+            subject = [ "group:pinchflat" ];
+          }
         ];
       };
     };

--- a/machines/eve/modules/pinchflat.nix
+++ b/machines/eve/modules/pinchflat.nix
@@ -1,0 +1,112 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  hostname = "pinchflat.thalheim.io";
+  downloadsDir = "/data/pinchflat";
+  zfsDataset = "zroot/root/pinchflat";
+in
+{
+  # Use the native NixOS Pinchflat service module
+  services.pinchflat = {
+    enable = true;
+    port = 8945;
+    mediaDir = downloadsDir;
+    openFirewall = false; # We use nginx reverse proxy
+    selfhosted = true; # Uses weak secret since we're behind Authelia
+    extraConfig = {
+      TZ = "Europe/Berlin";
+      # Expose feed endpoints without Pinchflat's auth (we use Authelia instead)
+      EXPOSE_FEED_ENDPOINTS = "true";
+    };
+  };
+
+  # Create ZFS dataset for pinchflat downloads before service starts
+  systemd.services.pinchflat = {
+    preStart = ''
+      # Create ZFS dataset if it doesn't exist
+      if ! ${pkgs.zfs}/bin/zfs list ${zfsDataset} >/dev/null 2>&1; then
+        ${pkgs.zfs}/bin/zfs create -o mountpoint=${downloadsDir} ${zfsDataset}
+      fi
+      # Ensure correct ownership
+      chown -R pinchflat:pinchflat ${downloadsDir}
+    '';
+    serviceConfig = {
+      # Run preStart as root to create ZFS dataset
+      PermissionsStartOnly = true;
+    };
+  };
+
+  # Nginx reverse proxy with Authelia forward-auth
+  services.nginx.virtualHosts.${hostname} = {
+    useACMEHost = "thalheim.io";
+    forceSSL = true;
+
+    # Authelia forward-auth verification endpoint (form-based login)
+    locations."/authelia" = {
+      proxyPass = "http://127.0.0.1:9091/api/verify";
+      extraConfig = ''
+        internal;
+        proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
+        proxy_set_header X-Forwarded-Method $request_method;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Uri $request_uri;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Content-Length "";
+        proxy_pass_request_body off;
+      '';
+    };
+
+    # Authelia basic auth endpoint (for podcast apps)
+    locations."/authelia-basic" = {
+      proxyPass = "http://127.0.0.1:9091/api/verify?auth=basic";
+      extraConfig = ''
+        internal;
+        proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
+        proxy_set_header X-Forwarded-Method $request_method;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Uri $request_uri;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        # Pass Authorization header to Authelia for basic auth
+        proxy_set_header Proxy-Authorization $http_authorization;
+        proxy_set_header Content-Length "";
+        proxy_pass_request_body off;
+      '';
+    };
+
+    # Feed endpoints with Authelia HTTP basic auth (for podcast apps)
+    locations."/sources/" = {
+      proxyPass = "http://127.0.0.1:${toString config.services.pinchflat.port}";
+      proxyWebsockets = true;
+      recommendedProxySettings = true;
+      extraConfig = ''
+        # Use Authelia basic auth - triggers HTTP Basic Auth dialog
+        auth_request /authelia-basic;
+        auth_request_set $user $upstream_http_remote_user;
+        proxy_set_header Remote-User $user;
+      '';
+    };
+
+    # Main UI with Authelia forward-auth (form-based login)
+    locations."/" = {
+      proxyPass = "http://127.0.0.1:${toString config.services.pinchflat.port}";
+      proxyWebsockets = true;
+      recommendedProxySettings = true;
+      extraConfig = ''
+        # Redirect to Authelia login on 401
+        error_page 401 =302 https://auth.thalheim.io/?rd=$scheme://$http_host$request_uri;
+
+        # Forward auth request to Authelia
+        auth_request /authelia;
+        auth_request_set $user $upstream_http_remote_user;
+
+        # Pass authenticated username (Pinchflat doesn't use it, but good practice)
+        proxy_set_header Remote-User $user;
+      '';
+    };
+  };
+}


### PR DESCRIPTION
Add Pinchflat, a self-hosted YouTube content downloader using yt-dlp, using the native NixOS service module from nixpkgs. Since Pinchflat only supports basic HTTP authentication (no OAuth/OIDC), it is placed behind Authelia forward-auth proxy for authentication.

- New module: machines/eve/modules/pinchflat.nix
- Uses services.pinchflat NixOS module (not Docker)
- Creates ZFS dataset zroot/root/pinchflat in systemd preStart
- Downloads stored in /data/pinchflat
- Accessible at pinchflat.thalheim.io
- Access restricted to 'pinchflat' LDAP group members
- Main UI uses Authelia form-based login
- RSS feed endpoints (/sources/) use Authelia HTTP basic auth for podcast app compatibility (same LDAP credentials)