### PR TITLE
pi: add stable-settings extension to suppress changelog version churn

### DIFF
--- a/home/.pi/agent/extensions/stable-settings.ts
+++ b/home/.pi/agent/extensions/stable-settings.ts
@@ -1,0 +1,19 @@
+// Keeps lastChangelogVersion stable to avoid noise in dotfiles git history
+// See: https://github.com/badlogic/pi-mono/issues/720
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async () => {
+    const settingsPath = join(homedir(), ".pi", "agent", "settings.json");
+    try {
+      const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+      settings.lastChangelogVersion = "99.99.99";
+      writeFileSync(settingsPath, JSON.stringify(settings, null, 2), "utf-8");
+    } catch {
+      // ignore errors
+    }
+  });
+}

--- a/home/.pi/agent/settings.json
+++ b/home/.pi/agent/settings.json
@@ -1,5 +1,5 @@
 {
-  "lastChangelogVersion": "0.48.0",
+  "lastChangelogVersion": "99.99.99",
   "followUpMode": "all",
   "theme": "light",
   "defaultProvider": "anthropic",

--- a/machines/dorits-laptop/configuration.nix
+++ b/machines/dorits-laptop/configuration.nix
@@ -68,6 +68,7 @@
   };
 
   environment.systemPackages = with pkgs; [
+    firefox
     celluloid
     mpv
     inkscape

--- a/machines/jacquardmachine/configuration.nix
+++ b/machines/jacquardmachine/configuration.nix
@@ -20,6 +20,8 @@
 
   environment.systemPackages = with pkgs; [ bottles ];
 
+  programs.steam.enable = true;
+
   # Disable envfs to fix systemd refusing to run with unpopulated /usr/
   services.envfs.enable = lib.mkForce false;
 


### PR DESCRIPTION

Fixes noise in dotfiles git history from lastChangelogVersion updates.
See: https://github.com/badlogic/pi-mono/issues/720
