### PR TITLE
pi: fix sendUserMessage crash when agent is processing

### DIFF
--- a/home/.pi/agent/extensions/commit-context.ts
+++ b/home/.pi/agent/extensions/commit-context.ts
@@ -42,7 +42,9 @@ export default function (pi: ExtensionAPI) {
         "```",
       ].join("\n");
 
-      pi.sendUserMessage(`${COMMIT_PROMPT}\n\n${gitContext}`);
+      pi.sendUserMessage(`${COMMIT_PROMPT}\n\n${gitContext}`, {
+        deliverAs: "followUp",
+      });
     },
   });
 }

--- a/home/.pi/agent/extensions/merge-context.ts
+++ b/home/.pi/agent/extensions/merge-context.ts
@@ -83,7 +83,9 @@ export default function (pi: ExtensionAPI) {
         "```",
       ].join("\n");
 
-      pi.sendUserMessage(`${MERGE_PROMPT}\n\n${gitContext}`);
+      pi.sendUserMessage(`${MERGE_PROMPT}\n\n${gitContext}`, {
+        deliverAs: "followUp",
+      });
     },
   });
 }

--- a/home/.pi/agent/extensions/rebase-context.ts
+++ b/home/.pi/agent/extensions/rebase-context.ts
@@ -70,7 +70,9 @@ export default function (pi: ExtensionAPI) {
 
       const argsLine = args.trim() ? `\nArguments: ${args.trim()}` : "";
 
-      pi.sendUserMessage(`${REBASE_PROMPT}${argsLine}\n\n${gitContext}`);
+      pi.sendUserMessage(`${REBASE_PROMPT}${argsLine}\n\n${gitContext}`, {
+        deliverAs: "followUp",
+      });
     },
   });
 }


### PR DESCRIPTION

Command extensions that use sendUserMessage() from a handler need to
specify a delivery mode, otherwise pi throws 'Agent is already
processing' because the agent isn't idle when the command handler runs.

Use deliverAs: 'followUp' so the message is queued and processed after
the current agent cycle completes.
