### PR TITLE
n8n-nodes-paperless: make package updatable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -858,11 +858,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772925745,
-        "narHash": "sha256-kAmOO5g5SW4B/RlVLUltaJsnplpeaQ2rg4aoav3AYZg=",
+        "lastModified": 1772963890,
+        "narHash": "sha256-Lf63cJmO56xDNS7qFKnm94YamATHX0ygGwimdH/RVZs=",
         "owner": "pinpox",
         "repo": "opencrow",
-        "rev": "aead68d1c2eacfbf571e915baa3cfa154375956c",
+        "rev": "bd6371eda8ac070011ab8e93b2c596f599396103",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -858,11 +858,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772923540,
-        "narHash": "sha256-/umUFmir0YUIR/2TSW4NGrbVcBdPlTJmvuw56bT1qx0=",
+        "lastModified": 1772925745,
+        "narHash": "sha256-kAmOO5g5SW4B/RlVLUltaJsnplpeaQ2rg4aoav3AYZg=",
         "owner": "pinpox",
         "repo": "opencrow",
-        "rev": "7f664b48b47b09dc0c78ee877dff639b9380fcd9",
+        "rev": "aead68d1c2eacfbf571e915baa3cfa154375956c",
         "type": "github"
       },
       "original": {

--- a/machines/eve/modules/n8n/default.nix
+++ b/machines/eve/modules/n8n/default.nix
@@ -106,6 +106,7 @@ in
           name: pkg: "ln -sfn ${pkg}/lib/node_modules/${name}/dist /var/lib/n8n/.n8n/custom/${name}"
         ) micsNodes
       );
+      n8n-nodes-paperless = self.packages.${pkgs.stdenv.hostPlatform.system}.n8n-nodes-paperless;
     in
     ''
       mkdir -p /var/lib/n8n/.n8n/custom
@@ -113,6 +114,8 @@ in
         self.inputs.n8n-nodes-caldav.packages.${pkgs.stdenv.hostPlatform.system}.default
       }/lib/node_modules/n8n-nodes-caldav/dist \
         /var/lib/n8n/.n8n/custom/n8n-nodes-caldav
+      ln -sfn ${n8n-nodes-paperless}/lib/node_modules/@n8n-chezmoi-sh/n8n-nodes-paperless/dist \
+        /var/lib/n8n/.n8n/custom/n8n-nodes-paperless
       ${linkCommands}
     '';
 

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -24,6 +24,7 @@ in
     };
     n8n-cli = pkgs.callPackage ./n8n-cli { inherit bun2nix; };
     n8n-hooks = pkgs.callPackage ./n8n-hooks { };
+    n8n-nodes-paperless = pkgs.callPackage ./n8n-nodes-paperless { };
 
     email-sync = pkgs.callPackage ./email-sync { };
     vcal = pkgs.callPackage ./vcal { };

--- a/pkgs/n8n-nodes-paperless/default.nix
+++ b/pkgs/n8n-nodes-paperless/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nodejs,
+  pnpm_9,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "n8n-nodes-paperless";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "chezmoidotsh";
+    repo = "n8n-nodes-paperless";
+    rev = finalAttrs.version;
+    hash = "sha256-LOmQpw1+U94jlyiIN3Xju1f92S+1afNFE4S6I6hp9VI=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_9;
+    fetcherVersion = 3;
+    hash = "sha256-/z/sLcuHzvAzk1foomzof4p2HRwo+nJPM83NUlADGUc=";
+  };
+
+  nativeBuildInputs = [
+    pnpmConfigHook
+    pnpm_9
+    nodejs
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/node_modules/@n8n-chezmoi-sh/n8n-nodes-paperless
+    cp -r dist package.json node_modules $out/lib/node_modules/@n8n-chezmoi-sh/n8n-nodes-paperless/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "n8n community node to manage documents with Paperless-ngx";
+    homepage = "https://github.com/chezmoidotsh/n8n-nodes-paperless";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/n8n-nodes-paperless/nix-update-args
+++ b/pkgs/n8n-nodes-paperless/nix-update-args
@@ -1,0 +1,1 @@
+--version-regex (.*)


### PR DESCRIPTION

Use tag-based rev instead of commit hash and add nix-update-args
so the updater can automatically bump versions.
