### PR TITLE
browser-cli: manage LibreWolf path declaratively for browsh fallback

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -598,11 +598,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772800810,
-        "narHash": "sha256-01bCrOEeuhRF3m5INA6Qo+LM8bpVQCBETq0xCDKRJzE=",
+        "lastModified": 1772969747,
+        "narHash": "sha256-6GOMhe0dDE+OD2RHQ3m5G3zAUJLBW1fuk3pYhEr8Ckg=",
         "owner": "Mic92",
         "repo": "mics-skills",
-        "rev": "0f0d3de407a66e3af15055f4df16927f8841b155",
+        "rev": "bb5f68aaa95c97c6fec64c8b7c02a1aa24921161",
         "type": "github"
       },
       "original": {

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -13,19 +13,12 @@
     ./modules/ai.nix
     ./modules/kimai.nix
     ./modules/mail.nix
-    ./modules/librewolf.nix
   ];
 
   fonts.fontconfig.enable = true;
 
   services.mpris-proxy.enable = true;
   services.syncthing.enable = true;
-
-  home.activation.installBrowserCliHost = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    ${
-      inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system}.browser-cli
-    }/bin/browser-cli --install-host
-  '';
 
   home.packages =
     with pkgs;
@@ -78,8 +71,6 @@
       nerd-fonts.fira-code
       inxi
       radicle-node
-      inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system}.gmaps-cli
-      inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system}.browser-cli
       inputs.niks3.packages.${pkgs.stdenv.hostPlatform.system}.niks3
     ]
     ++ lib.optionals pkgs.stdenv.isLinux [

--- a/home-manager/macos.nix
+++ b/home-manager/macos.nix
@@ -1,7 +1,6 @@
 {
   pkgs,
   inputs,
-  lib,
   ...
 }:
 {
@@ -12,7 +11,6 @@
     ./modules/kimai.nix
     ./modules/mail.nix
     ./modules/atuin-autosync.nix
-    ./modules/librewolf.nix
   ];
   home.packages = [
     pkgs.eternal-terminal
@@ -20,12 +18,5 @@
     pkgs.radicle-node
     inputs.strace-macos.packages.${pkgs.stdenv.hostPlatform.system}.default
     inputs.niks3.packages.${pkgs.stdenv.hostPlatform.system}.niks3
-    inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system}.browser-cli
   ];
-
-  home.activation.installBrowserCliHost = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    ${
-      inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system}.browser-cli
-    }/bin/browser-cli --install-host
-  '';
 }

--- a/home-manager/modules/ai.nix
+++ b/home-manager/modules/ai.nix
@@ -9,13 +9,17 @@ let
   selfPkgs = self.packages.${pkgs.stdenv.hostPlatform.system};
 in
 {
-  imports = [ inputs.mics-skills.homeManagerModules.default ];
+  imports = [
+    inputs.mics-skills.homeManagerModules.default
+    ./librewolf.nix
+  ];
 
   programs.mics-skills = {
     enable = true;
     package = inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system};
     skillsSrc = inputs.mics-skills;
     skills = [
+      "browser-cli"
       "context7-cli"
       "db-cli"
       "gmaps-cli"

--- a/home-manager/modules/librewolf.nix
+++ b/home-manager/modules/librewolf.nix
@@ -7,16 +7,32 @@
 
 let
   firefoxExtensions = pkgs.callPackages ../../pkgs/firefox-extensions { };
-  micsSkills = inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system};
+  micsSkillsPkgs = inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system};
+
+  librewolfPath =
+    if pkgs.stdenv.isDarwin then
+      "/Applications/Nix Casks/LibreWolf.app/Contents/MacOS/librewolf"
+    else
+      "${pkgs.librewolf}/bin/librewolf";
 in
 {
   # LibreWolf is installed via darwinModules/nix-casks.nix on macOS
   home.packages = lib.optionals pkgs.stdenv.isLinux [
     (pkgs.librewolf.override {
       extraPolicies = import ../../pkgs/librewolf-policies.nix {
-        inherit (micsSkills) browser-cli-extension;
+        inherit (micsSkillsPkgs) browser-cli-extension;
         inherit (firefoxExtensions) chrome-tab-gc-extension;
       };
     })
   ];
+
+  # Tell browser-cli where LibreWolf is so browsh can find it
+  xdg.configFile."browser-cli/config.toml".text = ''
+    firefox_path = "${librewolfPath}"
+  '';
+
+  # Register native messaging host so the browser extension can talk to browser-cli
+  home.activation.installBrowserCliHost = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    ${micsSkillsPkgs.browser-cli}/bin/browser-cli --install-host
+  '';
 }


### PR DESCRIPTION

browser-cli now auto-starts browsh as a headless backend when no GUI
browser is running. browsh needs to know where LibreWolf lives since
it's not a standard Firefox path — on macOS it's a Nix Cask app, on
Linux it's a Nix store path.

Centralize all browser-cli ↔ LibreWolf integration in librewolf.nix:
the config file, the native messaging host registration, and the
browser-cli skill. This replaces the manually created
~/.config/browser-cli/config.toml and removes duplicated browser-cli
package references and installBrowserCliHost activations that were
scattered across macos.nix and desktop.nix.


