### PR TITLE
pim: add sandboxed pi wrapper for calendar/email tasks

### DIFF
--- a/home-manager/modules/ai.nix
+++ b/home-manager/modules/ai.nix
@@ -11,11 +11,13 @@
     let
       aiTools = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system};
       micsSkills = inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system};
+      selfPkgs = self.packages.${pkgs.stdenv.hostPlatform.system};
     in
     [
-      self.packages.${pkgs.stdenv.hostPlatform.system}.claude-code
+      selfPkgs.claude-code
+      selfPkgs.claude-md
+      selfPkgs.pim
       micsSkills.pexpect-cli
-      self.packages.${pkgs.stdenv.hostPlatform.system}.claude-md
       micsSkills.kagi-search
       aiTools.pi
       aiTools.tuicr

--- a/home-manager/modules/mail.nix
+++ b/home-manager/modules/mail.nix
@@ -7,8 +7,8 @@
 }:
 
 let
-  # email-sync script
-  email-sync = pkgs.callPackage ../../pkgs/email-sync { };
+  # email-sync script from flake packages
+  email-sync = self.packages.${pkgs.stdenv.hostPlatform.system}.email-sync;
 
   # msmtp wrapper that saves sent mail to maildir
   msmtp-with-sent = pkgs.writeShellScriptBin "msmtp" ''

--- a/home-manager/modules/mail.nix
+++ b/home-manager/modules/mail.nix
@@ -73,6 +73,7 @@ lib.mkMerge [
       w3m # for HTML email viewing
 
       self.packages.${pkgs.stdenv.hostPlatform.system}.vcal
+      self.packages.${pkgs.stdenv.hostPlatform.system}.crabfit-cli
     ];
 
     # All config files are managed by homeshick:

