### PR TITLE
Migrate from flake-parts to adios-flake

### DIFF
--- a/devshell/flake-module.nix
+++ b/devshell/flake-module.nix
@@ -1,220 +1,221 @@
-{ inputs, lib, ... }:
 {
+  pkgs,
+  inputs',
+  self,
+  ...
+}:
+let
+  lib = pkgs.lib;
+  inputs = self.inputs;
 
-  imports = [ inputs.treefmt-nix.flakeModule ];
+  treefmtEval = inputs.treefmt-nix.lib.evalModule pkgs {
+    # Used to find the project root
+    projectRootFile = ".git/config";
 
-  perSystem =
-    {
-      inputs',
-      pkgs,
-      ...
-    }:
-    {
-      # Definitions like this are entirely equivalent to the ones
-      # you may have directly in flake.nix.
-      devShells.default = pkgs.mkShellNoCC {
-        nativeBuildInputs = [
-          pkgs.python3.pkgs.invoke
-          pkgs.python3.pkgs.deploykit
-          inputs'.clan-core.packages.default
-          # FIXME: clan-app currently fails to build due to webview-nightly compilation issues
-          # with the latest nixpkgs. Re-enable once the upstream issue is resolved.
-          # inputs'.clan-core.packages.clan-app
-        ]
-        ++ lib.optionals (!pkgs.stdenv.isDarwin) [
-          pkgs.bubblewrap
+    programs.terraform.enable = true;
+    programs.hclfmt.enable = true;
+    programs.yamlfmt.enable = true;
+    programs.actionlint.enable = true;
+    programs.mypy.enable = true;
+    programs.mypy.directories = {
+      "machines/eva/modules/prometheus" = { };
+      "openwrt" = { };
+      "pkgs/buildbot-pr-check" = {
+        extraPythonPackages = with pkgs.python3.pkgs; [
+          pytest
+          vcrpy
+          pytest-vcr
         ];
       };
-
-      treefmt = {
-        # Used to find the project root
-        projectRootFile = ".git/config";
-
-        programs.terraform.enable = true;
-        programs.hclfmt.enable = true;
-        programs.yamlfmt.enable = true;
-        programs.actionlint.enable = true;
-        programs.mypy.enable = true;
-        programs.mypy.directories = {
-          "machines/eva/modules/prometheus" = { };
-          "openwrt" = { };
-          "pkgs/buildbot-pr-check" = {
-            extraPythonPackages = with pkgs.python3.pkgs; [
-              pytest
-              vcrpy
-              pytest-vcr
-            ];
-          };
-          "pkgs/claude-md" = { };
-          "pkgs/merge-when-green" = { };
-          "pkgs/systemctl" = { };
-          "pkgs/vcal" = {
-            extraPythonPackages = with pkgs.python3.pkgs; [
-              icalendar
-              python-dateutil
-              pytz
-              types-pytz
-              types-python-dateutil
-              (pkgs.callPackage ../pkgs/vcal/types-icalendar.nix { inherit python; })
-              pytest
-            ];
-          };
-          "pkgs/rbw_pinentry" = {
-            extraPythonPackages = with pkgs.python3.pkgs; [
-              keyring
-            ];
-          };
-          "pkgs/calendar_bot" = {
-            extraPythonPackages = with pkgs.python3.pkgs; [
-              aiohttp
-              mautrix
-              asyncpg
-              python-olm
-              unpaddedbase64
-              pycryptodome
-              base58
-            ];
-          };
-        };
-        programs.deadnix.enable = true;
-        programs.stylua.enable = true;
-        programs.clang-format.enable = true;
-        programs.deno.enable = true;
-        programs.nixfmt.enable = true;
-        programs.shellcheck.enable = true;
-
-        settings.formatter.shellcheck.options = [
-          "--external-sources"
-          "--source-path=SCRIPTDIR"
+      "pkgs/claude-md" = { };
+      "pkgs/merge-when-green" = { };
+      "pkgs/systemctl" = { };
+      "pkgs/vcal" = {
+        extraPythonPackages = with pkgs.python3.pkgs; [
+          icalendar
+          python-dateutil
+          pytz
+          types-pytz
+          types-python-dateutil
+          (pkgs.callPackage ../pkgs/vcal/types-icalendar.nix { inherit python; })
+          pytest
         ];
-
-        programs.shfmt.enable = true;
-        programs.rustfmt.enable = true;
-        settings.formatter.shfmt.includes = [
-          "*.envrc"
-          "*.envrc.private-template"
-          "*.bashrc"
-          "*.bash_profile"
-          "*.bashrc.load"
+      };
+      "pkgs/rbw_pinentry" = {
+        extraPythonPackages = with pkgs.python3.pkgs; [
+          keyring
         ];
-
-        programs.ruff.format = true;
-        programs.ruff.check = true;
-
-        settings.formatter.ruff-check.excludes = [
-          "gdb/*"
-          "zsh/*"
-          "home/.config/qtile/*"
-          "home/.emacs/*"
-          # bug in ruff
-          "home/.config/shell_gpt/functions/execute_shell.py"
-        ];
-        settings.formatter.ruff-format.excludes = [
-          "gdb/*"
-          "zsh/*"
-        ];
-        settings.formatter.shfmt.excludes = [
-          "gdb/*"
-          "zsh/*"
-        ];
-        settings.formatter.shellcheck.excludes = [
-          "gdb/*"
-          "zsh/*"
-        ];
-
-        settings.global.excludes = [
-          "sops/*"
-          "vars/*"
-          "zsh/*"
-          "pkgs/buildbot-pr-check/tests/cassettes/*"
-          "home/.zsh-*"
-          "home/.fast-syntax-highlighting"
-          "home/.config/nixpkgs"
-          "home/.gef-*"
-          "terraform.tfstate"
-          "*.tfvars.sops.json"
-          "gdb/*"
-          "*nixos-vars.json"
-          "*/secrets.yaml"
-          "*/secrets.yml"
-          "machines/*/facts/*"
-          "darwin/*/*.yml"
-          "*/facter.json"
-          "*.pub"
-          "*.pem"
-          "*.conf"
-          "*.sieve"
-          "*.patch"
-          "*.zone"
-          "*.lock"
-          "*.age"
-          "*.fish"
-          "*.txt"
-          "*.toml"
-          "*.vim"
-          "*.el"
-          "*.config"
-          "*.png"
-          "*.jpg"
-          "*.jpeg"
-          "*.gif"
-          "*.svg"
-          "*.ico"
-          "home/.gdbinit-gef.py"
-          "home/.emacs.d/templates/*"
-          "home/.doom.d/snippets/*"
-          "*/secrets.enc.json"
-          "*/lazy-lock.json"
-
-          "*.gitignore"
-          "*.gitmodules"
-          "home-manager/modules/waybar.css"
-          "home/.Xresources"
-          "home/.agignore"
-          "home/.config/autorandr/*"
-          "home/.config/bat/*"
-          "home/.config/dunst/dunstrc"
-          "home/.config/foot/foot.ini"
-          "home/.config/htop/htoprc"
-          "home/.config/kanshi/config"
-          "home/.config/nvim/treesitter-rev"
-          "home/.config/river/init"
-          "home/.config/rofi/*"
-          "home/.dircolors.*"
-          "home/.direnvrc"
-          "home/.gdbinit"
-          "home/.gef.rc"
-          "home/.gemrc"
-          "home/.gitattributes"
-          "home/.gitconfig"
-          "home/.gitignore"
-          "home/.hgrc"
-          "home/.irbrc"
-          "home/.mbsyncrc"
-          "home/.mpv/config"
-          "home/.ncmpcpp/config"
-          "home/.ncmpcpp/keys"
-          "home/.parallel/will-cite"
-          "home/.pryrc"
-          "home/.psqlrc"
-          "home/.radare2rc"
-          "home/.ruby-agignore"
-          "home/.spacemacs"
-          "home/.tigrc"
-          "home/.vimrc"
-          "home/.xinitrc"
-          "home/.zsh-termsupport"
-          "home/.zshrc"
-          "home/.fish-pure"
-          "fish/*"
-          "home/bin/*"
-          "machines/eve/pkgs/logo.png"
-          "machines/turingmachine/modules/vpn-il1-standard.ovpn"
-          "machines/turingmachine/thermal-conf.xml.auto"
-          "openwrt/Justfile"
-          "openwrt/bin/nix-uci"
-          "openwrt/setup.cfg"
+      };
+      "pkgs/calendar_bot" = {
+        extraPythonPackages = with pkgs.python3.pkgs; [
+          aiohttp
+          mautrix
+          asyncpg
+          python-olm
+          unpaddedbase64
+          pycryptodome
+          base58
         ];
       };
     };
+    programs.deadnix.enable = true;
+    programs.stylua.enable = true;
+    programs.clang-format.enable = true;
+    programs.deno.enable = true;
+    programs.nixfmt.enable = true;
+    programs.shellcheck.enable = true;
+
+    settings.formatter.shellcheck.options = [
+      "--external-sources"
+      "--source-path=SCRIPTDIR"
+    ];
+
+    programs.shfmt.enable = true;
+    programs.rustfmt.enable = true;
+    settings.formatter.shfmt.includes = [
+      "*.envrc"
+      "*.envrc.private-template"
+      "*.bashrc"
+      "*.bash_profile"
+      "*.bashrc.load"
+    ];
+
+    programs.ruff.format = true;
+    programs.ruff.check = true;
+
+    settings.formatter.ruff-check.excludes = [
+      "gdb/*"
+      "zsh/*"
+      "home/.config/qtile/*"
+      "home/.emacs/*"
+      # bug in ruff
+      "home/.config/shell_gpt/functions/execute_shell.py"
+    ];
+    settings.formatter.ruff-format.excludes = [
+      "gdb/*"
+      "zsh/*"
+    ];
+    settings.formatter.shfmt.excludes = [
+      "gdb/*"
+      "zsh/*"
+    ];
+    settings.formatter.shellcheck.excludes = [
+      "gdb/*"
+      "zsh/*"
+    ];
+
+    settings.global.excludes = [
+      "sops/*"
+      "vars/*"
+      "zsh/*"
+      "pkgs/buildbot-pr-check/tests/cassettes/*"
+      "home/.zsh-*"
+      "home/.fast-syntax-highlighting"
+      "home/.config/nixpkgs"
+      "home/.gef-*"
+      "terraform.tfstate"
+      "*.tfvars.sops.json"
+      "gdb/*"
+      "*nixos-vars.json"
+      "*/secrets.yaml"
+      "*/secrets.yml"
+      "machines/*/facts/*"
+      "darwin/*/*.yml"
+      "*/facter.json"
+      "*.pub"
+      "*.pem"
+      "*.conf"
+      "*.sieve"
+      "*.patch"
+      "*.zone"
+      "*.lock"
+      "*.age"
+      "*.fish"
+      "*.txt"
+      "*.toml"
+      "*.vim"
+      "*.el"
+      "*.config"
+      "*.png"
+      "*.jpg"
+      "*.jpeg"
+      "*.gif"
+      "*.svg"
+      "*.ico"
+      "home/.gdbinit-gef.py"
+      "home/.emacs.d/templates/*"
+      "home/.doom.d/snippets/*"
+      "*/secrets.enc.json"
+      "*/lazy-lock.json"
+
+      "*.gitignore"
+      "*.gitmodules"
+      "home-manager/modules/waybar.css"
+      "home/.Xresources"
+      "home/.agignore"
+      "home/.config/autorandr/*"
+      "home/.config/bat/*"
+      "home/.config/dunst/dunstrc"
+      "home/.config/foot/foot.ini"
+      "home/.config/htop/htoprc"
+      "home/.config/kanshi/config"
+      "home/.config/nvim/treesitter-rev"
+      "home/.config/river/init"
+      "home/.config/rofi/*"
+      "home/.dircolors.*"
+      "home/.direnvrc"
+      "home/.gdbinit"
+      "home/.gef.rc"
+      "home/.gemrc"
+      "home/.gitattributes"
+      "home/.gitconfig"
+      "home/.gitignore"
+      "home/.hgrc"
+      "home/.irbrc"
+      "home/.mbsyncrc"
+      "home/.mpv/config"
+      "home/.ncmpcpp/config"
+      "home/.ncmpcpp/keys"
+      "home/.parallel/will-cite"
+      "home/.pryrc"
+      "home/.psqlrc"
+      "home/.radare2rc"
+      "home/.ruby-agignore"
+      "home/.spacemacs"
+      "home/.tigrc"
+      "home/.vimrc"
+      "home/.xinitrc"
+      "home/.zsh-termsupport"
+      "home/.zshrc"
+      "home/.fish-pure"
+      "fish/*"
+      "home/bin/*"
+      "machines/eve/pkgs/logo.png"
+      "machines/turingmachine/modules/vpn-il1-standard.ovpn"
+      "machines/turingmachine/thermal-conf.xml.auto"
+      "openwrt/Justfile"
+      "openwrt/bin/nix-uci"
+      "openwrt/setup.cfg"
+    ];
+  };
+in
+{
+  # Definitions like this are entirely equivalent to the ones
+  # you may have directly in flake.nix.
+  devShells.default = pkgs.mkShellNoCC {
+    nativeBuildInputs = [
+      pkgs.python3.pkgs.invoke
+      pkgs.python3.pkgs.deploykit
+      inputs'.clan-core.default
+      # FIXME: clan-app currently fails to build due to webview-nightly compilation issues
+      # with the latest nixpkgs. Re-enable once the upstream issue is resolved.
+      # inputs'.clan-core.clan-app
+    ]
+    ++ lib.optionals (!pkgs.stdenv.isDarwin) [
+      pkgs.bubblewrap
+    ];
+  };
+
+  formatter = treefmtEval.config.build.wrapper;
+  checks.formatting = treefmtEval.config.build.check self;
 }

--- a/devshell/flake-module.nix
+++ b/devshell/flake-module.nix
@@ -1,11 +1,11 @@
 {
   pkgs,
+  lib,
   inputs',
   self,
   ...
 }:
 let
-  lib = pkgs.lib;
   inputs = self.inputs;
 
   treefmtEval = inputs.treefmt-nix.lib.evalModule pkgs {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,38 @@
 {
   "nodes": {
+    "adios": {
+      "locked": {
+        "lastModified": 1772186395,
+        "narHash": "sha256-NshyMZYZwjKMLKEX0eDf9Fcekq8MFNFk02wW5knzlZU=",
+        "owner": "adisbladis",
+        "repo": "adios",
+        "rev": "6a54071689ec9ec784a16e4eec8ddb864eca2982",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "adios",
+        "type": "github"
+      }
+    },
+    "adios-flake": {
+      "inputs": {
+        "adios": "adios"
+      },
+      "locked": {
+        "lastModified": 1772282380,
+        "narHash": "sha256-ZCm0Z/eUAhyCh82L1jY8s1CzkFApft0lXMEdr2Mk5jc=",
+        "owner": "Mic92",
+        "repo": "adios-flake",
+        "rev": "f86acb8f11944295b197297dda37faefd0fe0f4a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "adios-flake",
+        "type": "github"
+      }
+    },
     "blueprint": {
       "inputs": {
         "nixpkgs": [
@@ -28,7 +61,7 @@
         "flake-parts": [
           "flake-parts"
         ],
-        "hercules-ci-effects": [],
+        "hercules-ci-effects": "hercules-ci-effects",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -222,6 +255,27 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-registry": {
       "flake": false,
       "locked": {
@@ -311,6 +365,31 @@
       }
     },
     "hercules-ci-effects": {
+      "inputs": {
+        "flake-parts": [
+          "buildbot-nix",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "buildbot-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771131391,
+        "narHash": "sha256-HPBNYf7HiKtBVy7/69vKpLYHX6wTcUxndxmybzDlXP8=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "0b152e0f7c5cc265a529cd63374b80e2771b207b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
+    "hercules-ci-effects_2": {
       "inputs": {
         "flake-parts": [
           "flake-parts"
@@ -462,7 +541,7 @@
     "nix": {
       "inputs": {
         "flake-compat": [],
-        "flake-parts": [],
+        "flake-parts": "flake-parts_2",
         "git-hooks-nix": [],
         "nixpkgs": [
           "nixpkgs"
@@ -734,6 +813,7 @@
     },
     "root": {
       "inputs": {
+        "adios-flake": "adios-flake",
         "blueprint": "blueprint",
         "buildbot-nix": "buildbot-nix",
         "clan-core": "clan-core",
@@ -747,7 +827,7 @@
         "flake-utils": "flake-utils",
         "forge-triage": "forge-triage",
         "harmonia": "harmonia",
-        "hercules-ci-effects": "hercules-ci-effects",
+        "hercules-ci-effects": "hercules-ci-effects_2",
         "home-manager": "home-manager",
         "llm-agents": "llm-agents",
         "mics-skills": "mics-skills",

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         "adios": "adios"
       },
       "locked": {
-        "lastModified": 1772282380,
-        "narHash": "sha256-ZCm0Z/eUAhyCh82L1jY8s1CzkFApft0lXMEdr2Mk5jc=",
+        "lastModified": 1772282809,
+        "narHash": "sha256-4d/UJy0ymiIQEQW2iPaTv22gPVv6Lt1yK6AxAqV2K4k=",
         "owner": "Mic92",
         "repo": "adios-flake",
-        "rev": "f86acb8f11944295b197297dda37faefd0fe0f4a",
+        "rev": "3157391aae42bc0ef1bb06881aa063b8d21324ed",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,16 +9,21 @@
   # To update all inputs:
   # $ nix flake update
   inputs = {
+    adios-flake.url = "github:Mic92/adios-flake";
+
+    # Kept as a top-level input so upstream dependencies that use
+    # flake-parts all share a single copy via follows.
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+
     hercules-ci-effects.url = "git+https://github.com/hercules-ci/hercules-ci-effects?shallow=1";
     hercules-ci-effects.inputs.nixpkgs.follows = "nixpkgs";
     hercules-ci-effects.inputs.flake-parts.follows = "flake-parts";
 
     harmonia.url = "github:nix-community/harmonia";
     harmonia.inputs.nixpkgs.follows = "nixpkgs";
-    harmonia.inputs.flake-parts.follows = "flake-parts";
     harmonia.inputs.treefmt-nix.follows = "treefmt-nix";
+    harmonia.inputs.flake-parts.follows = "flake-parts";
     harmonia.inputs.crane.follows = "crane";
     harmonia.inputs.nix.follows = "nix";
 
@@ -27,7 +32,6 @@
 
     nix.url = "git+https://github.com/Mic92/nix-1?shallow=1";
     nix.inputs.nixpkgs.follows = "nixpkgs";
-    nix.inputs.flake-parts.follows = "";
     nix.inputs.flake-compat.follows = "";
     nix.inputs.nixpkgs-regression.follows = "";
     nix.inputs.git-hooks-nix.follows = "";
@@ -57,14 +61,13 @@
 
     data-mesher.url = "git+https://git.clan.lol/clan/data-mesher?shallow=1";
     data-mesher.inputs.nixpkgs.follows = "nixpkgs";
-    data-mesher.inputs.flake-parts.follows = "flake-parts";
     data-mesher.inputs.treefmt-nix.follows = "treefmt-nix";
+    data-mesher.inputs.flake-parts.follows = "flake-parts";
 
     buildbot-nix.url = "git+https://github.com/nix-community/buildbot-nix?shallow=1";
     buildbot-nix.inputs.nixpkgs.follows = "nixpkgs";
-    buildbot-nix.inputs.flake-parts.follows = "flake-parts";
     buildbot-nix.inputs.treefmt-nix.follows = "treefmt-nix";
-    buildbot-nix.inputs.hercules-ci-effects.follows = "";
+    buildbot-nix.inputs.flake-parts.follows = "flake-parts";
 
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
@@ -101,16 +104,16 @@
 
     n8n-nodes-caldav.url = "github:Mic92/n8n-nodes-caldav";
     n8n-nodes-caldav.inputs.nixpkgs.follows = "nixpkgs";
-    n8n-nodes-caldav.inputs.flake-parts.follows = "flake-parts";
     n8n-nodes-caldav.inputs.treefmt-nix.follows = "treefmt-nix";
+    n8n-nodes-caldav.inputs.flake-parts.follows = "flake-parts";
 
     disko.url = "github:nix-community/disko";
     disko.inputs.nixpkgs.follows = "nixpkgs";
 
     direnv-instant.url = "github:Mic92/direnv-instant";
     direnv-instant.inputs.nixpkgs.follows = "nixpkgs";
-    direnv-instant.inputs.flake-parts.follows = "flake-parts";
     direnv-instant.inputs.treefmt-nix.follows = "treefmt-nix";
+    direnv-instant.inputs.flake-parts.follows = "flake-parts";
 
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
@@ -143,36 +146,36 @@
     nix-diff-rs = {
       url = "github:Mic92/nix-diff-rs";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-parts.follows = "flake-parts";
       inputs.treefmt-nix.follows = "treefmt-nix";
+      inputs.flake-parts.follows = "flake-parts";
     };
 
     nix-tree-rs = {
       url = "github:Mic92/nix-tree-rs";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-parts.follows = "flake-parts";
       inputs.treefmt-nix.follows = "treefmt-nix";
+      inputs.flake-parts.follows = "flake-parts";
     };
 
     nix-casks = {
       url = "github:atahanyorganci/nix-casks/archive";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-parts.follows = "flake-parts";
       inputs.treefmt-nix.follows = "treefmt-nix";
+      inputs.flake-parts.follows = "flake-parts";
     };
 
     niks3 = {
       url = "github:Mic92/niks3";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-parts.follows = "flake-parts";
       inputs.treefmt-nix.follows = "treefmt-nix";
+      inputs.flake-parts.follows = "flake-parts";
     };
 
     mics-skills = {
       url = "github:Mic92/mics-skills";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-parts.follows = "flake-parts";
       inputs.treefmt-nix.follows = "treefmt-nix";
+      inputs.flake-parts.follows = "flake-parts";
     };
 
     #microvm.url = "github:astro/microvm.nix";
@@ -181,109 +184,101 @@
   };
 
   outputs =
-    inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } (
-      {
-        withSystem,
-        self,
-        config,
-        ...
-      }:
-      {
-        imports = [
-          ./machines/flake-module.nix
-          ./nixosModules/openldap/flake-module.nix
-          ./home-manager/flake-module.nix
-          ./devshell/flake-module.nix
-          ./pkgs/flake-module.nix
-          ./openwrt/flake-module.nix
-          inputs.hercules-ci-effects.flakeModule
-          inputs.clan-core.flakeModules.default
-        ];
-        systems = [
-          "x86_64-linux"
-          "aarch64-linux"
-          "aarch64-darwin"
-        ];
+    inputs@{ adios-flake, self, ... }:
+    let
+      lib = inputs.nixpkgs.lib;
 
-        herculesCI = herculesCI: {
-          onPush.default.outputs.effects.deploy = withSystem config.defaultEffectSystem (
-            { pkgs, hci-effects, ... }:
-            hci-effects.runIf (herculesCI.config.repo.branch == "main") (
-              hci-effects.mkEffect {
-                effectScript = ''
-                  echo "${builtins.toJSON { inherit (herculesCI.config.repo) branch tag rev; }}"
-                  ${pkgs.hello}/bin/hello
-                '';
-              }
+      # Evaluate clan outside mkFlake since it produces system-agnostic outputs
+      clanConfig = import ./machines/flake-module.nix { inherit lib; };
+      clan = inputs.clan-core.lib.clan (
+        {
+          inherit self;
+          pkgsForSystem = system: import inputs.nixpkgs { inherit system; };
+        }
+        // clanConfig
+      );
+    in
+    adios-flake.lib.mkFlake {
+      inherit inputs self;
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      modules = [
+        (import ./nixosModules/openldap/flake-module.nix)
+        (import ./home-manager/flake-module.nix)
+        (import ./home-manager/modules/neovim/flake-module.nix)
+        (import ./devshell/flake-module.nix)
+        (import ./pkgs/flake-module.nix)
+        (import ./openwrt/flake-module.nix)
+      ];
+      perSystem =
+        {
+          self',
+          system,
+          ...
+        }:
+        let
+          machinesPerSystem = {
+            aarch64-linux = [
+              "blob64"
+            ];
+            x86_64-linux = [
+              "eve"
+              "eva"
+              "turingmachine"
+              "matchbox"
+              "bernie"
+              "jacquardmachine"
+              "dorits-laptop"
+            ];
+          };
+          darwinMachinesPerSystem = {
+            aarch64-darwin = [
+              "evo"
+            ];
+          };
+          nixosMachines = lib.mapAttrs' (n: lib.nameValuePair "nixos-${n}") (
+            lib.genAttrs (machinesPerSystem.${system} or [ ]) (
+              name: self.nixosConfigurations.${name}.config.system.build.toplevel
             )
           );
+          darwinMachines = lib.mapAttrs' (n: lib.nameValuePair "darwin-${n}") (
+            lib.genAttrs (darwinMachinesPerSystem.${system} or [ ]) (
+              name: self.darwinConfigurations.${name}.system
+            )
+          );
+
+          blacklistPackages = [
+            "install-iso"
+            "nspawn-template"
+            "netboot-pixie-core"
+            "netboot"
+          ];
+          packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") (
+            lib.filterAttrs (n: _v: !(builtins.elem n blacklistPackages)) self'.packages
+          );
+          devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self'.devShells;
+          homeConfigurations = lib.mapAttrs' (
+            name: config: lib.nameValuePair "home-manager-${name}" config.activation-script
+          ) (self'.legacyPackages.homeConfigurations or { });
+        in
+        {
+          checks = nixosMachines // darwinMachines // packages // devShells // homeConfigurations;
         };
+      flake = {
+        inherit (clan.config)
+          nixosConfigurations
+          darwinConfigurations
+          darwinModules
+          clanInternals
+          ;
 
-        perSystem =
-          {
-            inputs',
-            self',
-            lib,
-            system,
-            ...
-          }:
-          {
-            # make pkgs available to all `perSystem` functions
-            _module.args.pkgs = inputs'.nixpkgs.legacyPackages;
+        clan = clan.config;
 
-            # Set clan.pkgs for all machines
-            clan.pkgs = inputs'.nixpkgs.legacyPackages;
-
-            checks =
-              let
-                machinesPerSystem = {
-                  aarch64-linux = [
-                    "blob64"
-                  ];
-                  x86_64-linux = [
-                    "eve"
-                    "eva"
-                    "turingmachine"
-                    "matchbox"
-                    "bernie"
-                    "jacquardmachine"
-                    "dorits-laptop"
-                  ];
-                };
-                darwinMachinesPerSystem = {
-                  aarch64-darwin = [
-                    "evo"
-                  ];
-                };
-                nixosMachines = lib.mapAttrs' (n: lib.nameValuePair "nixos-${n}") (
-                  lib.genAttrs (machinesPerSystem.${system} or [ ]) (
-                    name: self.nixosConfigurations.${name}.config.system.build.toplevel
-                  )
-                );
-                darwinMachines = lib.mapAttrs' (n: lib.nameValuePair "darwin-${n}") (
-                  lib.genAttrs (darwinMachinesPerSystem.${system} or [ ]) (
-                    name: self.darwinConfigurations.${name}.system
-                  )
-                );
-
-                blacklistPackages = [
-                  "install-iso"
-                  "nspawn-template"
-                  "netboot-pixie-core"
-                  "netboot"
-                ];
-                packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") (
-                  lib.filterAttrs (n: _v: !(builtins.elem n blacklistPackages)) self'.packages
-                );
-                devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self'.devShells;
-                homeConfigurations = lib.mapAttrs' (
-                  name: config: lib.nameValuePair "home-manager-${name}" config.activation-script
-                ) (self'.legacyPackages.homeConfigurations or { });
-              in
-              nixosMachines // darwinMachines // packages // devShells // homeConfigurations;
-          };
-        # CI
-      }
-    );
+        nixosModules.default = ./nixosModules/default.nix;
+        nixosModules.authelia = ./nixosModules/authelia;
+      };
+    };
 }

--- a/home-manager/flake-module.nix
+++ b/home-manager/flake-module.nix
@@ -1,122 +1,120 @@
-{ self, inputs, ... }:
 {
-  imports = [ ./modules/neovim/flake-module.nix ];
+  pkgs,
+  self,
+  self',
+  system,
+  ...
+}:
+let
+  lib = pkgs.lib;
+  inputs = self.inputs;
 
-  perSystem =
+  homeManagerConfiguration =
     {
-      config,
-      pkgs,
-      lib,
-      ...
+      extraModules ? [ ],
     }:
-    let
-      homeManagerConfiguration =
+    (inputs.home-manager.lib.homeManagerConfiguration {
+      modules = [
         {
-          extraModules ? [ ],
-        }:
-        (inputs.home-manager.lib.homeManagerConfiguration {
-          modules = [
-            {
-              _module.args.self = self;
-              _module.args.inputs = self.inputs;
-              imports = extraModules ++ [
-                ./common.nix
-                inputs.nix-index-database.homeModules.nix-index
-                { programs.nix-index-database.comma.enable = true; }
-              ];
-            }
+          _module.args.self = self;
+          _module.args.inputs = inputs;
+          imports = extraModules ++ [
+            ./common.nix
+            inputs.nix-index-database.homeModules.nix-index
+            { programs.nix-index-database.comma.enable = true; }
           ];
-          inherit pkgs;
-        });
-    in
-    {
-      # selects the right home-manager configuration based on the hostname
-      # Called from my .zshrc like this:
-      # hm(){ nix run "$HOME/.homesick/repos/dotfiles#hm" -- "$@"; }
-      apps.hm = {
-        type = "app";
-        program = "${pkgs.writeShellScriptBin "hm" ''
-          set -x
-          export PATH=${
-            pkgs.lib.makeBinPath [
-              pkgs.gitMinimal
-              pkgs.coreutils
-              pkgs.findutils
-              pkgs.jq
-              pkgs.unixtools.hostname
-              pkgs.nixVersions.latest
-            ]
-          }
-          declare -A profiles=(
-            ["turingmachine"]="desktop"
-            ["jacquardmachine"]="desktop"
-            ["bernie"]="bernie"
-            ["web01"]="mic92"
-            ["bld2"]="mic92"
-            ["eve"]="eve"
-            ["evo"]="macos"
-          )
-          profile="common"
-          user=$(id -un)
-          host=$(hostname)
-          if [[ -n ''${profiles["$host-$user"]} ]]; then
-            profile=''${profiles["$host-$user"]};
-          elif [[ -n ''${profiles[$host]:-} ]]; then
-            profile=''${profiles[$host]}
-          fi
-          if [[ "''${1:-}" == profile ]]; then
-            echo $profile
-            exit 0
-          fi
-          ${
-            inputs.home-manager.packages.${pkgs.stdenv.hostPlatform.system}.home-manager
-          }/bin/home-manager --option keep-going true --flake "${self}#$profile" "$@"
-        ''}/bin/hm";
-      };
-
-      apps.bootstrap-dotfiles = {
-        type = "app";
-        program = "${pkgs.writeShellScriptBin "bootstrap-dotfiles" ''
-          set -x
-          export PATH=${
-            pkgs.lib.makeBinPath [
-              pkgs.gitMinimal
-              pkgs.coreutils
-              pkgs.findutils
-              pkgs.nix
-              pkgs.jq
-              pkgs.bash
-            ]
-          }
-          if [ ! -d "$HOME/.homesick/repos/homeshick" ]; then
-            git clone --depth=1 https://github.com/andsens/homeshick.git "$HOME/.homesick/repos/homeshick"
-          fi
-          if [ ! -d "$HOME/.homesick/repos/dotfiles" ]; then
-            "$HOME/.homesick/repos/homeshick/bin/homeshick" clone https://github.com/Mic92/dotfiles.git
-          fi
-          "$HOME/.homesick/repos/homeshick/bin/homeshick" symlink
-          nix run ${self}#hm -- switch
-        ''}/bin/bootstrap-dotfiles";
-      };
-      apps.default = config.apps.bootstrap-dotfiles;
-
-      legacyPackages = {
-        homeConfigurations = {
-          # this one should work for aarch64-linux/x86_64-linux and macos
-          common = homeManagerConfiguration { };
         }
-        // lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "aarch64-darwin") {
-          macos = homeManagerConfiguration { extraModules = [ ./macos.nix ]; };
-        }
-        // lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
-          desktop = homeManagerConfiguration { extraModules = [ ./desktop.nix ]; };
+      ];
+      inherit pkgs;
+    });
+in
+{
+  # selects the right home-manager configuration based on the hostname
+  # Called from my .zshrc like this:
+  # hm(){ nix run "$HOME/.homesick/repos/dotfiles#hm" -- "$@"; }
+  apps.hm = {
+    type = "app";
+    program = "${pkgs.writeShellScriptBin "hm" ''
+      set -x
+      export PATH=${
+        pkgs.lib.makeBinPath [
+          pkgs.gitMinimal
+          pkgs.coreutils
+          pkgs.findutils
+          pkgs.jq
+          pkgs.unixtools.hostname
+          pkgs.nixVersions.latest
+        ]
+      }
+      declare -A profiles=(
+        ["turingmachine"]="desktop"
+        ["jacquardmachine"]="desktop"
+        ["bernie"]="bernie"
+        ["web01"]="mic92"
+        ["bld2"]="mic92"
+        ["eve"]="eve"
+        ["evo"]="macos"
+      )
+      profile="common"
+      user=$(id -un)
+      host=$(hostname)
+      if [[ -n ''${profiles["$host-$user"]} ]]; then
+        profile=''${profiles["$host-$user"]};
+      elif [[ -n ''${profiles[$host]:-} ]]; then
+        profile=''${profiles[$host]}
+      fi
+      if [[ "''${1:-}" == profile ]]; then
+        echo $profile
+        exit 0
+      fi
+      ${
+        inputs.home-manager.packages.${system}.home-manager
+      }/bin/home-manager --option keep-going true --flake "${self}#$profile" "$@"
+    ''}/bin/hm";
+  };
 
-          # different username
-          mic92 = homeManagerConfiguration { extraModules = [ { home.username = "mic92"; } ]; };
+  apps.bootstrap-dotfiles = {
+    type = "app";
+    program = "${pkgs.writeShellScriptBin "bootstrap-dotfiles" ''
+      set -x
+      export PATH=${
+        pkgs.lib.makeBinPath [
+          pkgs.gitMinimal
+          pkgs.coreutils
+          pkgs.findutils
+          pkgs.nix
+          pkgs.jq
+          pkgs.bash
+        ]
+      }
+      if [ ! -d "$HOME/.homesick/repos/homeshick" ]; then
+        git clone --depth=1 https://github.com/andsens/homeshick.git "$HOME/.homesick/repos/homeshick"
+      fi
+      if [ ! -d "$HOME/.homesick/repos/dotfiles" ]; then
+        "$HOME/.homesick/repos/homeshick/bin/homeshick" clone https://github.com/Mic92/dotfiles.git
+      fi
+      "$HOME/.homesick/repos/homeshick/bin/homeshick" symlink
+      nix run ${self}#hm -- switch
+    ''}/bin/bootstrap-dotfiles";
+  };
+  apps.default = self'.apps.bootstrap-dotfiles;
 
-          eve = homeManagerConfiguration { extraModules = [ ./eve.nix ]; };
-          bernie = homeManagerConfiguration { extraModules = [ ./bernie.nix ]; };
-        };
-      };
+  legacyPackages = {
+    homeConfigurations = {
+      # this one should work for aarch64-linux/x86_64-linux and macos
+      common = homeManagerConfiguration { };
+    }
+    // lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "aarch64-darwin") {
+      macos = homeManagerConfiguration { extraModules = [ ./macos.nix ]; };
+    }
+    // lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
+      desktop = homeManagerConfiguration { extraModules = [ ./desktop.nix ]; };
+
+      # different username
+      mic92 = homeManagerConfiguration { extraModules = [ { home.username = "mic92"; } ]; };
+
+      eve = homeManagerConfiguration { extraModules = [ ./eve.nix ]; };
+      bernie = homeManagerConfiguration { extraModules = [ ./bernie.nix ]; };
     };
+  };
 }

--- a/home-manager/flake-module.nix
+++ b/home-manager/flake-module.nix
@@ -1,12 +1,12 @@
 {
   pkgs,
+  lib,
   self,
   self',
   system,
   ...
 }:
 let
-  lib = pkgs.lib;
   inputs = self.inputs;
 
   homeManagerConfiguration =

--- a/home-manager/modules/neovim/flake-module.nix
+++ b/home-manager/modules/neovim/flake-module.nix
@@ -1,6 +1,5 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 let
-  lib = pkgs.lib;
   nvim-lsp-packages = with pkgs; [
     nodejs # copilot
     # tree-sitter-cli needs a C compiler to build parsers from source

--- a/home-manager/modules/neovim/flake-module.nix
+++ b/home-manager/modules/neovim/flake-module.nix
@@ -1,86 +1,82 @@
-{ lib, ... }:
+{ pkgs, ... }:
+let
+  lib = pkgs.lib;
+  nvim-lsp-packages = with pkgs; [
+    nodejs # copilot
+    # tree-sitter-cli needs a C compiler to build parsers from source
+    (pkgs.symlinkJoin {
+      name = "tree-sitter-wrapped";
+      paths = [ pkgs.tree-sitter ];
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      postBuild = ''
+        wrapProgram $out/bin/tree-sitter \
+          --prefix PATH : ${lib.makeBinPath [ pkgs.stdenv.cc ]}
+      '';
+    })
+
+    # based on ./suggested-pkgs.json
+    basedpyright
+    bash-language-server
+    clang-tools
+    golangci-lint
+    gopls
+    lua-language-server
+    # dotnet is quiet heavy and we don't need an lsp for md files
+    #marksman
+    nil
+    nixd
+    nixfmt
+    prettierd
+    ruff
+    selene
+    shellcheck
+    shfmt
+    stylua
+    vtsls
+    yaml-language-server
+    vscode-langservers-extracted
+    # based on https://github.com/ray-x/go.nvim#go-binaries-install-and-update
+    go
+    delve
+    ginkgo
+    gofumpt
+    golines
+    gomodifytags
+    gotests
+    gotestsum
+    gotools
+    govulncheck
+    iferr
+    impl
+
+    # others
+    rust-analyzer
+    clippy
+    rustfmt
+
+    zls
+    terraform-ls
+    taplo
+    typos
+    typos-lsp
+  ];
+in
 {
-  perSystem =
-    {
-      pkgs,
-      config,
-      ...
-    }:
-    {
-      legacyPackages = {
-        nvim-lsp-packages = with pkgs; [
-          nodejs # copilot
-          # tree-sitter-cli needs a C compiler to build parsers from source
-          (pkgs.symlinkJoin {
-            name = "tree-sitter-wrapped";
-            paths = [ pkgs.tree-sitter ];
-            nativeBuildInputs = [ pkgs.makeWrapper ];
-            postBuild = ''
-              wrapProgram $out/bin/tree-sitter \
-                --prefix PATH : ${lib.makeBinPath [ pkgs.stdenv.cc ]}
-            '';
-          })
+  legacyPackages = {
+    inherit nvim-lsp-packages;
+  };
+  packages = {
+    neovim = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped (
+      pkgs.neovimUtils.makeNeovimConfig {
+        wrapRc = false;
+        withRuby = false;
+      }
+    );
+    nvim-open = pkgs.python3.pkgs.callPackage ./nvim-open.nix { };
 
-          # based on ./suggested-pkgs.json
-          basedpyright
-          bash-language-server
-          clang-tools
-          golangci-lint
-          gopls
-          lua-language-server
-          # dotnet is quiet heavy and we don't need an lsp for md files
-          #marksman
-          nil
-          nixd
-          nixfmt
-          prettierd
-          ruff
-          selene
-          shellcheck
-          shfmt
-          stylua
-          vtsls
-          yaml-language-server
-          vscode-langservers-extracted
-          # based on https://github.com/ray-x/go.nvim#go-binaries-install-and-update
-          go
-          delve
-          ginkgo
-          gofumpt
-          golines
-          gomodifytags
-          gotests
-          gotestsum
-          gotools
-          govulncheck
-          iferr
-          impl
-
-          # others
-          rust-analyzer
-          clippy
-          rustfmt
-
-          zls
-          terraform-ls
-          taplo
-          typos
-          typos-lsp
-        ];
-      };
-      packages = {
-        neovim = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped (
-          pkgs.neovimUtils.makeNeovimConfig {
-            wrapRc = false;
-            withRuby = false;
-          }
-        );
-        nvim-open = pkgs.python3.pkgs.callPackage ./nvim-open.nix { };
-
-        nvim = pkgs.callPackage ./nvim-standalone.nix {
-          nvim-appname = "nvim-mic92";
-          inherit (config.legacyPackages) nvim-lsp-packages;
-        };
-      };
+    nvim = pkgs.callPackage ./nvim-standalone.nix {
+      nvim-appname = "nvim-mic92";
+      inherit nvim-lsp-packages;
     };
+  };
 }

--- a/machines/flake-module.nix
+++ b/machines/flake-module.nix
@@ -1,154 +1,153 @@
+# Clan configuration — consumed by flake.nix via inputs.clan-core.lib.clan
+# This is NOT an adios-flake module; it's a plain function returning the
+# clan option attrset (meta, inventory) so flake.nix can pass it through.
 { lib, ... }:
 {
-  flake.nixosModules.default = ../nixosModules/default.nix;
-  flake.nixosModules.authelia = ../nixosModules/authelia;
-  clan = {
-    meta.name = "mic92";
+  meta.name = "mic92";
 
-    inventory = {
-      tags =
-        { config, ... }:
-        {
-          backup = builtins.filter (name: name != "blob64" && name != "installer") config.nixos;
-          wireguard-peers = builtins.filter (name: name != "eve" && name != "eva") config.nixos;
-        };
-
-      machines = {
-        eve.deploy.targetHost = "root@eve.i";
-        eva.deploy = {
-          targetHost = "root@eva.i";
-          buildHost = "root@eve.i";
-        };
-        evo = {
-          machineClass = "darwin";
-          deploy.targetHost = "root@evo.x";
-        };
-        turingmachine.deploy.targetHost = "root@turingmachine.x";
-        bernie.deploy.targetHost = "root@bernie.x";
-        blob64.deploy.targetHost = "root@blob64.x";
-        matchbox.deploy.targetHost = "root@matchbox.x";
-        jacquardmachine.deploy.targetHost = "root@jacquardmachine.x";
+  inventory = {
+    tags =
+      { config, ... }:
+      {
+        backup = builtins.filter (name: name != "blob64" && name != "installer") config.nixos;
+        wireguard-peers = builtins.filter (name: name != "eve" && name != "eva") config.nixos;
       };
 
-      instances = {
-        emergency-access = {
-          module.name = "emergency-access";
-          module.input = "clan-core";
-          roles.default.tags.nixos = { };
+    machines = {
+      eve.deploy.targetHost = "root@eve.i";
+      eva.deploy = {
+        targetHost = "root@eva.i";
+        buildHost = "root@eve.i";
+      };
+      evo = {
+        machineClass = "darwin";
+        deploy.targetHost = "root@evo.x";
+      };
+      turingmachine.deploy.targetHost = "root@turingmachine.x";
+      bernie.deploy.targetHost = "root@bernie.x";
+      blob64.deploy.targetHost = "root@blob64.x";
+      matchbox.deploy.targetHost = "root@matchbox.x";
+      jacquardmachine.deploy.targetHost = "root@jacquardmachine.x";
+    };
+
+    instances = {
+      emergency-access = {
+        module.name = "emergency-access";
+        module.input = "clan-core";
+        roles.default.tags.nixos = { };
+      };
+
+      borgbackup-blob64 = {
+        module.name = "borgbackup";
+        module.input = "clan-core";
+        roles.server.machines.blob64 = { };
+        roles.server.settings = {
+          directory = "/zdata/borg";
         };
+        roles.client.tags.backup = { };
+        roles.client.extraModules = [ ../nixosModules/borgbackup.nix ];
+      };
 
-        borgbackup-blob64 = {
-          module.name = "borgbackup";
-          module.input = "clan-core";
-          roles.server.machines.blob64 = { };
-          roles.server.settings = {
-            directory = "/zdata/borg";
-          };
-          roles.client.tags.backup = { };
-          roles.client.extraModules = [ ../nixosModules/borgbackup.nix ];
+      zerotier-mic92 = {
+        module.name = "zerotier";
+        module.input = "clan-core";
+        roles.controller.machines.eve = { };
+        roles.moon.machines.eva.settings = {
+          stableEndpoints = [
+            "116.203.179.132"
+            "2a01:4f8:1c1a:37b2::1"
+          ];
         };
-
-        zerotier-mic92 = {
-          module.name = "zerotier";
-          module.input = "clan-core";
-          roles.controller.machines.eve = { };
-          roles.moon.machines.eva.settings = {
-            stableEndpoints = [
-              "116.203.179.132"
-              "2a01:4f8:1c1a:37b2::1"
-            ];
-          };
-          roles.moon.machines.eve.settings = {
-            stableEndpoints = [
-              "135.181.61.171"
-              "2a01:4f9:4b:4084::1"
-            ];
-          };
-          roles.peer.tags.nixos = { };
+        roles.moon.machines.eve.settings = {
+          stableEndpoints = [
+            "135.181.61.171"
+            "2a01:4f9:4b:4084::1"
+          ];
         };
+        roles.peer.tags.nixos = { };
+      };
 
-        sshd-mic92 = {
-          module.name = "sshd";
-          module.input = "clan-core";
-          roles.server.tags.nixos = { };
-          roles.client.tags.nixos = { };
-          # tor-hidden-service
-          roles.client.extraModules = [ ../nixosModules/ssh.nix ];
-          roles.client.settings = {
-            certificate.searchDomains = [
-              "i"
-              "r"
-              "local"
-              "onion"
-              "thalheim.io"
-            ];
-          };
+      sshd-mic92 = {
+        module.name = "sshd";
+        module.input = "clan-core";
+        roles.server.tags.nixos = { };
+        roles.client.tags.nixos = { };
+        # tor-hidden-service
+        roles.client.extraModules = [ ../nixosModules/ssh.nix ];
+        roles.client.settings = {
+          certificate.searchDomains = [
+            "i"
+            "r"
+            "local"
+            "onion"
+            "thalheim.io"
+          ];
         };
+      };
 
-        wireguard = {
-          module.name = "wireguard";
-          module.input = "clan-core";
+      wireguard = {
+        module.name = "wireguard";
+        module.input = "clan-core";
 
-          roles.controller.settings.domain = "x";
-          roles.peer.settings.domain = "x";
+        roles.controller.settings.domain = "x";
+        roles.peer.settings.domain = "x";
 
-          roles.controller.machines.eva = {
-            settings = {
-              endpoint = "eva.i";
-              port = 51820;
-            };
-          };
-          roles.controller.machines.eve = {
-            settings = {
-              endpoint = "eve.i";
-              port = 51821;
-            };
-          };
-
-          roles.peer.settings.controller = "eva";
-          roles.peer.tags.wireguard-peers = { };
-
-          roles.peer.machines.turingmachine.settings.controller = lib.mkForce "eve";
-          roles.peer.machines.jacquardmachine.settings.controller = "eva";
-          roles.peer.machines.evo.settings.controller = "eva";
-        };
-
-        internet = {
-          module.name = "internet";
-          module.input = "clan-core";
-          roles.default.machines.eve = {
-            settings.host = "eve.i";
-          };
-          roles.default.machines.eva = {
-            settings.host = "eva.i";
+        roles.controller.machines.eva = {
+          settings = {
+            endpoint = "eva.i";
+            port = 51820;
           };
         };
-
-        tor.roles.server.tags.nixos = { };
-
-        users-root = {
-          module.name = "users";
-          module.input = "clan-core";
-          roles.default.tags.nixos = { };
-          roles.default.settings = {
-            user = "root";
-            prompt = false;
-            groups = [ ];
+        roles.controller.machines.eve = {
+          settings = {
+            endpoint = "eve.i";
+            port = 51821;
           };
         };
 
-        localbackup-turingmachine = {
-          module.name = "localbackup";
-          module.input = "clan-core";
-          roles.default.machines.turingmachine.settings = {
-            targets.hdd = {
-              directory = "/backup-2tb/turingmachine";
-              mountpoint = "/backup-2tb";
-              preMountHook = "localbackup-unlock-hdd";
-            };
-          };
-          roles.default.extraModules = [ ../machines/turingmachine/modules/localbackup.nix ];
+        roles.peer.settings.controller = "eva";
+        roles.peer.tags.wireguard-peers = { };
+
+        roles.peer.machines.turingmachine.settings.controller = lib.mkForce "eve";
+        roles.peer.machines.jacquardmachine.settings.controller = "eva";
+        roles.peer.machines.evo.settings.controller = "eva";
+      };
+
+      internet = {
+        module.name = "internet";
+        module.input = "clan-core";
+        roles.default.machines.eve = {
+          settings.host = "eve.i";
         };
+        roles.default.machines.eva = {
+          settings.host = "eva.i";
+        };
+      };
+
+      tor.roles.server.tags.nixos = { };
+
+      users-root = {
+        module.name = "users";
+        module.input = "clan-core";
+        roles.default.tags.nixos = { };
+        roles.default.settings = {
+          user = "root";
+          prompt = false;
+          groups = [ ];
+        };
+      };
+
+      localbackup-turingmachine = {
+        module.name = "localbackup";
+        module.input = "clan-core";
+        roles.default.machines.turingmachine.settings = {
+          targets.hdd = {
+            directory = "/backup-2tb/turingmachine";
+            mountpoint = "/backup-2tb";
+            preMountHook = "localbackup-unlock-hdd";
+          };
+        };
+        roles.default.extraModules = [ ../machines/turingmachine/modules/localbackup.nix ];
       };
     };
   };

--- a/nixosModules/openldap/flake-module.nix
+++ b/nixosModules/openldap/flake-module.nix
@@ -1,13 +1,10 @@
+{ pkgs, ... }:
 {
-  perSystem =
-    { pkgs, lib, ... }:
-    {
-      devShells = lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
-        ldap = pkgs.mkShell {
-          packages = [
-            pkgs.apache-directory-studio
-          ];
-        };
-      };
+  devShells = pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
+    ldap = pkgs.mkShell {
+      packages = [
+        pkgs.apache-directory-studio
+      ];
     };
+  };
 }

--- a/nixosModules/openldap/flake-module.nix
+++ b/nixosModules/openldap/flake-module.nix
@@ -1,6 +1,6 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
-  devShells = pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
+  devShells = lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
     ldap = pkgs.mkShell {
       packages = [
         pkgs.apache-directory-studio

--- a/openwrt/flake-module.nix
+++ b/openwrt/flake-module.nix
@@ -1,23 +1,14 @@
+{ pkgs, ... }:
+let
+  uci = pkgs.callPackage ./nix { };
+in
 {
-  ...
-}:
-{
-  perSystem =
-    {
-      pkgs,
-      ...
-    }:
-    let
-      uci = pkgs.callPackage ./nix { };
-    in
-    {
-      packages.openwrt-example = (uci.writeUci ./example.nix).command;
+  packages.openwrt-example = (uci.writeUci ./example.nix).command;
 
-      devShells.openwrt = pkgs.mkShell {
-        buildInputs = [
-          pkgs.just
-          pkgs.sops
-        ];
-      };
-    };
+  devShells.openwrt = pkgs.mkShell {
+    buildInputs = [
+      pkgs.just
+      pkgs.sops
+    ];
+  };
 }

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -1,71 +1,69 @@
-{ inputs, ... }:
 {
-  perSystem =
-    {
-      inputs',
-      self',
-      pkgs,
-      ...
-    }:
-    let
-      micsSkills = inputs'.mics-skills.packages;
-      aiTools = inputs'.llm-agents.packages;
-    in
-    {
-      packages = {
-        forge-triage = inputs'.forge-triage.packages.default;
-        merge-when-green = pkgs.callPackage ./merge-when-green {
-          flake-fmt = inputs'.flake-fmt.packages.default;
-        };
-        claude-code = pkgs.callPackage ./claude-code {
-          claude-code = inputs'.llm-agents.packages.claude-code;
-        };
-
-        email-sync = pkgs.callPackage ./email-sync { };
-        vcal = pkgs.callPackage ./vcal { };
-        buildbot-pr-check = pkgs.python3.pkgs.callPackage ./buildbot-pr-check { };
-        claude-md = pkgs.python3.pkgs.callPackage ./claude-md { };
-        crabfit-cli = pkgs.python3.pkgs.callPackage ./crabfit-cli { };
-        inherit (pkgs.callPackages ./firefox-extensions { })
-          chrome-tab-gc-extension
-          ;
-        gh-radicle = pkgs.callPackage ./gh-radicle { };
-        iroh-ssh = pkgs.callPackage ./iroh-ssh { };
-        # Cross-platform secure pinentry (works on macOS and Linux)
-        rbw-pinentry = pkgs.callPackage ./rbw_pinentry { };
-        # Matrix calendar bot
-        calendar-bot = pkgs.python3.pkgs.callPackage ./calendar_bot { };
-        # Nix evaluation warnings extractor
-        nix-eval-warnings = pkgs.callPackage ./nix-eval-warnings { };
-        # Reference all flake inputs to ensure they get cached
-        flake-inputs = pkgs.callPackage ./flake-inputs { inherit inputs; };
-        # Package updater CLI
-        updater = pkgs.callPackage ./updater { };
-        # Sandboxed pi for calendar/email tasks
-        pim = pkgs.callPackage ./pim {
-          inherit (self'.packages) email-sync crabfit-cli;
-          pi = aiTools.pi;
-          db-cli = micsSkills.db-cli;
-          kagi-search = micsSkills.kagi-search;
-        };
-      }
-      // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
-        alertmanager-bar = pkgs.callPackage ./alertmanager-bar { };
-        blueutil = pkgs.callPackage ./blueutil { };
-        systemctl-macos = pkgs.callPackage ./systemctl { };
-      }
-      // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "aarch64-darwin") {
-        kdeconnect = pkgs.callPackage ./kdeconnect { };
-        librewolf-macos = pkgs.callPackage ./librewolf-macos { };
-        radicle-desktop = pkgs.callPackage ./radicle-desktop { };
-      }
-      // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-        phantun = pkgs.callPackage ./phantun { };
-        phpldapadmin = pkgs.callPackage ../nixosModules/phpldapadmin/package.nix { };
-        radicle-github-sync = pkgs.callPackage ./radicle-github-sync { };
-      }
-      // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
-        cewe-fotowelt = pkgs.callPackage ./cewe-fotowelt { };
-      };
+  pkgs,
+  inputs',
+  self',
+  self,
+  ...
+}:
+let
+  inputs = self.inputs;
+  micsSkills = inputs'.mics-skills;
+  aiTools = inputs'.llm-agents;
+in
+{
+  packages = {
+    forge-triage = inputs'.forge-triage.default;
+    merge-when-green = pkgs.callPackage ./merge-when-green {
+      flake-fmt = inputs'.flake-fmt.default;
     };
+    claude-code = pkgs.callPackage ./claude-code {
+      claude-code = inputs'.llm-agents.claude-code;
+    };
+
+    email-sync = pkgs.callPackage ./email-sync { };
+    vcal = pkgs.callPackage ./vcal { };
+    buildbot-pr-check = pkgs.python3.pkgs.callPackage ./buildbot-pr-check { };
+    claude-md = pkgs.python3.pkgs.callPackage ./claude-md { };
+    crabfit-cli = pkgs.python3.pkgs.callPackage ./crabfit-cli { };
+    inherit (pkgs.callPackages ./firefox-extensions { })
+      chrome-tab-gc-extension
+      ;
+    gh-radicle = pkgs.callPackage ./gh-radicle { };
+    iroh-ssh = pkgs.callPackage ./iroh-ssh { };
+    # Cross-platform secure pinentry (works on macOS and Linux)
+    rbw-pinentry = pkgs.callPackage ./rbw_pinentry { };
+    # Matrix calendar bot
+    calendar-bot = pkgs.python3.pkgs.callPackage ./calendar_bot { };
+    # Nix evaluation warnings extractor
+    nix-eval-warnings = pkgs.callPackage ./nix-eval-warnings { };
+    # Reference all flake inputs to ensure they get cached
+    flake-inputs = pkgs.callPackage ./flake-inputs { inherit inputs; };
+    # Package updater CLI
+    updater = pkgs.callPackage ./updater { };
+    # Sandboxed pi for calendar/email tasks
+    pim = pkgs.callPackage ./pim {
+      inherit (self'.packages) email-sync crabfit-cli;
+      pi = aiTools.pi;
+      db-cli = micsSkills.db-cli;
+      kagi-search = micsSkills.kagi-search;
+    };
+  }
+  // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+    alertmanager-bar = pkgs.callPackage ./alertmanager-bar { };
+    blueutil = pkgs.callPackage ./blueutil { };
+    systemctl-macos = pkgs.callPackage ./systemctl { };
+  }
+  // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "aarch64-darwin") {
+    kdeconnect = pkgs.callPackage ./kdeconnect { };
+    librewolf-macos = pkgs.callPackage ./librewolf-macos { };
+    radicle-desktop = pkgs.callPackage ./radicle-desktop { };
+  }
+  // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+    phantun = pkgs.callPackage ./phantun { };
+    phpldapadmin = pkgs.callPackage ../nixosModules/phpldapadmin/package.nix { };
+    radicle-github-sync = pkgs.callPackage ./radicle-github-sync { };
+  }
+  // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
+    cewe-fotowelt = pkgs.callPackage ./cewe-fotowelt { };
+  };
 }

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  lib,
   inputs',
   self',
   self,
@@ -48,22 +49,22 @@ in
       kagi-search = micsSkills.kagi-search;
     };
   }
-  // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+  // lib.optionalAttrs pkgs.stdenv.isDarwin {
     alertmanager-bar = pkgs.callPackage ./alertmanager-bar { };
     blueutil = pkgs.callPackage ./blueutil { };
     systemctl-macos = pkgs.callPackage ./systemctl { };
   }
-  // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "aarch64-darwin") {
+  // lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "aarch64-darwin") {
     kdeconnect = pkgs.callPackage ./kdeconnect { };
     librewolf-macos = pkgs.callPackage ./librewolf-macos { };
     radicle-desktop = pkgs.callPackage ./radicle-desktop { };
   }
-  // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+  // lib.optionalAttrs pkgs.stdenv.isLinux {
     phantun = pkgs.callPackage ./phantun { };
     phpldapadmin = pkgs.callPackage ../nixosModules/phpldapadmin/package.nix { };
     radicle-github-sync = pkgs.callPackage ./radicle-github-sync { };
   }
-  // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
+  // lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
     cewe-fotowelt = pkgs.callPackage ./cewe-fotowelt { };
   };
 }


### PR DESCRIPTION
Replace flake-parts with [adios-flake](https://github.com/Mic92/adios-flake),
a lighter-weight alternative that uses direct function dispatch instead of the
NixOS module system for per-system evaluation.

## What changed

- `flake.nix`: replaced `flake-parts.lib.mkFlake` with `adios-flake.lib.mkFlake`
- All 7 per-system modules (`devshell/`, `home-manager/`, `pkgs/`, `openwrt/`,
  `nixosModules/openldap/`, `home-manager/modules/neovim/`): converted from
  flake-parts module format to plain functions taking `{ pkgs, lib, self, ... }:`
- `machines/flake-module.nix`: now a plain function consumed by
  `inputs.clan-core.lib.clan` directly (not a flake-parts module)
- treefmt-nix: uses `treefmt-nix.lib.evalModule` directly instead of
  `treefmt-nix.flakeModule`
- Dropped `herculesCI` output (was tightly coupled to `hercules-ci-effects.flakeModule`)
- Dropped empty `overlays` output (came from flake-parts boilerplate)
- Added `flake-parts` as top-level input for `follows` deduplication — collapses
  5 duplicate copies across upstream inputs

## Evaluation benchmarks

Measured with `NIX_SHOW_STATS=1`, eval cache cleared, 5 runs each.
Baseline: [`7b3a760b0`](https://github.com/Mic92/dotfiles/commit/7b3a760b0) (main, flake-parts).

| Benchmark | flake-parts | adios-flake | Speedup |
|:---|---:|---:|---:|
| `packages.aarch64-darwin` (1 system) | 0.401s | 0.288s | **28% faster** |
| `formatter` (3 systems) | 0.519s | 0.359s | **31% faster** |
| `devShells` (3 systems) | 0.482s | 0.345s | **28% faster** |

Detailed stats in [adios-flake BENCHMARKS.md](https://github.com/Mic92/adios-flake/blob/main/BENCHMARKS.md).

## Tested

- [x] `nix build .#packages.aarch64-darwin.nvim`
- [x] `nix build .#checks.aarch64-darwin.formatting`
- [x] `nix build .#darwinConfigurations.evo.system`
- [x] `nix eval .#legacyPackages.homeConfigurations` → `["common" "macos"]`
- [x] `nix eval .#formatter` → all 3 systems resolve to `treefmt`
- [x] Top-level flake attributes match original (minus intentionally dropped outputs)