### PR TITLE
pi-agent-extensions: switch back to upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,4 +33,4 @@
 	url = https://github.com/jorgebucaran/autopair.fish
 [submodule "pi-agent-extensions"]
 	path = pi-agent-extensions
-	url = https://github.com/Mic92/pi-agent-extensions
+	url = https://github.com/rytswd/pi-agent-extensions


### PR DESCRIPTION
Our changes have been merged into rytswd/pi-agent-extensions, no need to keep using the fork.