### PR TITLE
darwinModules: add environment.casks for macOS app management

### DIFF
--- a/darwinModules/casks.nix
+++ b/darwinModules/casks.nix
@@ -1,0 +1,75 @@
+# Module that provides environment.casks option for installing macOS apps
+# via ditto with efficient marker-based caching.
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.environment;
+
+  # Generate the sync script for all apps
+  syncScript = lib.concatMapStringsSep "\n" (pkg: ''
+    sync_app "${pkg}"
+  '') cfg.casks;
+in
+{
+  options.environment.casks = lib.mkOption {
+    type = lib.types.listOf lib.types.package;
+    default = [ ];
+    description = ''
+      List of macOS application packages to install via ditto.
+      Uses marker-based caching to only copy when the store path changes.
+      Apps are installed to /Applications/Nix Casks.
+    '';
+  };
+
+  config = lib.mkIf (cfg.casks != [ ]) {
+    # Efficient marker-based app syncing - only copies when store path changes
+    system.activationScripts.postActivation.text = lib.mkAfter ''
+      echo "setting up /Applications/Nix Casks..." >&2
+      targetDir='/Applications/Nix Casks'
+      markerDir="$targetDir/.sources"
+      mkdir -p "$targetDir" "$markerDir"
+
+      # Track which apps we want to keep
+      declare -A wantedApps
+
+      sync_app() {
+        local src="$1"
+
+        for app in "$src/Applications/"*.app; do
+          [[ -e "$app" ]] || continue
+          local appName
+          appName=$(basename "$app")
+          local dest="$targetDir/$appName"
+          local marker="$markerDir/$appName"
+
+          wantedApps["$appName"]=1
+
+          if [[ ! -f "$marker" ]] || [[ "$(cat "$marker")" != "$src" ]]; then
+            echo "Syncing $appName..." >&2
+            chmod -R u+w "$dest" 2>/dev/null || true
+            rm -rf "$dest"
+            /usr/bin/ditto "$app" "$dest"
+            echo "$src" > "$marker"
+          fi
+        done
+      }
+
+      ${syncScript}
+
+      # Remove apps no longer in the list
+      for app in "$targetDir/"*.app; do
+        [[ -e "$app" ]] || continue
+        appName=$(basename "$app")
+        if [[ -z "''${wantedApps[$appName]:-}" ]]; then
+          echo "Removing stale $appName..." >&2
+          chmod -R u+w "$app" 2>/dev/null || true
+          rm -rf "$app"
+          rm -f "$markerDir/$appName"
+        fi
+      done
+    '';
+  };
+}

--- a/darwinModules/nix-casks.nix
+++ b/darwinModules/nix-casks.nix
@@ -1,10 +1,12 @@
 { self, pkgs, ... }:
 let
   cask = self.inputs.nix-casks.packages.${pkgs.stdenv.hostPlatform.system};
+  myPkgs = self.packages.${pkgs.stdenv.hostPlatform.system};
 in
 {
-  # Install GUI apps via nix-casks and custom packages
-  environment.systemPackages = [
+  imports = [ ./casks.nix ];
+
+  environment.casks = [
     cask.alt-tab
     cask.ferdium
     cask.ungoogled-chromium
@@ -16,9 +18,10 @@ in
     cask.secretive
     cask.gather
     cask.inkscape
-    self.packages.${pkgs.stdenv.hostPlatform.system}.kdeconnect
-    self.packages.${pkgs.stdenv.hostPlatform.system}.librewolf-macos
-    self.packages.${pkgs.stdenv.hostPlatform.system}.radicle-desktop
+    cask.calibre
+    myPkgs.kdeconnect
+    myPkgs.librewolf-macos
+    myPkgs.radicle-desktop
   ];
 
   # Configure SSH to use Secretive for key management


### PR DESCRIPTION

nix-darwin's rsync with --copy-unsafe-links fails on apps containing
recursive hardlink structures. calibre's QtWebEngineProcess.app has
QtWebEngineCore.framework nested inside itself via hardlinks, causing
rsync to recurse until hitting the path length limit.

Instead of patching nix-darwin, introduce a separate mechanism using
macOS ditto which handles app bundles correctly. Store paths are
tracked via marker files to avoid unnecessary copies on each
activation.

This also seems to be much faster than rsync when having many apps.