--- a/pkgs/crabfit-cli/README.md
+++ b/pkgs/crabfit-cli/README.md
@@ -1,0 +1,25 @@
+# crabfit-cli
+
+A command-line interface for [Crab.fit](https://crab.fit), the open-source
+scheduling tool.
+
+## Features
+
+- Create events with flexible date/time specifications
+- Add availability responses via CLI
+- View availability overlap to find best meeting times
+- Supports custom API endpoints for self-hosted instances
+
+## Usage
+
+See [SKILL.md](SKILL.md) for detailed usage instructions and examples.
+
+## Configuration
+
+| Environment Variable | Description  | Default                |
+| -------------------- | ------------ | ---------------------- |
+| `CRABFIT_API_URL`    | API base URL | `https://api.crab.fit` |
+
+## License
+
+MIT

--- a/pkgs/crabfit-cli/SKILL.md
+++ b/pkgs/crabfit-cli/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: crabfit-cli
+description: Create and manage Crab.fit scheduling events. Use for coordinating meeting times across multiple people.
+---
+
+# Usage
+
+```bash
+# Create an event for the next 3 days, 9am-5pm
+python3 crabfit_cli.py create --dates +0:+2 --start 9 --end 17
+
+# Create a named event for specific dates
+python3 crabfit_cli.py create --name "Team Meeting" --dates 2026-01-20,2026-01-22
+
+# Create with specific timezone
+python3 crabfit_cli.py create --dates +0:+6 --timezone America/New_York
+
+# Add your availability (all slots)
+python3 crabfit_cli.py respond EVENT_ID --name "Alice" --all
+
+# Add specific availability
+python3 crabfit_cli.py respond EVENT_ID --name "Bob" --slots 1000-19012026 1100-19012026
+
+# Show event with availability overlap
+python3 crabfit_cli.py show EVENT_ID
+```
+
+# Date Formats
+
+- Single date: `2026-01-20`
+- Range: `2026-01-20:2026-01-25`
+- Comma-separated: `2026-01-20,2026-01-22,2026-01-24`
+- Relative: `+0` (today), `+1` (tomorrow), `+0:+6` (next 7 days)
+
+# Time Slot Format
+
+Slots use `HHmm-DDMMYYYY` format in UTC (e.g., `0900-19012026` = 09:00 UTC on
+Jan 19, 2026).
+
+# Environment Variables
+
+- `CRABFIT_API_URL`: API base URL (default: `https://api.crab.fit`)
+
+# Example Workflow
+
+```bash
+# 1. Create event
+python3 crabfit_cli.py create --name "Project Sync" --dates +1:+5 --start 10 --end 16
+
+# 2. Share URL with participants, they respond via web or CLI
+
+# 3. Check availability overlap
+python3 crabfit_cli.py show project-sync-123456
+```
+
+Output shows best meeting times:
+
+```
+All 3 available:
+  ✓ Mon Jan 19 11:00-13:00
+  ✓ Tue Jan 20 14:00-16:00
+
+2/3 available:
+  • Mon Jan 19 10:00-11:00  (missing: Bob)
+```

--- a/pkgs/crabfit-cli/crabfit_cli.py
+++ b/pkgs/crabfit-cli/crabfit_cli.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""CLI to create and manage Crab.fit events."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING, Any, cast
+from zoneinfo import ZoneInfo
+
+if TYPE_CHECKING:
+    from datetime import date
+
+API_BASE = os.environ.get("CRABFIT_API_URL", "https://api.crab.fit")
+
+
+def format_time_slot(datetime_obj: dt.datetime) -> str:
+    """Convert a datetime to crabfit's HHmm-DDMMYYYY format (UTC)."""
+    utc_dt = datetime_obj.astimezone(ZoneInfo("UTC"))
+    return (
+        f"{utc_dt.hour:02d}{utc_dt.minute:02d}-{utc_dt.day:02d}{utc_dt.month:02d}{utc_dt.year:04d}"
+    )
+
+
+def generate_time_slots(
+    dates: list[str],
+    start_hour: int,
+    end_hour: int,
+    timezone: str,
+) -> list[str]:
+    """Generate time slots for given dates and hour range.
+
+    Args:
+        dates: List of dates in YYYY-MM-DD format.
+        start_hour: Start hour (0-23).
+        end_hour: End hour (1-24, exclusive).
+        timezone: IANA timezone string.
+
+    Returns:
+        List of time slot strings in HHmm-DDMMYYYY format.
+
+    """
+    tz = ZoneInfo(timezone)
+    slots = []
+
+    for date_str in dates:
+        year, month, day = map(int, date_str.split("-"))
+
+        # Generate hours, handling overnight ranges
+        hours: list[int]
+        if start_hour < end_hour:
+            hours = list(range(start_hour, end_hour))
+        else:
+            hours = list(range(start_hour, 24)) + list(range(end_hour))
+
+        for hour in hours:
+            datetime_obj = dt.datetime(year, month, day, hour, 0, tzinfo=tz)
+            slots.append(format_time_slot(datetime_obj))
+
+    return slots
+
+
+def api_request(
+    method: str,
+    endpoint: str,
+    data: dict[str, Any] | None = None,
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Make an API request to crab.fit.
+
+    Args:
+        method: HTTP method (GET, POST, PATCH).
+        endpoint: API endpoint path.
+        data: Optional JSON payload.
+
+    Returns:
+        Parsed JSON response.
+
+    """
+    url = f"{API_BASE}{endpoint}"
+    if not url.startswith(("https://", "http://")):
+        msg = f"Invalid URL scheme: {url}"
+        raise ValueError(msg)
+
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+
+    request_data = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(  # noqa: S310
+        url,
+        data=request_data,
+        headers=headers,
+        method=method,
+    )
+
+    try:
+        with urllib.request.urlopen(req) as response:  # noqa: S310
+            result: dict[str, Any] | list[dict[str, Any]] = json.loads(response.read().decode())
+            return result
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode() if e.fp else ""
+        print(f"API Error {e.code}: {error_body}", file=sys.stderr)
+        sys.exit(1)
+
+
+def create_event(
+    name: str | None,
+    dates: list[str],
+    start_hour: int,
+    end_hour: int,
+    timezone: str,
+) -> dict[str, Any]:
+    """Create a new crabfit event.
+
+    Args:
+        name: Event name (optional, auto-generated if None).
+        dates: List of dates in YYYY-MM-DD format.
+        start_hour: Start hour (0-23).
+        end_hour: End hour (1-24, exclusive).
+        timezone: IANA timezone string.
+
+    Returns:
+        Created event data.
+
+    """
+    times = generate_time_slots(dates, start_hour, end_hour, timezone)
+
+    payload: dict[str, Any] = {
+        "times": times,
+        "timezone": timezone,
+    }
+    if name:
+        payload["name"] = name
+
+    return cast("dict[str, Any]", api_request("POST", "/event", payload))
+
+
+def get_event(event_id: str) -> dict[str, Any]:
+    """Get event details.
+
+    Args:
+        event_id: The event ID.
+
+    Returns:
+        Event data.
+
+    """
+    return cast("dict[str, Any]", api_request("GET", f"/event/{event_id}"))
+
+
+def get_people(event_id: str) -> list[dict[str, Any]]:
+    """Get all people and their availability for an event.
+
+    Args:
+        event_id: The event ID.
+
+    Returns:
+        List of person data.
+
+    """
+    return cast("list[dict[str, Any]]", api_request("GET", f"/event/{event_id}/people"))
+
+
+def login_or_create_person(event_id: str, name: str) -> dict[str, Any]:
+    """Login or create a person for an event.
+
+    Args:
+        event_id: The event ID.
+        name: Person's name.
+
+    Returns:
+        Person data.
+
+    """
+    return cast("dict[str, Any]", api_request("GET", f"/event/{event_id}/people/{name}"))
+
+
+def update_availability(
+    event_id: str,
+    name: str,
+    availability: list[str],
+) -> dict[str, Any]:
+    """Update a person's availability for an event.
+
+    Args:
+        event_id: The event ID.
+        name: Person's name.
+        availability: List of time slots the person is available.
+
+    Returns:
+        Updated person data.
+
+    """
+    return cast(
+        "dict[str, Any]",
+        api_request("PATCH", f"/event/{event_id}/people/{name}", {"availability": availability}),
+    )
+
+
+def parse_date_range(date_range: str) -> list[str]:
+    """Parse a date range string into a list of dates.
+
+    Formats:
+        - Single date: 2026-01-20
+        - Range: 2026-01-20:2026-01-25
+        - Comma-separated: 2026-01-20,2026-01-22,2026-01-24
+        - Relative: +0 (today), +1 (tomorrow), +0:+6 (next 7 days)
+
+    Args:
+        date_range: Date range specification string.
+
+    Returns:
+        List of dates in YYYY-MM-DD format.
+
+    """
+    dates = []
+    today = dt.datetime.now(tz=dt.UTC).date()
+
+    for part in date_range.split(","):
+        stripped_part = part.strip()
+        if ":" in stripped_part:
+            start_str, end_str = stripped_part.split(":")
+            start_date = _parse_single_date(start_str.strip(), today)
+            end_date = _parse_single_date(end_str.strip(), today)
+            current = start_date
+            while current <= end_date:
+                dates.append(current.strftime("%Y-%m-%d"))
+                current += dt.timedelta(days=1)
+        else:
+            dates.append(_parse_single_date(stripped_part, today).strftime("%Y-%m-%d"))
+
+    return dates
+
+
+def _parse_single_date(date_str: str, today: date) -> date:
+    """Parse a single date string.
+
+    Args:
+        date_str: Date string (YYYY-MM-DD or +N for relative).
+        today: Reference date for relative dates.
+
+    Returns:
+        Parsed date.
+
+    """
+    if date_str.startswith("+"):
+        days = int(date_str[1:])
+        return today + dt.timedelta(days=days)
+    return dt.datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=dt.UTC).date()
+
+
+def cmd_create(args: argparse.Namespace) -> None:
+    """Handle the create command.
+
+    Args:
+        args: Parsed command-line arguments.
+
+    """
+    dates = parse_date_range(args.dates)
+    timezone: str = args.timezone
+
+    event = create_event(
+        name=args.name,
+        dates=dates,
+        start_hour=args.start,
+        end_hour=args.end,
+        timezone=timezone,
+    )
+
+    print(f"Created event: {event['name']}")
+    print(f"URL: https://crab.fit/{event['id']}")
+    print(f"Dates: {', '.join(dates)}")
+    print(f"Time: {args.start:02d}:00 - {args.end:02d}:00 ({timezone})")
+
+    if args.json:
+        print(json.dumps(event, indent=2))
+
+
+def cmd_respond(args: argparse.Namespace) -> None:
+    """Handle the respond command.
+
+    Args:
+        args: Parsed command-line arguments.
+
+    """
+    event = get_event(args.event_id)
+    event_times: list[str] = event["times"]
+
+    # Login/create the person
+    login_or_create_person(args.event_id, args.name)
+
+    # Determine availability
+    if args.all:
+        availability = event_times
+    elif args.slots:
+        availability = args.slots
+    else:
+        # Default: mark available for all slots
+        availability = event_times
+
+    # Update availability
+    result = update_availability(args.event_id, args.name, availability)
+
+    print(f"Updated availability for {result['name']}")
+    print(f"Event: {event['name']}")
+    print(f"Available for {len(result['availability'])} / {len(event_times)} slots")
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+
+
+def parse_time_slot(slot: str, timezone: str) -> dt.datetime:
+    """Parse a crabfit time slot string to datetime.
+
+    Args:
+        slot: Time slot in HHmm-DDMMYYYY format.
+        timezone: Target timezone for display.
+
+    Returns:
+        Datetime in the specified timezone.
+
+    """
+    hour = int(slot[0:2])
+    minute = int(slot[2:4])
+    day = int(slot[5:7])
+    month = int(slot[7:9])
+    year = int(slot[9:13])
+
+    utc_dt = dt.datetime(year, month, day, hour, minute, tzinfo=dt.UTC)
+    return utc_dt.astimezone(ZoneInfo(timezone))
+
+
+def format_slot_time(datetime_obj: dt.datetime) -> str:
+    """Format a datetime as a human-readable time slot.
+
+    Args:
+        datetime_obj: The datetime to format.
+
+    Returns:
+        Formatted string like "Mon Jan 19 10:00-11:00".
+
+    """
+    end_time = datetime_obj + dt.timedelta(hours=1)
+    return (
+        f"{datetime_obj.strftime('%a %b %d')} "
+        f"{datetime_obj.strftime('%H:%M')}-{end_time.strftime('%H:%M')}"
+    )
+
+
+def _build_availability_map(
+    event_times: list[str],
+    people: list[dict[str, Any]],
+) -> dict[str, list[str]]:
+    """Build a map of time slots to available people.
+
+    Args:
+        event_times: List of all event time slots.
+        people: List of people with their availability.
+
+    Returns:
+        Map of slot -> list of names available.
+
+    """
+    availability_map: dict[str, list[str]] = {slot: [] for slot in event_times}
+    for person in people:
+        for slot in person["availability"]:
+            if slot in availability_map:
+                availability_map[slot].append(person["name"])
+    return availability_map
+
+
+def _group_slots_by_count(
+    availability_map: dict[str, list[str]],
+) -> dict[int, list[str]]:
+    """Group time slots by number of people available.
+
+    Args:
+        availability_map: Map of slot -> list of names.
+
+    Returns:
+        Map of count -> list of slots with that count.
+
+    """
+    slots_by_count: dict[int, list[str]] = {}
+    for slot, available_names in availability_map.items():
+        count = len(available_names)
+        if count not in slots_by_count:
+            slots_by_count[count] = []
+        slots_by_count[count].append(slot)
+    return slots_by_count
+
+
+def _group_consecutive_slots(slots: list[str], timezone: str) -> list[list[str]]:
+    """Group consecutive time slots together.
+
+    Args:
+        slots: Sorted list of slot strings.
+        timezone: Timezone for parsing.
+
+    Returns:
+        List of groups, where each group is consecutive slots.
+
+    """
+    groups: list[list[str]] = []
+    current_group: list[str] = []
+
+    for slot in slots:
+        if not current_group:
+            current_group = [slot]
+            continue
+
+        prev_dt = parse_time_slot(current_group[-1], timezone)
+        curr_dt = parse_time_slot(slot, timezone)
+        if curr_dt - prev_dt == dt.timedelta(hours=1):
+            current_group.append(slot)
+        else:
+            groups.append(current_group)
+            current_group = [slot]
+
+    if current_group:
+        groups.append(current_group)
+
+    return groups
+
+
+def cmd_show(args: argparse.Namespace) -> None:
+    """Handle the show command.
+
+    Args:
+        args: Parsed command-line arguments.
+
+    """
+    event = get_event(args.event_id)
+    people = get_people(args.event_id)
+    timezone: str = event["timezone"]
+    event_times: list[str] = event["times"]
+
+    print(f"Event: {event['name']}")
+    print(f"URL: https://crab.fit/{event['id']}")
+    print(f"Timezone: {timezone}")
+
+    if not people:
+        print("\nNo responses yet.")
+        if args.json:
+            print(json.dumps({"event": event, "people": people}, indent=2))
+        return
+
+    availability_map = _build_availability_map(event_times, people)
+    num_people = len(people)
+    names = [p["name"] for p in people]
+
+    print(f"Participants ({num_people}): {', '.join(names)}")
+    print("\n" + "=" * 50)
+
+    slots_by_count = _group_slots_by_count(availability_map)
+
+    for count in sorted(slots_by_count.keys(), reverse=True):
+        if count == 0:
+            continue
+
+        slots = sorted(slots_by_count[count])
+        if count == num_people:
+            label = f"All {num_people} available"
+        else:
+            label = f"{count}/{num_people} available"
+        print(f"\n{label}:")
+
+        for group in _group_consecutive_slots(slots, timezone):
+            _print_slot_group(group, timezone, availability_map, num_people)
+
+    if args.json:
+        print(json.dumps({"event": event, "people": people}, indent=2))
+
+
+def _print_slot_group(
+    slots: list[str],
+    timezone: str,
+    availability_map: dict[str, list[str]],
+    num_people: int,
+) -> None:
+    """Print a group of consecutive time slots.
+
+    Args:
+        slots: List of consecutive slot strings.
+        timezone: Timezone for display.
+        availability_map: Map of slot to available names.
+        num_people: Total number of participants.
+
+    """
+    start_dt = parse_time_slot(slots[0], timezone)
+    end_dt = parse_time_slot(slots[-1], timezone) + dt.timedelta(hours=1)
+
+    time_str = (
+        f"{start_dt.strftime('%a %b %d')} {start_dt.strftime('%H:%M')}-{end_dt.strftime('%H:%M')}"
+    )
+
+    available_names = availability_map[slots[0]]
+    count = len(available_names)
+
+    if count == num_people:
+        print(f"  ✓ {time_str}")
+    else:
+        # Get actual missing names by checking who's NOT in available_names
+        all_names_set: set[str] = set()
+        for names_list in availability_map.values():
+            all_names_set.update(names_list)
+        missing_names = [n for n in all_names_set if n not in available_names]
+        print(f"  • {time_str}  (missing: {', '.join(missing_names)})")
+
+
+def _get_system_timezone() -> str:
+    """Get the system timezone name.
+
+    Returns:
+        IANA timezone string, defaults to UTC if detection fails.
+
+    """
+    # Check TZ env var first
+    tz_env = os.environ.get("TZ")
+    if tz_env:
+        return tz_env
+
+    # Try /etc/localtime symlink (Linux)
+    localtime = pathlib.Path("/etc/localtime")
+    if localtime.is_symlink():
+        target = str(localtime.resolve())
+        # Extract timezone from path like /usr/share/zoneinfo/Europe/Berlin
+        if "zoneinfo/" in target:
+            return target.split("zoneinfo/")[-1]
+
+    return "UTC"
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="CLI for creating and managing Crab.fit events",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Create an event for next 3 days, 9am-5pm
+  %(prog)s create --dates +0:+2 --start 9 --end 17
+
+  # Create a named event for specific dates
+  %(prog)s create --name "Team Meeting" --dates 2026-01-20,2026-01-22
+
+  # Create an event with a specific timezone
+  %(prog)s create --dates +0:+6 --timezone America/New_York
+
+  # Show event details
+  %(prog)s show my-event-123456
+""",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Create command
+    create_parser = subparsers.add_parser("create", help="Create a new event")
+    create_parser.add_argument(
+        "--name",
+        "-n",
+        help="Event name (auto-generated if not provided)",
+    )
+    create_parser.add_argument(
+        "--dates",
+        "-d",
+        required=True,
+        help="Dates: YYYY-MM-DD, range (date1:date2), relative (+N), or comma-separated",
+    )
+    create_parser.add_argument(
+        "--start",
+        "-s",
+        type=int,
+        default=9,
+        help="Start hour (0-23, default: 9)",
+    )
+    create_parser.add_argument(
+        "--end",
+        "-e",
+        type=int,
+        default=17,
+        help="End hour (1-24, default: 17)",
+    )
+    create_parser.add_argument(
+        "--timezone",
+        "-t",
+        default=_get_system_timezone(),
+        help="Timezone (default: system timezone)",
+    )
+    create_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output full JSON response",
+    )
+    create_parser.set_defaults(func=cmd_create)
+
+    # Respond command
+    respond_parser = subparsers.add_parser("respond", help="Add your availability to an event")
+    respond_parser.add_argument("event_id", help="Event ID or URL")
+    respond_parser.add_argument(
+        "--name",
+        "-n",
+        required=True,
+        help="Your name",
+    )
+    respond_parser.add_argument(
+        "--all",
+        "-a",
+        action="store_true",
+        help="Mark available for all time slots",
+    )
+    respond_parser.add_argument(
+        "--slots",
+        nargs="+",
+        help="Specific time slots (in HHmm-DDMMYYYY format)",
+    )
+    respond_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output full JSON response",
+    )
+    respond_parser.set_defaults(func=cmd_respond)
+
+    # Show command
+    show_parser = subparsers.add_parser("show", help="Show event details")
+    show_parser.add_argument("event_id", help="Event ID or URL")
+    show_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output full JSON response",
+    )
+    show_parser.set_defaults(func=cmd_show)
+
+    args = parser.parse_args()
+
+    # Extract event ID from URL if needed
+    if hasattr(args, "event_id") and "crab.fit/" in args.event_id:
+        args.event_id = args.event_id.split("crab.fit/")[-1].split("?")[0]
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/crabfit-cli/default.nix
+++ b/pkgs/crabfit-cli/default.nix
@@ -1,0 +1,18 @@
+{
+  buildPythonApplication,
+  hatchling,
+}:
+
+buildPythonApplication {
+  pname = "crabfit-cli";
+  version = "0.1.0";
+  src = ./.;
+  pyproject = true;
+
+  build-system = [ hatchling ];
+
+  meta = {
+    description = "CLI for creating and managing Crab.fit scheduling events";
+    mainProgram = "crabfit-cli";
+  };
+}

