### PR TITLE
pi: point skills to ~/.claude/skills

### DIFF
--- a/home/.pi/agent/settings.json
+++ b/home/.pi/agent/settings.json
@@ -4,5 +4,8 @@
   "theme": "light",
   "defaultProvider": "anthropic",
   "defaultModel": "claude-opus-4-6",
-  "defaultThinkingLevel": "off"
+  "defaultThinkingLevel": "off",
+  "skills": [
+    "~/.claude/skills"
+  ]
 }


### PR DESCRIPTION

Pi loads skills from ~/.pi/agent/skills/ by default, but our
home-manager config installs them to ~/.claude/skills/ (for Claude
Code compatibility). Use pi's settings.json 'skills' array to tell
it where to find them.
