### PR TITLE
n8n: drop standalone n8n-nodes-caldav input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -611,32 +611,6 @@
         "type": "github"
       }
     },
-    "n8n-nodes-caldav": {
-      "inputs": {
-        "flake-parts": [
-          "flake-parts"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "treefmt-nix": [
-          "treefmt-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773567584,
-        "narHash": "sha256-dgiBv5SQbU1b7qXeDXg2WR1SLe83c1Dv7g+IQOPfsvA=",
-        "owner": "Mic92",
-        "repo": "n8n-nodes-caldav",
-        "rev": "1c209b4b726e4bd82f14673777960c84cab5bcbd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Mic92",
-        "repo": "n8n-nodes-caldav",
-        "type": "github"
-      }
-    },
     "niks3": {
       "inputs": {
         "flake-parts": [
@@ -959,7 +933,6 @@
         "llm-agents": "llm-agents",
         "mics-n8n-nodes": "mics-n8n-nodes",
         "mics-skills": "mics-skills",
-        "n8n-nodes-caldav": "n8n-nodes-caldav",
         "niks3": "niks3",
         "nix": "nix",
         "nix-casks": "nix-casks",

--- a/flake.lock
+++ b/flake.lock
@@ -813,10 +813,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773571486,
+        "lastModified": 1773573797,
         "narHash": "sha256-XUSs0VuKGKKhRD/nbxJShtUCQjenYTNiUkYoSbrJnyg=",
         "ref": "main",
-        "rev": "fb18e3ee2bb24c3155147caae7a3ff05231b7ea3",
+        "rev": "006824caefe850f7be4b43dc58b2a063f88ba46f",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/Mic92/nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -102,11 +102,6 @@
     clan-core.inputs.systems.follows = "systems";
     clan-core.inputs.nix-darwin.follows = "nix-darwin";
 
-    n8n-nodes-caldav.url = "github:Mic92/n8n-nodes-caldav";
-    n8n-nodes-caldav.inputs.nixpkgs.follows = "nixpkgs";
-    n8n-nodes-caldav.inputs.treefmt-nix.follows = "treefmt-nix";
-    n8n-nodes-caldav.inputs.flake-parts.follows = "flake-parts";
-
     mics-n8n-nodes.url = "github:Mic92/mics-n8n-nodes";
     mics-n8n-nodes.inputs.nixpkgs.follows = "nixpkgs";
     mics-n8n-nodes.inputs.treefmt-nix.follows = "treefmt-nix";

--- a/machines/eve/modules/n8n/default.nix
+++ b/machines/eve/modules/n8n/default.nix
@@ -110,10 +110,6 @@ in
     in
     ''
       mkdir -p /var/lib/n8n/.n8n/custom
-      ln -sfn ${
-        self.inputs.n8n-nodes-caldav.packages.${pkgs.stdenv.hostPlatform.system}.default
-      }/lib/node_modules/n8n-nodes-caldav/dist \
-        /var/lib/n8n/.n8n/custom/n8n-nodes-caldav
       ln -sfn ${n8n-nodes-paperless}/lib/node_modules/@n8n-chezmoi-sh/n8n-nodes-paperless/dist \
         /var/lib/n8n/.n8n/custom/n8n-nodes-paperless
       ${linkCommands}


### PR DESCRIPTION

The caldav package was integrated into the mics-n8n-nodes monorepo
(Mic92/mics-n8n-nodes@af50c84), so the separate flake input is
redundant. The linkCommands loop in the n8n preStart already iterates
all packages from mics-n8n-nodes, which now includes n8n-nodes-caldav.
