### PR TITLE
ai: drop coding-agent-search

### DIFF
--- a/home-manager/modules/ai.nix
+++ b/home-manager/modules/ai.nix
@@ -26,7 +26,6 @@
       aiTools.gemini-cli
       aiTools.ccusage
       aiTools.ccstatusline
-      aiTools.coding-agent-search
       pkgs.pueue
     ];
 }


### PR DESCRIPTION

Package is broken on Darwin due to onnxruntime rpath issues.
See: https://github.com/numtide/llm-agents.nix/pull/1976


