### PR TITLE
eve: opencrow: work around broken pam_lastlog2 in systemd 259

### DIFF
--- a/machines/eve/configuration.nix
+++ b/machines/eve/configuration.nix
@@ -93,5 +93,10 @@
   ];
   nixpkgs.pkgs = self.inputs.nixpkgs.legacyPackages.x86_64-linux;
 
+  # Work around broken pam_lastlog2.so missing libpam linkage in systemd 259
+  # https://github.com/NixOS/nixpkgs/issues/493934
+  # TODO: remove once https://github.com/NixOS/nixpkgs/pull/495347 is merged
+  containers.opencrow.config.security.pam.services.login.updateWtmp = lib.mkForce false;
+
   # The NixOS release to be compatible with for stateful data such as databases.
 }

--- a/machines/eve/modules/opencrow.nix
+++ b/machines/eve/modules/opencrow.nix
@@ -125,8 +125,6 @@ in
   containers.opencrow.config.users.groups.opencrow.gid = 2000;
   users.groups.opencrow.gid = 2000;
 
-
-
   # /etc/localtime is bind-mounted from the host (UTC) in nspawn containers,
   # so we rely on /etc/timezone and TZ env var instead.
   containers.opencrow.config.environment.etc."timezone".text = "Europe/Berlin\n";


### PR DESCRIPTION

machinectl shell fails immediately because pam_lastlog2.so from
util-linux is not linked against libpam, causing PAM session setup
to fail with "Module is unknown".

Disable updateWtmp for the container's login PAM service until
nixpkgs#495347 merges the proper fix in util-linux.
