### PR TITLE
tmux: enable extended-keys with csi-u format

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -12,4 +12,4 @@ theme = iTerm2 Solarized Light
 
 keybind = performable:copy=copy_to_clipboard
 keybind = performable:paste=paste_from_clipboard
-keybind = shift+enter=text:\n
+keybind = alt+backspace=text:\x1b\x7f

--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -41,6 +41,10 @@ run-shell ~/.nix-profile/share/tmux-plugins/tmux-thumbs/tmux-thumbs.tmux
 # allow passing through escape sequences
 set -g allow-passthrough on
 
+# extended keys for proper modifier key forwarding (Shift+Enter, Ctrl+Enter, etc.)
+set -g extended-keys on
+set -g extended-keys-format csi-u
+
 # address vim mode switching delay (http://superuser.com/a/252717/65504)
 set -s escape-time 0
 


### PR DESCRIPTION

Pi (and other TUI apps) need extended key reporting to distinguish
modified Enter keys (Shift+Enter, Ctrl+Enter) from plain Enter.
Without this, tmux strips modifier information and all variants
collapse to the same \r sequence.
