### PR TITLE
updater: add nix package with all dependencies

### DIFF
--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -31,10 +31,9 @@ jobs:
         run: |
           echo "${{ steps.app-token.outputs.token }}" | gh auth login --with-token
       - name: Update packages
-        working-directory: pkgs
         run: |
           if [ -n "${{ inputs.package }}" ]; then
-            python3 -m updater --pr -p "${{ inputs.package }}"
+            nix run .#updater -- --pr -p "${{ inputs.package }}"
           else
-            python3 -m updater --pr
+            nix run .#updater -- --pr
           fi

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -34,6 +34,8 @@
         nix-eval-warnings = pkgs.callPackage ./nix-eval-warnings { };
         # Reference all flake inputs to ensure they get cached
         flake-inputs = pkgs.callPackage ./flake-inputs { inherit inputs; };
+        # Package updater CLI
+        updater = pkgs.callPackage ./updater { };
       }
       // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
         blueutil = pkgs.callPackage ./blueutil { };

--- a/pkgs/updater/README.md
+++ b/pkgs/updater/README.md
@@ -5,13 +5,19 @@ Automatically update third-party packages in `pkgs/`.
 ## Usage
 
 ```bash
+# Using the nix package (recommended, includes all dependencies)
+nix run .#updater -- --list
+nix run .#updater -- --dry-run
+nix run .#updater -- --pr
+nix run .#updater -- --pr -p <name>
+
+# Or directly with Python (requires nix-update, gh in PATH)
 cd pkgs
 python3 -m updater --list       # List all updatable packages
 python3 -m updater --dry-run    # Preview what would be updated
 python3 -m updater              # Update all packages in place
 python3 -m updater -p <name>    # Update a single package
 python3 -m updater --pr         # Create a PR for each updated package
-python3 -m updater --pr -p <name>  # Create PR for a single package
 ```
 
 The `--pr` flag uses git worktrees to create PRs without affecting your current

--- a/pkgs/updater/default.nix
+++ b/pkgs/updater/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  python3,
+  makeWrapper,
+  nix-update,
+  nix,
+  git,
+  gh,
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "updater";
+  version = "0.1.0";
+  pyproject = false;
+
+  src = ./.;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/updater $out/bin
+    cp -r *.py $out/lib/updater/
+
+    makeWrapper ${python3}/bin/python3 $out/bin/updater \
+      --add-flags "-m updater" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          nix-update
+          nix
+          git
+          gh
+        ]
+      } \
+      --set PYTHONPATH $out/lib
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Package updater for dotfiles";
+    mainProgram = "updater";
+  };
+}


### PR DESCRIPTION

The updater package bundles python, nix-update, nix, git, and gh
so it can be run in CI without additional setup.

Usage: nix run .#updater -- --pr