--- a/pkgs/crabfit-cli/pyproject.toml
+++ b/pkgs/crabfit-cli/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "crabfit-cli"
+version = "0.1.0"
+description = "CLI for creating and managing Crab.fit scheduling events"
+
+[project.scripts]
+crabfit-cli = "crabfit_cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["crabfit_cli.py"]
+
+[tool.ruff]
+target-version = "py313"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+    "T201",   # allow print()
+    "D203",   # incompatible with D211 (no-blank-line-before-class)
+    "D213",   # incompatible with D212 (multi-line-summary-first-line)
+    "COM812", # conflicts with formatter
+]
+
+[tool.mypy]
+python_version = "3.13"
+strict = true

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -22,6 +22,7 @@
         vcal = pkgs.callPackage ./vcal { };
         buildbot-pr-check = pkgs.python3.pkgs.callPackage ./buildbot-pr-check { };
         claude-md = pkgs.python3.pkgs.callPackage ./claude-md { };
+        crabfit-cli = pkgs.python3.pkgs.callPackage ./crabfit-cli { };
         inherit (pkgs.callPackages ./firefox-extensions { })
           chrome-tab-gc-extension
           ;
@@ -39,7 +40,7 @@
         updater = pkgs.callPackage ./updater { };
         # Sandboxed pi for calendar/email tasks
         pim = pkgs.callPackage ./pim {
-          inherit (self'.packages) email-sync;
+          inherit (self'.packages) email-sync crabfit-cli;
           pi = aiTools.pi;
           db-cli = micsSkills.db-cli;
           kagi-search = micsSkills.kagi-search;

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -3,9 +3,14 @@
   perSystem =
     {
       inputs',
+      self',
       pkgs,
       ...
     }:
+    let
+      micsSkills = inputs'.mics-skills.packages;
+      aiTools = inputs'.llm-agents.packages;
+    in
     {
       packages = {
         merge-when-green = pkgs.callPackage ./merge-when-green { };
@@ -32,6 +37,13 @@
         flake-inputs = pkgs.callPackage ./flake-inputs { inherit inputs; };
         # Package updater CLI
         updater = pkgs.callPackage ./updater { };
+        # Sandboxed pi for calendar/email tasks
+        pim = pkgs.callPackage ./pim {
+          inherit (self'.packages) email-sync;
+          pi = aiTools.pi;
+          db-cli = micsSkills.db-cli;
+          kagi-search = micsSkills.kagi-search;
+        };
       }
       // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
         blueutil = pkgs.callPackage ./blueutil { };

--- a/pkgs/pim/README.md
+++ b/pkgs/pim/README.md
@@ -1,0 +1,45 @@
+# pim - Personal Information Manager
+
+A sandboxed AI assistant for calendar, email, contacts, and travel planning.
+
+## Features
+
+- **Sandboxed** (Linux): Runs in bwrap with restricted filesystem access
+- **Focused toolset**: Only PIM-related tools available
+- **Model**: claude-haiku-4-5
+
+## Available Tools
+
+| Category | Tools                                                         |
+| -------- | ------------------------------------------------------------- |
+| Calendar | `khal`, `vdirsyncer`, `todo`                                  |
+| Email    | `notmuch`, `afew`, `mrefile`, `msmtp`, `mbsync`, `email-sync` |
+| Contacts | `khard`                                                       |
+| Travel   | `db-cli` (German trains)                                      |
+| Search   | `kagi-search`                                                 |
+
+## Usage
+
+```bash
+pim                           # Interactive mode
+pim "what's on my calendar?"  # With initial prompt
+pim -c                        # Continue previous session
+```
+
+## Examples
+
+```bash
+# Calendar
+pim "list my events for tomorrow"
+pim "delete the meeting at 3pm"
+
+# Email  
+pim "search for emails from Jonas"
+pim "show unread emails"
+
+# Contacts
+pim "find Jonas in my contacts"
+
+# Travel
+pim "train from Munich to Berlin tomorrow at 9am"
+```

--- a/pkgs/pim/default.nix
+++ b/pkgs/pim/default.nix
@@ -1,0 +1,226 @@
+{
+  lib,
+  stdenv,
+  writeShellApplication,
+  # Calendar tools
+  khal,
+  vdirsyncer,
+  todoman,
+  # Email tools
+  notmuch,
+  afew,
+  mblaze,
+  msmtp,
+  isync,
+  # Contacts
+  khard,
+  # Supporting tools
+  rbw,
+  coreutils,
+  gnugrep,
+  gnused,
+  gawk,
+  findutils,
+  bash,
+  util-linux,
+  # Email sync
+  email-sync,
+  # AI tools
+  pi,
+  db-cli,
+  kagi-search,
+  # Sandboxing (Linux only)
+  bubblewrap,
+}:
+
+let
+  # Build a minimal PATH with only calendar/email related tools
+  toolsPath = lib.makeBinPath [
+    # Calendar
+    khal
+    vdirsyncer
+    todoman
+    # Email
+    notmuch
+    afew
+    mblaze
+    msmtp
+    isync
+    # Contacts
+    khard
+    # Auth
+    rbw
+    # Basic utils
+    coreutils
+    gnugrep
+    gnused
+    gawk
+    findutils
+    bash
+    util-linux
+    # Email sync
+    email-sync
+    # Skills dependencies
+    db-cli
+    kagi-search
+  ];
+
+  systemPrompt = ''
+    You are a calendar, email, and travel planning assistant.
+
+    Available tools:
+    - Calendar: khal, vdirsyncer, todo (todoman)
+    - Email: notmuch, afew, mrefile (from mblaze), msmtp, mbsync
+    - Contacts: khard
+    - Travel: db-cli (German trains)
+    - Search: kagi-search
+
+    Key directories:
+    - Calendars: ~/.local/share/calendars/
+    - Mail: ~/mail/thalheim.io/
+    - Contacts: ~/.contacts/
+
+    Common tasks:
+    - List calendar events: khal list
+    - List with UIDs: khal list --format "{start-time}-{end-time} {title} [{uid}]"
+    - Delete calendar entry: printf "D\ny\n" | khal edit <uid>
+    - List todos: todo list
+    - Search email: notmuch search <query>
+    - Show email: notmuch show --format=text <thread-id>
+    - Sync calendars: vdirsyncer sync
+    - Sync email: email-sync
+    - Search contacts: khard list <name>
+    - Train connections: db-cli "From" "To"
+  '';
+
+  # Directories that need read-write access (relative to $HOME)
+  rwDirs = [
+    ".local/share/calendars"
+    ".local/share/vdirsyncer"
+    ".local/share/notmuch"
+    ".local/share/khal"
+    ".cache/vdirsyncer"
+    ".cache/khal"
+    ".cache/notmuch"
+    ".cache/rbw"
+    ".contacts"
+    "mail"
+    ".pi"
+    ".claude/outputs"
+  ];
+
+  # Directories/files that need read-only access (relative to $HOME)
+  roDirs = [
+    ".config/khal"
+    ".config/vdirsyncer"
+    ".config/todoman"
+    ".config/notmuch"
+    ".config/afew"
+    ".config/msmtp"
+    ".config/khard"
+    ".config/rbw"
+    ".mbsyncrc"
+    ".notmuch-config"
+    ".claude/skills"
+    # Configs and extensions are symlinks to dotfiles
+    ".homesick/repos/dotfiles/home"
+  ];
+
+in
+writeShellApplication {
+  name = "pim";
+
+  runtimeInputs = [ pi ] ++ lib.optionals stdenv.isLinux [ bubblewrap ];
+
+  text = ''
+        TOOLS_PATH=${lib.escapeShellArg toolsPath}
+
+        # Build system prompt with current calendar
+        SYSTEM_PROMPT=${lib.escapeShellArg systemPrompt}
+        SYSTEM_PROMPT+="
+    Current calendar:
+    $(cal -3)"
+
+        # Ensure session directory exists
+        mkdir -p "$HOME/.pi/pim"
+        mkdir -p "$HOME/.claude/outputs"
+
+        run_pi() {
+            PATH="$TOOLS_PATH:$PATH" \
+            pi \
+                --provider anthropic \
+                --model claude-haiku-4-5 \
+                --session-dir "$HOME/.pi/pim" \
+                --append-system-prompt "$SYSTEM_PROMPT" \
+                --skills "db-cli,kagi-search" \
+                "$@"
+        }
+
+        # Linux sandboxing with bwrap
+        if [[ "$(uname)" == "Linux" ]] && command -v bwrap &>/dev/null; then
+            # Build bwrap arguments
+            BWRAP_ARGS=(
+                # Basic system access
+                --ro-bind /nix/store /nix/store
+                --ro-bind /etc /etc
+                --ro-bind /run /run
+                --dev /dev
+                --proc /proc
+                --tmpfs /tmp
+
+                # XDG runtime (for rbw agent socket, etc.)
+                --bind "''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}" "''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+            )
+
+            # Add read-write binds for data directories
+            for dir in ${lib.escapeShellArgs rwDirs}; do
+                target="$HOME/$dir"
+                if [[ -e "$target" ]]; then
+                    BWRAP_ARGS+=(--bind "$target" "$target")
+                fi
+            done
+
+            # Add read-only binds for config
+            for dir in ${lib.escapeShellArgs roDirs}; do
+                target="$HOME/$dir"
+                if [[ -e "$target" ]]; then
+                    BWRAP_ARGS+=(--ro-bind "$target" "$target")
+                fi
+            done
+
+            # Environment variables
+            BWRAP_ARGS+=(
+                --setenv HOME "$HOME"
+                --setenv PATH "$TOOLS_PATH"
+                --setenv TERM "''${TERM:-xterm-256color}"
+                --setenv LANG "''${LANG:-en_US.UTF-8}"
+                --setenv XDG_RUNTIME_DIR "''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+            )
+
+            # Pass through API keys if set
+            [[ -n "''${ANTHROPIC_API_KEY:-}" ]] && BWRAP_ARGS+=(--setenv ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY")
+            [[ -n "''${OPENAI_API_KEY:-}" ]] && BWRAP_ARGS+=(--setenv OPENAI_API_KEY "$OPENAI_API_KEY")
+            [[ -n "''${GEMINI_API_KEY:-}" ]] && BWRAP_ARGS+=(--setenv GEMINI_API_KEY "$GEMINI_API_KEY")
+            [[ -n "''${KAGI_API_KEY:-}" ]] && BWRAP_ARGS+=(--setenv KAGI_API_KEY "$KAGI_API_KEY")
+
+            # Network and namespace options
+            BWRAP_ARGS+=(
+                --share-net
+                --unshare-pid
+                --die-with-parent
+            )
+
+            exec bwrap "''${BWRAP_ARGS[@]}" \
+                ${pi}/bin/pi \
+                    --provider anthropic \
+                    --model claude-haiku-4-5 \
+                    --session-dir "$HOME/.pi/pim" \
+                    --append-system-prompt "$SYSTEM_PROMPT" \
+                    --skills "db-cli,kagi-search" \
+                    "$@"
+        else
+            # macOS or no bwrap - just restrict PATH
+            run_pi "$@"
+        fi
+  '';
+}

--- a/pkgs/pim/default.nix
+++ b/pkgs/pim/default.nix
@@ -29,6 +29,7 @@
   pi,
   db-cli,
   kagi-search,
+  crabfit-cli,
   # Sandboxing (Linux only)
   bubblewrap,
 }:
@@ -63,6 +64,7 @@ let
     # Skills dependencies
     db-cli
     kagi-search
+    crabfit-cli
   ];
 
   systemPrompt = ''
@@ -74,6 +76,7 @@ let
     - Contacts: khard
     - Travel: db-cli (German trains)
     - Search: kagi-search
+    - Scheduling: crabfit-cli (create/manage crab.fit events)
 
     Key directories:
     - Calendars: ~/.local/share/calendars/
@@ -91,6 +94,8 @@ let
     - Sync email: email-sync
     - Search contacts: khard list <name>
     - Train connections: db-cli "From" "To"
+    - Create scheduling poll: crabfit-cli create --name "Meeting" --dates +0:+6
+    - Show poll results: crabfit-cli show <event-id>
   '';
 
   # Directories that need read-write access (relative to $HOME)


### PR DESCRIPTION

Adds a new 'pim' (Personal Information Manager) command that:
- Restricts PATH to calendar/email tools (khal, vdirsyncer, todo,
  notmuch, afew, mblaze, msmtp, isync, khard, rbw, bash, crabfit-cli)
- Includes db-cli and kagi-search skills for travel planning
- Uses claude-haiku-4-5 model by default
- On Linux, runs inside a bwrap sandbox with:
  - Read-only access to /nix/store, /etc, /run, configs
  - Read-write access to calendar data, contacts, mail, pi sessions
  - Network access for sync and API calls
  - PID namespace isolation

This provides a focused, sandboxed environment for calendar and
email management tasks.

