### PR TITLE
db-cli: update db-vendo-client

### DIFF
--- a/pkgs/db-cli/package-lock.json
+++ b/pkgs/db-cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "db-vendo-client": "^6.8.2"
+        "db-vendo-client": "^6.10.6"
       },
       "bin": {
         "db-cli": "bin/db-cli.mjs"
@@ -296,6 +296,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -510,9 +511,9 @@
       }
     },
     "node_modules/db-vendo-client": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/db-vendo-client/-/db-vendo-client-6.8.2.tgz",
-      "integrity": "sha512-u/p7VJeVKoboI/hHkqBdc91qTISOwKlgBBahVQjgHf3V7Hho/dafknASpnqyt+yKmc2Xl4THteeRHvFLrecm3Q==",
+      "version": "6.10.6",
+      "resolved": "https://registry.npmjs.org/db-vendo-client/-/db-vendo-client-6.10.6.tgz",
+      "integrity": "sha512-2TbuG4NUPvJh0PE2177yB/OqLh/Su8TyJEofT0IB0I07F66bJqkr5zhQCRbb7Q1uJrGZLXukE9Y4kBnljHAdxw==",
       "license": "ISC",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -619,6 +620,7 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/pkgs/db-cli/package.json
+++ b/pkgs/db-cli/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "description": "CLI tool for searching Deutsche Bahn train connections",
   "dependencies": {
-    "db-vendo-client": "^6.8.2"
+    "db-vendo-client": "^6.10.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",


### PR DESCRIPTION
Several DB API changes seem to have rendered the application unusable. They are fixed in the latest upstream db-vendo-client, so I updated it to restore the functionality.