### PR TITLE
eve: add route96 Nostr blob storage server

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -546,11 +546,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773631298,
-        "narHash": "sha256-ayzlBBwiXP30BiI+T4POukapy+x0TG7MVsWbTIfUDac=",
+        "lastModified": 1773673399,
+        "narHash": "sha256-JOcnmrHBA2S63kcfu20bEYnpkF0cRYE7BdZs5jMW+sY=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "49964b8b4efa9ed7ffab7cbd63497ab029bdfc82",
+        "rev": "cc1f5259ec9140bd921fc6070517f334eef36697",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -858,15 +858,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1773575153,
-        "narHash": "sha256-p5rPrNWDmKgcE0Fc9GYYv6CeXI8sELLKdQl/i1UVpz4=",
+        "lastModified": 1773691064,
+        "narHash": "sha256-4Apm3qYkeFoJh8FcUp5v5yMuStpZI0oaYjmib91QMmI=",
         "owner": "pinpox",
         "repo": "opencrow",
-        "rev": "a9f3091c78586227fc1db03d7dd07e32348310fe",
+        "rev": "30dcd506c65832b64a0c90eea995ccc8ddfbdfaa",
         "type": "github"
       },
       "original": {
         "owner": "pinpox",
+        "ref": "nostr",
         "repo": "opencrow",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -132,7 +132,7 @@
       inputs.systems.follows = "systems";
     };
 
-    opencrow.url = "github:pinpox/opencrow";
+    opencrow.url = "github:pinpox/opencrow/nostr";
     opencrow.inputs.nixpkgs.follows = "nixpkgs";
     opencrow.inputs.treefmt-nix.follows = "treefmt-nix";
 

--- a/machines/eve/configuration.nix
+++ b/machines/eve/configuration.nix
@@ -50,6 +50,7 @@
     ./modules/n8n
     ./modules/network.nix
     ./modules/nostr-relay.nix
+    ./modules/route96.nix
     ./modules/nextcloud.nix
     ./modules/nginx/default.nix
     ./modules/opencrow

--- a/machines/eve/modules/opencrow/nostr.nix
+++ b/machines/eve/modules/opencrow/nostr.nix
@@ -26,7 +26,7 @@
     OPENCROW_NOSTR_PRIVATE_KEY_FILE = "%d/nostr-private-key";
     OPENCROW_NOSTR_RELAYS = "wss://nostr.0cx.de,wss://nos.lol,wss://nostr.thalheim.io";
     OPENCROW_NOSTR_DM_RELAYS = "wss://nos.lol,wss://nostr.thalheim.io,wss://nostr.0cx.de";
-    OPENCROW_NOSTR_BLOSSOM_SERVERS = "https://blossom.nostr.build";
+    OPENCROW_NOSTR_BLOSSOM_SERVERS = "https://nostr-files.thalheim.io";
     OPENCROW_NOSTR_ALLOWED_USERS = "npub10yt4rh4g5t5kd47x7w8dpwqq7s228c53xacjqxvxjwu0kes3kzvsynqfu8";
     OPENCROW_NOSTR_NAME = "janet";
     OPENCROW_NOSTR_DISPLAY_NAME = "Janet";

--- a/machines/eve/modules/route96.nix
+++ b/machines/eve/modules/route96.nix
@@ -1,0 +1,107 @@
+# Nostr blob storage server (Blossom / NIP-96 protocols)
+#
+#   https://nostr-files.thalheim.io
+#
+# Test connectivity:
+#   curl https://nostr-files.thalheim.io/
+#   curl -H "Accept: application/nostr+json" https://nostr-files.thalheim.io/.well-known/nostr/nip96.json
+{
+  pkgs,
+  ...
+}:
+let
+  route96 = pkgs.callPackage ../../../pkgs/route96 { };
+  domain = "nostr-files.thalheim.io";
+  port = 8396;
+  dataDir = "/var/lib/route96";
+
+  configFile = pkgs.writeText "route96-config.yaml" ''
+    listen: "127.0.0.1:${toString port}"
+    database: "mysql://route96@localhost/route96?socket=/run/mysqld/mysqld.sock"
+    storage_dir: "${dataDir}/files"
+    max_upload_bytes: 104857600
+    public_url: "https://${domain}"
+    delete_unaccessed_days: 90
+  '';
+in
+{
+  # ── MySQL database ──────────────────────────────────────────────────────
+
+  services.mysql = {
+    enable = true;
+    package = pkgs.mariadb;
+    ensureDatabases = [ "route96" ];
+    ensureUsers = [
+      {
+        name = "route96";
+        ensurePermissions = {
+          "route96.*" = "ALL PRIVILEGES";
+        };
+      }
+    ];
+  };
+
+  # ── route96 service ─────────────────────────────────────────────────────
+
+  systemd.services.route96 = {
+    description = "Route96 Nostr blob storage";
+    wantedBy = [ "multi-user.target" ];
+    after = [
+      "network.target"
+      "mysql.service"
+    ];
+    requires = [ "mysql.service" ];
+
+    serviceConfig = {
+      Type = "simple";
+      ExecStart = "${route96}/bin/route96 --config ${configFile}";
+      Restart = "on-failure";
+      RestartSec = 5;
+      # Working directory determines where index.html is loaded from
+      WorkingDirectory = "${route96}/share/route96";
+
+      StateDirectory = "route96";
+      User = "route96";
+      Group = "route96";
+
+      NoNewPrivileges = true;
+      ProtectSystem = "strict";
+      ProtectHome = true;
+      PrivateTmp = true;
+      PrivateDevices = true;
+      ProtectKernelTunables = true;
+      ProtectControlGroups = true;
+      ReadWritePaths = [ dataDir ];
+    };
+
+    preStart = ''
+      mkdir -p ${dataDir}/files
+    '';
+  };
+
+  users.users.route96 = {
+    isSystemUser = true;
+    group = "route96";
+  };
+  users.groups.route96 = { };
+
+  # ── nginx reverse proxy ─────────────────────────────────────────────────
+
+  services.nginx.virtualHosts.${domain} = {
+    useACMEHost = "thalheim.io";
+    forceSSL = true;
+    locations."/" = {
+      proxyPass = "http://127.0.0.1:${toString port}";
+      extraConfig = ''
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        client_max_body_size 100m;
+      '';
+    };
+  };
+}

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -68,6 +68,7 @@ in
   }
   // lib.optionalAttrs pkgs.stdenv.isLinux {
     groups-relay = pkgs.callPackage ./groups-relay { };
+    route96 = pkgs.callPackage ./route96 { };
     phantun = pkgs.callPackage ./phantun { };
     phpldapadmin = pkgs.callPackage ../nixosModules/phpldapadmin/package.nix { };
     radicle-github-sync = pkgs.callPackage ./radicle-github-sync { };

--- a/pkgs/route96/0001-remove-candle-payments-deps-for-nix-build.patch
+++ b/pkgs/route96/0001-remove-candle-payments-deps-for-nix-build.patch
@@ -1,0 +1,4666 @@
+From b102e4858b4d77fced8f2165e66831010dbfb6a8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Mon, 16 Mar 2026 20:36:29 +0100
+Subject: [PATCH] remove candle/payments deps for nix build
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ Cargo.lock | 2539 ++++++++++++++++------------------------------------
+ Cargo.toml |    9 +-
+ 2 files changed, 783 insertions(+), 1765 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index fa46492..cc9dea2 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2,20 +2,11 @@
+ # It is not intended for manual editing.
+ version = 4
+ 
+-[[package]]
+-name = "addr2line"
+-version = "0.24.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+-dependencies = [
+- "gimli",
+-]
+-
+ [[package]]
+ name = "adler2"
+-version = "2.0.0"
++version = "2.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
++checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+ 
+ [[package]]
+ name = "aead"
+@@ -29,9 +20,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aho-corasick"
+-version = "1.1.3"
++version = "1.1.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
++checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+ dependencies = [
+  "memchr",
+ ]
+@@ -42,12 +33,6 @@ version = "0.2.21"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+ 
+-[[package]]
+-name = "android-tzdata"
+-version = "0.1.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+-
+ [[package]]
+ name = "android_system_properties"
+ version = "0.1.5"
+@@ -59,9 +44,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "anstream"
+-version = "0.6.18"
++version = "1.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
++checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+ dependencies = [
+  "anstyle",
+  "anstyle-parse",
+@@ -74,44 +59,44 @@ dependencies = [
+ 
+ [[package]]
+ name = "anstyle"
+-version = "1.0.10"
++version = "1.0.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
++checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+ 
+ [[package]]
+ name = "anstyle-parse"
+-version = "0.2.6"
++version = "1.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
++checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+ dependencies = [
+  "utf8parse",
+ ]
+ 
+ [[package]]
+ name = "anstyle-query"
+-version = "1.1.2"
++version = "1.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
++checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+ dependencies = [
+- "windows-sys 0.59.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+ name = "anstyle-wincon"
+-version = "3.0.7"
++version = "3.0.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
++checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+ dependencies = [
+  "anstyle",
+- "once_cell",
+- "windows-sys 0.59.0",
++ "once_cell_polyfill",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+ name = "anyhow"
+-version = "1.0.100"
++version = "1.0.102"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
++checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+ 
+ [[package]]
+ name = "arraydeque"
+@@ -127,9 +112,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+ 
+ [[package]]
+ name = "async-trait"
+-version = "0.1.88"
++version = "0.1.89"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
++checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -153,15 +138,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+ 
+ [[package]]
+ name = "autocfg"
+-version = "1.4.0"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
++checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+ 
+ [[package]]
+ name = "aws-lc-rs"
+-version = "1.15.4"
++version = "1.16.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
++checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+ dependencies = [
+  "aws-lc-sys",
+  "zeroize",
+@@ -169,9 +154,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-lc-sys"
+-version = "0.37.0"
++version = "0.38.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
++checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+ dependencies = [
+  "cc",
+  "cmake",
+@@ -267,37 +252,6 @@ dependencies = [
+  "syn",
+ ]
+ 
+-[[package]]
+-name = "backtrace"
+-version = "0.3.74"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+-dependencies = [
+- "addr2line",
+- "cfg-if",
+- "libc",
+- "miniz_oxide",
+- "object",
+- "rustc-demangle",
+- "windows-targets 0.52.6",
+-]
+-
+-[[package]]
+-name = "base58ck"
+-version = "0.1.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+-dependencies = [
+- "bitcoin-internals 0.3.0",
+- "bitcoin_hashes 0.14.0",
+-]
+-
+-[[package]]
+-name = "base64"
+-version = "0.21.7"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+-
+ [[package]]
+ name = "base64"
+ version = "0.22.1"
+@@ -306,15 +260,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+ 
+ [[package]]
+ name = "base64ct"
+-version = "1.7.3"
++version = "1.8.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
++checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+ 
+ [[package]]
+ name = "bech32"
+-version = "0.11.0"
++version = "0.11.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
++checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+ 
+ [[package]]
+ name = "bindgen"
+@@ -322,7 +276,7 @@ version = "0.72.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags 2.11.0",
+  "cexpr",
+  "clang-sys",
+  "itertools",
+@@ -334,105 +288,31 @@ dependencies = [
+  "syn",
+ ]
+ 
+-[[package]]
+-name = "bindgen_cuda"
+-version = "0.1.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "282be55fb326843bb67cccceeeaf21c961ef303f60018f9a2ab69494dad8eaf9"
+-dependencies = [
+- "glob",
+- "num_cpus",
+- "rayon",
+-]
+-
+ [[package]]
+ name = "bip39"
+-version = "2.1.0"
++version = "2.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "33415e24172c1b7d6066f6d999545375ab8e1d95421d6784bdfff9496f292387"
++checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+ dependencies = [
+- "bitcoin_hashes 0.13.0",
++ "bitcoin_hashes",
+  "serde",
+  "unicode-normalization",
+ ]
+ 
+-[[package]]
+-name = "bit-set"
+-version = "0.8.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+-dependencies = [
+- "bit-vec",
+-]
+-
+-[[package]]
+-name = "bit-vec"
+-version = "0.8.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+-
+-[[package]]
+-name = "bitcoin"
+-version = "0.32.7"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
+-dependencies = [
+- "base58ck",
+- "bech32",
+- "bitcoin-internals 0.3.0",
+- "bitcoin-io",
+- "bitcoin-units",
+- "bitcoin_hashes 0.14.0",
+- "hex-conservative 0.2.1",
+- "hex_lit",
+- "secp256k1",
+-]
+-
+-[[package]]
+-name = "bitcoin-internals"
+-version = "0.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+-
+-[[package]]
+-name = "bitcoin-internals"
+-version = "0.3.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+-
+ [[package]]
+ name = "bitcoin-io"
+-version = "0.1.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+-
+-[[package]]
+-name = "bitcoin-units"
+-version = "0.1.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+-dependencies = [
+- "bitcoin-internals 0.3.0",
+-]
+-
+-[[package]]
+-name = "bitcoin_hashes"
+-version = "0.13.0"
++version = "0.1.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+-dependencies = [
+- "bitcoin-internals 0.2.0",
+- "hex-conservative 0.1.2",
+-]
++checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+ 
+ [[package]]
+ name = "bitcoin_hashes"
+-version = "0.14.0"
++version = "0.14.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
++checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+ dependencies = [
+  "bitcoin-io",
+- "hex-conservative 0.2.1",
++ "hex-conservative",
+  "serde",
+ ]
+ 
+@@ -444,11 +324,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+ 
+ [[package]]
+ name = "bitflags"
+-version = "2.9.0"
++version = "2.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
++checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+ dependencies = [
+- "serde",
++ "serde_core",
+ ]
+ 
+ [[package]]
+@@ -471,29 +351,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "bumpalo"
+-version = "3.17.0"
++version = "3.20.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
++checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+ 
+ [[package]]
+ name = "bytemuck"
+-version = "1.22.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+-dependencies = [
+- "bytemuck_derive",
+-]
+-
+-[[package]]
+-name = "bytemuck_derive"
+-version = "1.9.3"
++version = "1.25.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn",
+-]
++checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+ 
+ [[package]]
+ name = "byteorder"
+@@ -509,84 +375,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+ 
+ [[package]]
+ name = "bytes"
+-version = "1.10.1"
++version = "1.11.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+-
+-[[package]]
+-name = "candle-core"
+-version = "0.9.2"
+-source = "git+https://github.com/DrJesseGlass/candle?branch=fix%2Fdisable-bf16-wmma-pre-ampere#bb4d7025db5d6ad43d0286849d5f3dfc993c7c84"
+-dependencies = [
+- "byteorder",
+- "candle-kernels",
+- "candle-ug",
+- "cudarc 0.19.3",
+- "float8 0.6.1",
+- "gemm 0.19.0",
+- "half",
+- "libm",
+- "memmap2",
+- "num-traits",
+- "num_cpus",
+- "rand 0.9.0",
+- "rand_distr",
+- "rayon",
+- "safetensors 0.7.0",
+- "thiserror 2.0.12",
+- "yoke 0.8.1",
+- "zip",
+-]
+-
+-[[package]]
+-name = "candle-kernels"
+-version = "0.9.2"
+-source = "git+https://github.com/DrJesseGlass/candle?branch=fix%2Fdisable-bf16-wmma-pre-ampere#bb4d7025db5d6ad43d0286849d5f3dfc993c7c84"
+-dependencies = [
+- "bindgen_cuda",
+-]
+-
+-[[package]]
+-name = "candle-nn"
+-version = "0.9.2"
+-source = "git+https://github.com/DrJesseGlass/candle?branch=fix%2Fdisable-bf16-wmma-pre-ampere#bb4d7025db5d6ad43d0286849d5f3dfc993c7c84"
+-dependencies = [
+- "candle-core",
+- "half",
+- "libc",
+- "num-traits",
+- "rayon",
+- "safetensors 0.7.0",
+- "serde",
+- "thiserror 2.0.12",
+-]
+-
+-[[package]]
+-name = "candle-transformers"
+-version = "0.9.2"
+-source = "git+https://github.com/DrJesseGlass/candle?branch=fix%2Fdisable-bf16-wmma-pre-ampere#bb4d7025db5d6ad43d0286849d5f3dfc993c7c84"
+-dependencies = [
+- "byteorder",
+- "candle-core",
+- "candle-nn",
+- "fancy-regex",
+- "num-traits",
+- "rand 0.9.0",
+- "rayon",
+- "serde",
+- "serde_json",
+- "serde_plain",
+- "tracing",
+-]
+-
+-[[package]]
+-name = "candle-ug"
+-version = "0.9.2"
+-source = "git+https://github.com/DrJesseGlass/candle?branch=fix%2Fdisable-bf16-wmma-pre-ampere#bb4d7025db5d6ad43d0286849d5f3dfc993c7c84"
+-dependencies = [
+- "ug",
+- "ug-cuda",
+-]
++checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+ 
+ [[package]]
+ name = "cbc"
+@@ -599,9 +390,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "cc"
+-version = "1.2.55"
++version = "1.2.57"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
++checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+ dependencies = [
+  "find-msvc-tools",
+  "jobserver",
+@@ -637,9 +428,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "cfg-if"
+-version = "1.0.0"
++version = "1.0.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
++checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+ 
+ [[package]]
+ name = "cfg_aliases"
+@@ -673,17 +464,16 @@ dependencies = [
+ 
+ [[package]]
+ name = "chrono"
+-version = "0.4.40"
++version = "0.4.44"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
++checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+ dependencies = [
+- "android-tzdata",
+  "iana-time-zone",
+  "js-sys",
+  "num-traits",
+  "serde",
+  "wasm-bindgen",
+- "windows-link 0.1.1",
++ "windows-link",
+ ]
+ 
+ [[package]]
+@@ -715,14 +505,14 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+ dependencies = [
+  "glob",
+  "libc",
+- "libloading 0.8.6",
++ "libloading",
+ ]
+ 
+ [[package]]
+ name = "clap"
+-version = "4.5.34"
++version = "4.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
++checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+ dependencies = [
+  "clap_builder",
+  "clap_derive",
+@@ -730,9 +520,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap_builder"
+-version = "4.5.34"
++version = "4.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
++checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+ dependencies = [
+  "anstream",
+  "anstyle",
+@@ -742,9 +532,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap_derive"
+-version = "4.5.32"
++version = "4.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
++checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+ dependencies = [
+  "heck",
+  "proc-macro2",
+@@ -754,9 +544,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap_lex"
+-version = "0.7.4"
++version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
++checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+ 
+ [[package]]
+ name = "cmake"
+@@ -769,9 +559,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "colorchoice"
+-version = "1.0.3"
++version = "1.0.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
++checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+ 
+ [[package]]
+ name = "combine"
+@@ -794,9 +584,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "config"
+-version = "0.15.11"
++version = "0.15.21"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
++checksum = "4fe5feec195269515c4722937cd7ffcfe7b4205d18d2e6577b7223ecb159ab00"
+ dependencies = [
+  "async-trait",
+  "convert_case",
+@@ -804,7 +594,8 @@ dependencies = [
+  "pathdiff",
+  "ron",
+  "rust-ini",
+- "serde",
++ "serde-untagged",
++ "serde_core",
+  "serde_json",
+  "toml",
+  "winnow",
+@@ -813,15 +604,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "console"
+-version = "0.16.1"
++version = "0.16.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
++checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+ dependencies = [
+  "encode_unicode",
+  "libc",
+- "once_cell",
+  "unicode-width",
+- "windows-sys 0.61.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+@@ -845,7 +635,7 @@ version = "0.1.16"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+ dependencies = [
+- "getrandom 0.2.15",
++ "getrandom 0.2.17",
+  "once_cell",
+  "tiny-keccak",
+ ]
+@@ -925,9 +715,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crc"
+-version = "3.2.1"
++version = "3.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
++checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+ dependencies = [
+  "crc-catalog",
+ ]
+@@ -947,25 +737,6 @@ dependencies = [
+  "cfg-if",
+ ]
+ 
+-[[package]]
+-name = "crossbeam-deque"
+-version = "0.8.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+-dependencies = [
+- "crossbeam-epoch",
+- "crossbeam-utils",
+-]
+-
+-[[package]]
+-name = "crossbeam-epoch"
+-version = "0.9.18"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+-dependencies = [
+- "crossbeam-utils",
+-]
+-
+ [[package]]
+ name = "crossbeam-queue"
+ version = "0.3.12"
+@@ -983,42 +754,21 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+ 
+ [[package]]
+ name = "crunchy"
+-version = "0.2.3"
++version = "0.2.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
++checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+ 
+ [[package]]
+ name = "crypto-common"
+-version = "0.1.6"
++version = "0.1.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
++checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+ dependencies = [
+  "generic-array",
+  "rand_core 0.6.4",
+  "typenum",
+ ]
+ 
+-[[package]]
+-name = "cudarc"
+-version = "0.17.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0bf99ab37ee7072d64d906aa2dada9a3422f1d975cdf8c8055a573bc84897ed8"
+-dependencies = [
+- "half",
+- "libloading 0.8.6",
+-]
+-
+-[[package]]
+-name = "cudarc"
+-version = "0.19.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6468cb7fa330840f3ebcd8df51edc0e7bf5c18df524792ce6004c6821851cdf3"
+-dependencies = [
+- "float8 0.7.0",
+- "half",
+- "libloading 0.9.0",
+-]
+-
+ [[package]]
+ name = "dashmap"
+ version = "6.1.0"
+@@ -1035,9 +785,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "der"
+-version = "0.7.9"
++version = "0.7.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
++checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+ dependencies = [
+  "const-oid",
+  "pem-rfc7468",
+@@ -1083,7 +833,7 @@ dependencies = [
+  "libc",
+  "option-ext",
+  "redox_users",
+- "windows-sys 0.61.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+@@ -1127,22 +877,6 @@ version = "1.0.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+ 
+-[[package]]
+-name = "dyn-stack"
+-version = "0.13.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+-dependencies = [
+- "bytemuck",
+- "dyn-stack-macros",
+-]
+-
+-[[package]]
+-name = "dyn-stack-macros"
+-version = "0.1.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+-
+ [[package]]
+ name = "either"
+ version = "1.15.0"
+@@ -1167,18 +901,6 @@ dependencies = [
+  "cfg-if",
+ ]
+ 
+-[[package]]
+-name = "enum-as-inner"
+-version = "0.6.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+-dependencies = [
+- "heck",
+- "proc-macro2",
+- "quote",
+- "syn",
+-]
+-
+ [[package]]
+ name = "env_logger"
+ version = "0.10.2"
+@@ -1198,14 +920,25 @@ version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+ 
++[[package]]
++name = "erased-serde"
++version = "0.4.10"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
++dependencies = [
++ "serde",
++ "serde_core",
++ "typeid",
++]
++
+ [[package]]
+ name = "errno"
+-version = "0.3.10"
++version = "0.3.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
++checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+ dependencies = [
+  "libc",
+- "windows-sys 0.59.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+@@ -1221,51 +954,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "event-listener"
+-version = "5.4.0"
++version = "5.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
++checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+ dependencies = [
+  "concurrent-queue",
+  "parking",
+  "pin-project-lite",
+ ]
+ 
+-[[package]]
+-name = "fancy-regex"
+-version = "0.17.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+-dependencies = [
+- "bit-set",
+- "regex-automata",
+- "regex-syntax",
+-]
+-
+ [[package]]
+ name = "fastrand"
+ version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+ 
+-[[package]]
+-name = "fedimint-tonic-lnd"
+-version = "0.2.0"
+-source = "git+https://github.com/v0l/tonic_lnd.git?rev=57fcd1ac2e8834c6f93cfa3c84ba67420a9dd3ed#57fcd1ac2e8834c6f93cfa3c84ba67420a9dd3ed"
+-dependencies = [
+- "hex",
+- "hyper-rustls",
+- "hyper-util",
+- "prost",
+- "rustls",
+- "rustls-pemfile",
+- "rustls-webpki",
+- "tokio",
+- "tokio-stream",
+- "tonic",
+- "tonic-prost",
+- "tonic-prost-build",
+-]
+-
+ [[package]]
+ name = "ffmpeg-rs-raw"
+ version = "0.3.0"
+@@ -1296,12 +999,6 @@ version = "0.1.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+ 
+-[[package]]
+-name = "fixedbitset"
+-version = "0.5.7"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+-
+ [[package]]
+ name = "flate2"
+ version = "1.1.9"
+@@ -1312,28 +1009,6 @@ dependencies = [
+  "miniz_oxide",
+ ]
+ 
+-[[package]]
+-name = "float8"
+-version = "0.6.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
+-dependencies = [
+- "cudarc 0.19.3",
+- "half",
+- "num-traits",
+- "rand 0.9.0",
+- "rand_distr",
+-]
+-
+-[[package]]
+-name = "float8"
+-version = "0.7.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
+-dependencies = [
+- "half",
+-]
+-
+ [[package]]
+ name = "flume"
+ version = "0.11.1"
+@@ -1357,12 +1032,6 @@ version = "0.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+ 
+-[[package]]
+-name = "foldhash"
+-version = "0.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+-
+ [[package]]
+ name = "foreign-types"
+ version = "0.3.2"
+@@ -1380,9 +1049,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+ 
+ [[package]]
+ name = "form_urlencoded"
+-version = "1.2.1"
++version = "1.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
++checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+ dependencies = [
+  "percent-encoding",
+ ]
+@@ -1404,9 +1073,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures"
+-version = "0.3.31"
++version = "0.3.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
++checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+ dependencies = [
+  "futures-channel",
+  "futures-core",
+@@ -1419,9 +1088,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures-channel"
+-version = "0.3.31"
++version = "0.3.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
++checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+ dependencies = [
+  "futures-core",
+  "futures-sink",
+@@ -1429,15 +1098,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures-core"
+-version = "0.3.31"
++version = "0.3.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
++checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+ 
+ [[package]]
+ name = "futures-executor"
+-version = "0.3.31"
++version = "0.3.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
++checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+ dependencies = [
+  "futures-core",
+  "futures-task",
+@@ -1457,15 +1126,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures-io"
+-version = "0.3.31"
++version = "0.3.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
++checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+ 
+ [[package]]
+ name = "futures-macro"
+-version = "0.3.31"
++version = "0.3.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
++checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -1474,21 +1143,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures-sink"
+-version = "0.3.31"
++version = "0.3.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
++checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+ 
+ [[package]]
+ name = "futures-task"
+-version = "0.3.31"
++version = "0.3.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
++checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+ 
+ [[package]]
+ name = "futures-util"
+-version = "0.3.31"
++version = "0.3.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
++checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+ dependencies = [
+  "futures-channel",
+  "futures-core",
+@@ -1498,248 +1167,9 @@ dependencies = [
+  "futures-task",
+  "memchr",
+  "pin-project-lite",
+- "pin-utils",
+  "slab",
+ ]
+ 
+-[[package]]
+-name = "gemm"
+-version = "0.18.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
+-dependencies = [
+- "dyn-stack",
+- "gemm-c32 0.18.2",
+- "gemm-c64 0.18.2",
+- "gemm-common 0.18.2",
+- "gemm-f16 0.18.2",
+- "gemm-f32 0.18.2",
+- "gemm-f64 0.18.2",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "seq-macro",
+-]
+-
+-[[package]]
+-name = "gemm"
+-version = "0.19.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+-dependencies = [
+- "dyn-stack",
+- "gemm-c32 0.19.0",
+- "gemm-c64 0.19.0",
+- "gemm-common 0.19.0",
+- "gemm-f16 0.19.0",
+- "gemm-f32 0.19.0",
+- "gemm-f64 0.19.0",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "seq-macro",
+-]
+-
+-[[package]]
+-name = "gemm-c32"
+-version = "0.18.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
+-dependencies = [
+- "dyn-stack",
+- "gemm-common 0.18.2",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "seq-macro",
+-]
+-
+-[[package]]
+-name = "gemm-c32"
+-version = "0.19.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+-dependencies = [
+- "dyn-stack",
+- "gemm-common 0.19.0",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "seq-macro",
+-]
+-
+-[[package]]
+-name = "gemm-c64"
+-version = "0.18.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
+-dependencies = [
+- "dyn-stack",
+- "gemm-common 0.18.2",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "seq-macro",
+-]
+-
+-[[package]]
+-name = "gemm-c64"
+-version = "0.19.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+-dependencies = [
+- "dyn-stack",
+- "gemm-common 0.19.0",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "seq-macro",
+-]
+-
+-[[package]]
+-name = "gemm-common"
+-version = "0.18.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
+-dependencies = [
+- "bytemuck",
+- "dyn-stack",
+- "half",
+- "libm",
+- "num-complex",
+- "num-traits",
+- "once_cell",
+- "paste",
+- "pulp 0.21.5",
+- "raw-cpuid",
+- "rayon",
+- "seq-macro",
+- "sysctl",
+-]
+-
+-[[package]]
+-name = "gemm-common"
+-version = "0.19.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+-dependencies = [
+- "bytemuck",
+- "dyn-stack",
+- "half",
+- "libm",
+- "num-complex",
+- "num-traits",
+- "once_cell",
+- "paste",
+- "pulp 0.22.2",
+- "raw-cpuid",
+- "rayon",
+- "seq-macro",
+- "sysctl",
+-]
+-
+-[[package]]
+-name = "gemm-f16"
+-version = "0.18.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+-dependencies = [
+- "dyn-stack",
+- "gemm-common 0.18.2",
+- "gemm-f32 0.18.2",
+- "half",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "rayon",
+- "seq-macro",
+-]
+-
+-[[package]]
+-name = "gemm-f16"
+-version = "0.19.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+-dependencies = [
+- "dyn-stack",
+- "gemm-common 0.19.0",
+- "gemm-f32 0.19.0",
+- "half",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "rayon",
+- "seq-macro",
+-]
+-
+-[[package]]
+-name = "gemm-f32"
+-version = "0.18.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
+-dependencies = [
+- "dyn-stack",
+- "gemm-common 0.18.2",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "seq-macro",
+-]
+-
+-[[package]]
+-name = "gemm-f32"
+-version = "0.19.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+-dependencies = [
+- "dyn-stack",
+- "gemm-common 0.19.0",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "seq-macro",
+-]
+-
+-[[package]]
+-name = "gemm-f64"
+-version = "0.18.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
+-dependencies = [
+- "dyn-stack",
+- "gemm-common 0.18.2",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "seq-macro",
+-]
+-
+-[[package]]
+-name = "gemm-f64"
+-version = "0.19.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+-dependencies = [
+- "dyn-stack",
+- "gemm-common 0.19.0",
+- "num-complex",
+- "num-traits",
+- "paste",
+- "raw-cpuid",
+- "seq-macro",
+-]
+-
+ [[package]]
+ name = "generic-array"
+ version = "0.14.7"
+@@ -1752,36 +1182,43 @@ dependencies = [
+ 
+ [[package]]
+ name = "getrandom"
+-version = "0.2.15"
++version = "0.2.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
++checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+ dependencies = [
+  "cfg-if",
+  "js-sys",
+  "libc",
+- "wasi 0.11.0+wasi-snapshot-preview1",
++ "wasi",
+  "wasm-bindgen",
+ ]
+ 
+ [[package]]
+ name = "getrandom"
+-version = "0.3.2"
++version = "0.3.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
++checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+ dependencies = [
+  "cfg-if",
+  "js-sys",
+  "libc",
+- "r-efi",
+- "wasi 0.14.2+wasi-0.2.4",
++ "r-efi 5.3.0",
++ "wasip2",
+  "wasm-bindgen",
+ ]
+ 
+ [[package]]
+-name = "gimli"
+-version = "0.31.1"
++name = "getrandom"
++version = "0.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
++checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
++dependencies = [
++ "cfg-if",
++ "libc",
++ "r-efi 6.0.0",
++ "wasip2",
++ "wasip3",
++]
+ 
+ [[package]]
+ name = "glob"
+@@ -1791,9 +1228,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+ 
+ [[package]]
+ name = "h2"
+-version = "0.4.8"
++version = "0.4.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
++checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+ dependencies = [
+  "atomic-waker",
+  "bytes",
+@@ -1808,20 +1245,6 @@ dependencies = [
+  "tracing",
+ ]
+ 
+-[[package]]
+-name = "half"
+-version = "2.5.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+-dependencies = [
+- "bytemuck",
+- "cfg-if",
+- "crunchy",
+- "num-traits",
+- "rand 0.9.0",
+- "rand_distr",
+-]
+-
+ [[package]]
+ name = "hashbrown"
+ version = "0.14.5"
+@@ -1830,13 +1253,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+ 
+ [[package]]
+ name = "hashbrown"
+-version = "0.15.2"
++version = "0.15.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
++checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+ dependencies = [
+  "allocator-api2",
+  "equivalent",
+- "foldhash 0.1.5",
++ "foldhash",
+ ]
+ 
+ [[package]]
+@@ -1844,13 +1267,6 @@ name = "hashbrown"
+ version = "0.16.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+-dependencies = [
+- "allocator-api2",
+- "equivalent",
+- "foldhash 0.2.0",
+- "serde",
+- "serde_core",
+-]
+ 
+ [[package]]
+ name = "hashlink"
+@@ -1858,7 +1274,7 @@ version = "0.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+ dependencies = [
+- "hashbrown 0.15.2",
++ "hashbrown 0.15.5",
+ ]
+ 
+ [[package]]
+@@ -1869,15 +1285,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+ 
+ [[package]]
+ name = "hermit-abi"
+-version = "0.3.9"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+-
+-[[package]]
+-name = "hermit-abi"
+-version = "0.5.0"
++version = "0.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
++checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+ 
+ [[package]]
+ name = "hex"
+@@ -1890,25 +1300,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "hex-conservative"
+-version = "0.1.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
+-
+-[[package]]
+-name = "hex-conservative"
+-version = "0.2.1"
++version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
++checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+ dependencies = [
+  "arrayvec",
+ ]
+ 
+-[[package]]
+-name = "hex_lit"
+-version = "0.1.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+-
+ [[package]]
+ name = "hf-hub"
+ version = "0.5.0"
+@@ -1923,14 +1321,14 @@ dependencies = [
+  "log",
+  "native-tls",
+  "num_cpus",
+- "rand 0.9.0",
++ "rand 0.9.2",
+  "reqwest 0.12.28",
+  "serde",
+  "serde_json",
+- "thiserror 2.0.12",
++ "thiserror 2.0.18",
+  "tokio",
+  "ureq",
+- "windows-sys 0.61.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+@@ -1953,21 +1351,20 @@ dependencies = [
+ 
+ [[package]]
+ name = "home"
+-version = "0.5.11"
++version = "0.5.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
++checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+ dependencies = [
+- "windows-sys 0.59.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+ name = "http"
+-version = "1.3.1"
++version = "1.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
++checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+ dependencies = [
+  "bytes",
+- "fnv",
+  "itoa",
+ ]
+ 
+@@ -2014,9 +1411,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+ 
+ [[package]]
+ name = "humantime"
+-version = "2.2.0"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
++checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+ 
+ [[package]]
+ name = "hyper"
+@@ -2043,11 +1440,10 @@ dependencies = [
+ 
+ [[package]]
+ name = "hyper-rustls"
+-version = "0.27.5"
++version = "0.27.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
++checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+ dependencies = [
+- "futures-util",
+  "http",
+  "hyper",
+  "hyper-util",
+@@ -2058,19 +1454,6 @@ dependencies = [
+  "tower-service",
+ ]
+ 
+-[[package]]
+-name = "hyper-timeout"
+-version = "0.5.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+-dependencies = [
+- "hyper",
+- "hyper-util",
+- "pin-project-lite",
+- "tokio",
+- "tower-service",
+-]
+-
+ [[package]]
+ name = "hyper-tls"
+ version = "0.6.0"
+@@ -2093,7 +1476,7 @@ version = "0.1.20"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+ dependencies = [
+- "base64 0.22.1",
++ "base64",
+  "bytes",
+  "futures-channel",
+  "futures-util",
+@@ -2114,9 +1497,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "iana-time-zone"
+-version = "0.1.62"
++version = "0.1.65"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
++checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+ dependencies = [
+  "android_system_properties",
+  "core-foundation-sys",
+@@ -2138,21 +1521,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "icu_collections"
+-version = "1.5.0"
++version = "2.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
++checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+ dependencies = [
+  "displaydoc",
+- "yoke 0.7.5",
++ "potential_utf",
++ "yoke",
+  "zerofrom",
+  "zerovec",
+ ]
+ 
+ [[package]]
+-name = "icu_locid"
+-version = "1.5.0"
++name = "icu_locale_core"
++version = "2.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
++checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+ dependencies = [
+  "displaydoc",
+  "litemap",
+@@ -2161,104 +1545,72 @@ dependencies = [
+  "zerovec",
+ ]
+ 
+-[[package]]
+-name = "icu_locid_transform"
+-version = "1.5.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+-dependencies = [
+- "displaydoc",
+- "icu_locid",
+- "icu_locid_transform_data",
+- "icu_provider",
+- "tinystr",
+- "zerovec",
+-]
+-
+-[[package]]
+-name = "icu_locid_transform_data"
+-version = "1.5.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
+-
+ [[package]]
+ name = "icu_normalizer"
+-version = "1.5.0"
++version = "2.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
++checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+ dependencies = [
+- "displaydoc",
+  "icu_collections",
+  "icu_normalizer_data",
+  "icu_properties",
+  "icu_provider",
+  "smallvec",
+- "utf16_iter",
+- "utf8_iter",
+- "write16",
+  "zerovec",
+ ]
+ 
+ [[package]]
+ name = "icu_normalizer_data"
+-version = "1.5.1"
++version = "2.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
++checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+ 
+ [[package]]
+ name = "icu_properties"
+-version = "1.5.1"
++version = "2.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
++checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+ dependencies = [
+- "displaydoc",
+  "icu_collections",
+- "icu_locid_transform",
++ "icu_locale_core",
+  "icu_properties_data",
+  "icu_provider",
+- "tinystr",
++ "zerotrie",
+  "zerovec",
+ ]
+ 
+ [[package]]
+ name = "icu_properties_data"
+-version = "1.5.1"
++version = "2.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
++checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+ 
+ [[package]]
+ name = "icu_provider"
+-version = "1.5.0"
++version = "2.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
++checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+ dependencies = [
+  "displaydoc",
+- "icu_locid",
+- "icu_provider_macros",
+- "stable_deref_trait",
+- "tinystr",
++ "icu_locale_core",
+  "writeable",
+- "yoke 0.7.5",
++ "yoke",
+  "zerofrom",
++ "zerotrie",
+  "zerovec",
+ ]
+ 
+ [[package]]
+-name = "icu_provider_macros"
+-version = "1.5.0"
++name = "id-arena"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn",
+-]
++checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+ 
+ [[package]]
+ name = "idna"
+-version = "1.0.3"
++version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
++checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+ dependencies = [
+  "idna_adapter",
+  "smallvec",
+@@ -2267,9 +1619,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "idna_adapter"
+-version = "1.2.0"
++version = "1.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
++checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+ dependencies = [
+  "icu_normalizer",
+  "icu_properties",
+@@ -2277,9 +1629,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "image"
+-version = "0.25.9"
++version = "0.25.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
++checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+ dependencies = [
+  "bytemuck",
+  "byteorder-lite",
+@@ -2293,7 +1645,7 @@ version = "3.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "dd266c66b0a0e2d4c6db8e710663fc163a2d33595ce997b6fbda407c8759d344"
+ dependencies = [
+- "base64 0.22.1",
++ "base64",
+  "image",
+  "rustdct",
+  "serde",
+@@ -2302,19 +1654,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "indexmap"
+-version = "2.8.0"
++version = "2.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
++checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+ dependencies = [
+  "equivalent",
+- "hashbrown 0.15.2",
++ "hashbrown 0.16.1",
++ "serde",
++ "serde_core",
+ ]
+ 
+ [[package]]
+ name = "indicatif"
+-version = "0.18.0"
++version = "0.18.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
++checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+ dependencies = [
+  "console",
+  "portable-atomic",
+@@ -2334,11 +1688,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "inotify"
+-version = "0.11.0"
++version = "0.11.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
++checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags 2.11.0",
+  "inotify-sys",
+  "libc",
+ ]
+@@ -2376,9 +1730,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ipnet"
+-version = "2.11.0"
++version = "2.12.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
++checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+ 
+ [[package]]
+ name = "iri-string"
+@@ -2392,35 +1746,35 @@ dependencies = [
+ 
+ [[package]]
+ name = "is-terminal"
+-version = "0.4.16"
++version = "0.4.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
++checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+ dependencies = [
+- "hermit-abi 0.5.0",
++ "hermit-abi",
+  "libc",
+- "windows-sys 0.59.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+ name = "is_terminal_polyfill"
+-version = "1.70.1"
++version = "1.70.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
++checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+ 
+ [[package]]
+ name = "itertools"
+-version = "0.12.1"
++version = "0.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
++checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+ dependencies = [
+  "either",
+ ]
+ 
+ [[package]]
+ name = "itoa"
+-version = "1.0.15"
++version = "1.0.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
++checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+ 
+ [[package]]
+ name = "jni"
+@@ -2450,15 +1804,15 @@ version = "0.1.34"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+ dependencies = [
+- "getrandom 0.3.2",
++ "getrandom 0.3.4",
+  "libc",
+ ]
+ 
+ [[package]]
+ name = "js-sys"
+-version = "0.3.85"
++version = "0.3.91"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
++checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+ dependencies = [
+  "once_cell",
+  "wasm-bindgen",
+@@ -2514,29 +1868,25 @@ dependencies = [
+ ]
+ 
+ [[package]]
+-name = "libc"
+-version = "0.2.175"
++name = "leb128fmt"
++version = "0.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
++checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+ 
+ [[package]]
+-name = "libloading"
+-version = "0.8.6"
++name = "libc"
++version = "0.2.183"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+-dependencies = [
+- "cfg-if",
+- "windows-targets 0.52.6",
+-]
++checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+ 
+ [[package]]
+ name = "libloading"
+-version = "0.9.0"
++version = "0.8.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
++checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+ dependencies = [
+  "cfg-if",
+- "windows-link 0.2.0",
++ "windows-link",
+ ]
+ 
+ [[package]]
+@@ -2547,12 +1897,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+ 
+ [[package]]
+ name = "libredox"
+-version = "0.1.12"
++version = "0.1.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
++checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags 2.11.0",
+  "libc",
++ "plain",
++ "redox_syscall 0.7.3",
+ ]
+ 
+ [[package]]
+@@ -2565,37 +1917,17 @@ dependencies = [
+  "vcpkg",
+ ]
+ 
+-[[package]]
+-name = "lightning-invoice"
+-version = "0.34.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b85e5e14bcdb30d746e9785b04f27938292e8944f78f26517e01e91691f6b3f2"
+-dependencies = [
+- "bech32",
+- "bitcoin",
+- "lightning-types",
+-]
+-
+-[[package]]
+-name = "lightning-types"
+-version = "0.3.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cb1aac93f22f2c2eac8a0ee83bb1a1ea58673caa2c82847302710b83364d04e6"
+-dependencies = [
+- "bitcoin",
+-]
+-
+ [[package]]
+ name = "linux-raw-sys"
+-version = "0.9.3"
++version = "0.12.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
++checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+ 
+ [[package]]
+ name = "litemap"
+-version = "0.7.5"
++version = "0.8.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
++checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+ 
+ [[package]]
+ name = "litrs"
+@@ -2605,19 +1937,18 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+ 
+ [[package]]
+ name = "lock_api"
+-version = "0.4.12"
++version = "0.4.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
++checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+ dependencies = [
+- "autocfg",
+  "scopeguard",
+ ]
+ 
+ [[package]]
+ name = "log"
+-version = "0.4.27"
++version = "0.4.29"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
++checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+ 
+ [[package]]
+ name = "lru-slab"
+@@ -2643,19 +1974,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "memchr"
+-version = "2.7.4"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+-
+-[[package]]
+-name = "memmap2"
+-version = "0.9.5"
++version = "2.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+-dependencies = [
+- "libc",
+- "stable_deref_trait",
+-]
++checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+ 
+ [[package]]
+ name = "mime"
+@@ -2687,9 +2008,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+ 
+ [[package]]
+ name = "miniz_oxide"
+-version = "0.8.5"
++version = "0.8.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
++checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+ dependencies = [
+  "adler2",
+  "simd-adler32",
+@@ -2697,21 +2018,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "mio"
+-version = "1.0.3"
++version = "1.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
++checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+ dependencies = [
+  "libc",
+  "log",
+- "wasi 0.11.0+wasi-snapshot-preview1",
+- "windows-sys 0.52.0",
++ "wasi",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+ name = "moxcms"
+-version = "0.7.11"
++version = "0.8.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
++checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+ dependencies = [
+  "num-traits",
+  "pxfm",
+@@ -2734,12 +2055,6 @@ dependencies = [
+  "version_check",
+ ]
+ 
+-[[package]]
+-name = "multimap"
+-version = "0.10.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+-
+ [[package]]
+ name = "mutate_once"
+ version = "0.1.2"
+@@ -2779,14 +2094,14 @@ version = "0.44.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "3aa5e3b6a278ed061835fe1ee293b71641e6bf8b401cfe4e1834bbf4ef0a34e1"
+ dependencies = [
+- "base64 0.22.1",
++ "base64",
+  "bech32",
+  "bip39",
+- "bitcoin_hashes 0.14.0",
++ "bitcoin_hashes",
+  "cbc",
+  "chacha20",
+  "chacha20poly1305",
+- "getrandom 0.2.15",
++ "getrandom 0.2.17",
+  "hex",
+  "instant",
+  "scrypt",
+@@ -2803,7 +2118,7 @@ version = "8.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags 2.11.0",
+  "fsevent-sys",
+  "inotify",
+  "kqueue",
+@@ -2817,41 +2132,19 @@ dependencies = [
+ 
+ [[package]]
+ name = "notify-types"
+-version = "2.0.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+-
+-[[package]]
+-name = "num"
+-version = "0.4.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+-dependencies = [
+- "num-bigint",
+- "num-complex",
+- "num-integer",
+- "num-iter",
+- "num-rational",
+- "num-traits",
+-]
+-
+-[[package]]
+-name = "num-bigint"
+-version = "0.4.6"
++version = "2.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
++checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+ dependencies = [
+- "num-integer",
+- "num-traits",
++ "bitflags 2.11.0",
+ ]
+ 
+ [[package]]
+ name = "num-bigint-dig"
+-version = "0.8.4"
++version = "0.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
++checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+ dependencies = [
+- "byteorder",
+  "lazy_static",
+  "libm",
+  "num-integer",
+@@ -2868,7 +2161,6 @@ version = "0.4.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+ dependencies = [
+- "bytemuck",
+  "num-traits",
+ ]
+ 
+@@ -2898,17 +2190,6 @@ dependencies = [
+  "num-traits",
+ ]
+ 
+-[[package]]
+-name = "num-rational"
+-version = "0.4.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+-dependencies = [
+- "num-bigint",
+- "num-integer",
+- "num-traits",
+-]
+-
+ [[package]]
+ name = "num-traits"
+ version = "0.2.19"
+@@ -2921,28 +2202,25 @@ dependencies = [
+ 
+ [[package]]
+ name = "num_cpus"
+-version = "1.16.0"
++version = "1.17.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
++checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+ dependencies = [
+- "hermit-abi 0.3.9",
++ "hermit-abi",
+  "libc",
+ ]
+ 
+ [[package]]
+-name = "object"
+-version = "0.36.7"
++name = "once_cell"
++version = "1.21.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+-dependencies = [
+- "memchr",
+-]
++checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+ 
+ [[package]]
+-name = "once_cell"
+-version = "1.21.3"
++name = "once_cell_polyfill"
++version = "1.70.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
++checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+ 
+ [[package]]
+ name = "opaque-debug"
+@@ -2952,11 +2230,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+ 
+ [[package]]
+ name = "openssl"
+-version = "0.10.75"
++version = "0.10.76"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
++checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags 2.11.0",
+  "cfg-if",
+  "foreign-types",
+  "libc",
+@@ -2984,9 +2262,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+ 
+ [[package]]
+ name = "openssl-sys"
+-version = "0.9.111"
++version = "0.9.112"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
++checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+ dependencies = [
+  "cc",
+  "libc",
+@@ -3018,9 +2296,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+ 
+ [[package]]
+ name = "parking_lot"
+-version = "0.12.3"
++version = "0.12.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
++checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+ dependencies = [
+  "lock_api",
+  "parking_lot_core",
+@@ -3028,63 +2306,34 @@ dependencies = [
+ 
+ [[package]]
+ name = "parking_lot_core"
+-version = "0.9.10"
++version = "0.9.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
++checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+ dependencies = [
+  "cfg-if",
+  "libc",
+- "redox_syscall",
++ "redox_syscall 0.5.18",
+  "smallvec",
+- "windows-targets 0.52.6",
++ "windows-link",
+ ]
+ 
+ [[package]]
+ name = "password-hash"
+ version = "0.5.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+-dependencies = [
+- "base64ct",
+- "rand_core 0.6.4",
+- "subtle",
+-]
+-
+-[[package]]
+-name = "paste"
+-version = "1.0.15"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+-
+-[[package]]
+-name = "pathdiff"
+-version = "0.2.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+-
+-[[package]]
+-name = "payments-rs"
+-version = "0.2.0"
+-source = "git+https://github.com/v0l/payments-rs.git?rev=60b0fbf3838385439fbd08d43565fb1d9ab810fb#60b0fbf3838385439fbd08d43565fb1d9ab810fb"
+-dependencies = [
+- "anyhow",
+- "async-trait",
+- "chrono",
+- "fedimint-tonic-lnd",
+- "futures",
+- "hex",
+- "hmac",
+- "lightning-invoice",
+- "log",
+- "reqwest 0.13.2",
+- "serde",
+- "serde_html_form",
+- "serde_json",
+- "sha2",
+- "tokio",
+- "tokio-stream",
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
++dependencies = [
++ "base64ct",
++ "rand_core 0.6.4",
++ "subtle",
+ ]
+ 
++[[package]]
++name = "pathdiff"
++version = "0.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
++
+ [[package]]
+ name = "pbkdf2"
+ version = "0.12.2"
+@@ -3106,26 +2355,25 @@ dependencies = [
+ 
+ [[package]]
+ name = "percent-encoding"
+-version = "2.3.1"
++version = "2.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
++checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+ 
+ [[package]]
+ name = "pest"
+-version = "2.8.0"
++version = "2.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
++checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+ dependencies = [
+  "memchr",
+- "thiserror 2.0.12",
+  "ucd-trie",
+ ]
+ 
+ [[package]]
+ name = "pest_derive"
+-version = "2.8.0"
++version = "2.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
++checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+ dependencies = [
+  "pest",
+  "pest_generator",
+@@ -3133,9 +2381,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "pest_generator"
+-version = "2.8.0"
++version = "2.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
++checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+ dependencies = [
+  "pest",
+  "pest_meta",
+@@ -3146,51 +2394,19 @@ dependencies = [
+ 
+ [[package]]
+ name = "pest_meta"
+-version = "2.8.0"
++version = "2.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
++checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+ dependencies = [
+- "once_cell",
+  "pest",
+  "sha2",
+ ]
+ 
+-[[package]]
+-name = "petgraph"
+-version = "0.8.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+-dependencies = [
+- "fixedbitset",
+- "hashbrown 0.15.2",
+- "indexmap",
+-]
+-
+-[[package]]
+-name = "pin-project"
+-version = "1.1.10"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+-dependencies = [
+- "pin-project-internal",
+-]
+-
+-[[package]]
+-name = "pin-project-internal"
+-version = "1.1.10"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn",
+-]
+-
+ [[package]]
+ name = "pin-project-lite"
+-version = "0.2.16"
++version = "0.2.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
++checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+ 
+ [[package]]
+ name = "pin-utils"
+@@ -3225,6 +2441,12 @@ version = "0.3.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+ 
++[[package]]
++name = "plain"
++version = "0.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
++
+ [[package]]
+ name = "poly1305"
+ version = "0.8.0"
+@@ -3238,9 +2460,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "portable-atomic"
+-version = "1.11.1"
++version = "1.13.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
++
++[[package]]
++name = "potential_utf"
++version = "0.1.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
++checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
++dependencies = [
++ "zerovec",
++]
+ 
+ [[package]]
+ name = "powerfmt"
+@@ -3269,9 +2500,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "prettyplease"
+-version = "0.2.33"
++version = "0.2.37"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
++checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+ dependencies = [
+  "proc-macro2",
+  "syn",
+@@ -3288,123 +2519,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.94"
++version = "1.0.106"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
++checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+ dependencies = [
+  "unicode-ident",
+ ]
+ 
+-[[package]]
+-name = "prost"
+-version = "0.14.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+-dependencies = [
+- "bytes",
+- "prost-derive",
+-]
+-
+-[[package]]
+-name = "prost-build"
+-version = "0.14.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+-dependencies = [
+- "heck",
+- "itertools",
+- "log",
+- "multimap",
+- "petgraph",
+- "prettyplease",
+- "prost",
+- "prost-types",
+- "pulldown-cmark",
+- "pulldown-cmark-to-cmark",
+- "regex",
+- "syn",
+- "tempfile",
+-]
+-
+-[[package]]
+-name = "prost-derive"
+-version = "0.14.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+-dependencies = [
+- "anyhow",
+- "itertools",
+- "proc-macro2",
+- "quote",
+- "syn",
+-]
+-
+-[[package]]
+-name = "prost-types"
+-version = "0.14.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+-dependencies = [
+- "prost",
+-]
+-
+-[[package]]
+-name = "pulldown-cmark"
+-version = "0.13.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+-dependencies = [
+- "bitflags 2.9.0",
+- "memchr",
+- "unicase",
+-]
+-
+-[[package]]
+-name = "pulldown-cmark-to-cmark"
+-version = "22.0.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+-dependencies = [
+- "pulldown-cmark",
+-]
+-
+-[[package]]
+-name = "pulp"
+-version = "0.21.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
+-dependencies = [
+- "bytemuck",
+- "cfg-if",
+- "libm",
+- "num-complex",
+- "reborrow",
+- "version_check",
+-]
+-
+-[[package]]
+-name = "pulp"
+-version = "0.22.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+-dependencies = [
+- "bytemuck",
+- "cfg-if",
+- "libm",
+- "num-complex",
+- "paste",
+- "pulp-wasm-simd-flag",
+- "raw-cpuid",
+- "reborrow",
+- "version_check",
+-]
+-
+-[[package]]
+-name = "pulp-wasm-simd-flag"
+-version = "0.1.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+-
+ [[package]]
+ name = "pxfm"
+ version = "0.1.28"
+@@ -3425,7 +2546,7 @@ dependencies = [
+  "rustc-hash",
+  "rustls",
+  "socket2",
+- "thiserror 2.0.12",
++ "thiserror 2.0.18",
+  "tokio",
+  "tracing",
+  "web-time",
+@@ -3433,21 +2554,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "quinn-proto"
+-version = "0.11.13"
++version = "0.11.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
++checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+ dependencies = [
+  "aws-lc-rs",
+  "bytes",
+- "getrandom 0.3.2",
++ "getrandom 0.3.4",
+  "lru-slab",
+- "rand 0.9.0",
++ "rand 0.9.2",
+  "ring",
+  "rustc-hash",
+  "rustls",
+  "rustls-pki-types",
+  "slab",
+- "thiserror 2.0.12",
++ "thiserror 2.0.18",
+  "tinyvec",
+  "tracing",
+  "web-time",
+@@ -3469,18 +2590,24 @@ dependencies = [
+ 
+ [[package]]
+ name = "quote"
+-version = "1.0.40"
++version = "1.0.45"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
++checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+ dependencies = [
+  "proc-macro2",
+ ]
+ 
+ [[package]]
+ name = "r-efi"
+-version = "5.2.0"
++version = "5.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
++
++[[package]]
++name = "r-efi"
++version = "6.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
++checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+ 
+ [[package]]
+ name = "rand"
+@@ -3495,13 +2622,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "rand"
+-version = "0.9.0"
++version = "0.9.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
++checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+ dependencies = [
+  "rand_chacha 0.9.0",
+- "rand_core 0.9.3",
+- "zerocopy",
++ "rand_core 0.9.5",
+ ]
+ 
+ [[package]]
+@@ -3521,7 +2647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+ dependencies = [
+  "ppv-lite86",
+- "rand_core 0.9.3",
++ "rand_core 0.9.5",
+ ]
+ 
+ [[package]]
+@@ -3530,70 +2656,34 @@ version = "0.6.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+ dependencies = [
+- "getrandom 0.2.15",
++ "getrandom 0.2.17",
+ ]
+ 
+ [[package]]
+ name = "rand_core"
+-version = "0.9.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+-dependencies = [
+- "getrandom 0.3.2",
+-]
+-
+-[[package]]
+-name = "rand_distr"
+-version = "0.5.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+-dependencies = [
+- "num-traits",
+- "rand 0.9.0",
+-]
+-
+-[[package]]
+-name = "raw-cpuid"
+-version = "11.6.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+-dependencies = [
+- "bitflags 2.9.0",
+-]
+-
+-[[package]]
+-name = "rayon"
+-version = "1.10.0"
++version = "0.9.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
++checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+ dependencies = [
+- "either",
+- "rayon-core",
++ "getrandom 0.3.4",
+ ]
+ 
+ [[package]]
+-name = "rayon-core"
+-version = "1.12.1"
++name = "redox_syscall"
++version = "0.5.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
++checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+ dependencies = [
+- "crossbeam-deque",
+- "crossbeam-utils",
++ "bitflags 2.11.0",
+ ]
+ 
+-[[package]]
+-name = "reborrow"
+-version = "0.5.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+-
+ [[package]]
+ name = "redox_syscall"
+-version = "0.5.17"
++version = "0.7.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
++checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags 2.11.0",
+ ]
+ 
+ [[package]]
+@@ -3602,16 +2692,16 @@ version = "0.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+ dependencies = [
+- "getrandom 0.2.15",
++ "getrandom 0.2.17",
+  "libredox",
+- "thiserror 2.0.12",
++ "thiserror 2.0.18",
+ ]
+ 
+ [[package]]
+ name = "regex"
+-version = "1.11.1"
++version = "1.12.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
++checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+ dependencies = [
+  "aho-corasick",
+  "memchr",
+@@ -3621,9 +2711,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "regex-automata"
+-version = "0.4.9"
++version = "0.4.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
++checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+ dependencies = [
+  "aho-corasick",
+  "memchr",
+@@ -3632,9 +2722,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "regex-syntax"
+-version = "0.8.5"
++version = "0.8.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
++checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+ 
+ [[package]]
+ name = "reqwest"
+@@ -3642,7 +2732,7 @@ version = "0.12.28"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+ dependencies = [
+- "base64 0.22.1",
++ "base64",
+  "bytes",
+  "encoding_rs",
+  "futures-core",
+@@ -3685,7 +2775,7 @@ version = "0.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+ dependencies = [
+- "base64 0.22.1",
++ "base64",
+  "bytes",
+  "encoding_rs",
+  "futures-core",
+@@ -3730,7 +2820,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+ dependencies = [
+  "cc",
+  "cfg-if",
+- "getrandom 0.2.15",
++ "getrandom 0.2.17",
+  "libc",
+  "untrusted",
+  "windows-sys 0.52.0",
+@@ -3738,14 +2828,16 @@ dependencies = [
+ 
+ [[package]]
+ name = "ron"
+-version = "0.8.1"
++version = "0.12.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
++checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
+ dependencies = [
+- "base64 0.21.7",
+- "bitflags 2.9.0",
++ "bitflags 2.11.0",
++ "once_cell",
+  "serde",
+  "serde_derive",
++ "typeid",
++ "unicode-ident",
+ ]
+ 
+ [[package]]
+@@ -3756,10 +2848,7 @@ dependencies = [
+  "async-trait",
+  "axum",
+  "axum-extra",
+- "base64 0.22.1",
+- "candle-core",
+- "candle-nn",
+- "candle-transformers",
++ "base64",
+  "chrono",
+  "clap",
+  "config",
+@@ -3779,7 +2868,6 @@ dependencies = [
+  "mime2ext",
+  "nostr",
+  "notify",
+- "payments-rs",
+  "pretty_env_logger",
+  "reqwest 0.13.2",
+  "serde",
+@@ -3798,9 +2886,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rsa"
+-version = "0.9.8"
++version = "0.9.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
++checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+ dependencies = [
+  "const-oid",
+  "digest",
+@@ -3818,21 +2906,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "rust-ini"
+-version = "0.21.1"
++version = "0.21.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
++checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+ dependencies = [
+  "cfg-if",
+  "ordered-multimap",
+- "trim-in-place",
+ ]
+ 
+-[[package]]
+-name = "rustc-demangle"
+-version = "0.1.24"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+-
+ [[package]]
+ name = "rustc-hash"
+ version = "2.1.1"
+@@ -3864,22 +2945,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustix"
+-version = "1.0.3"
++version = "1.1.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
++checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags 2.11.0",
+  "errno",
+  "libc",
+  "linux-raw-sys",
+- "windows-sys 0.59.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+ name = "rustls"
+-version = "0.23.36"
++version = "0.23.37"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
++checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+ dependencies = [
+  "aws-lc-rs",
+  "log",
+@@ -3903,15 +2984,6 @@ dependencies = [
+  "security-framework",
+ ]
+ 
+-[[package]]
+-name = "rustls-pemfile"
+-version = "2.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+-dependencies = [
+- "rustls-pki-types",
+-]
+-
+ [[package]]
+ name = "rustls-pki-types"
+ version = "1.14.0"
+@@ -3940,7 +3012,7 @@ dependencies = [
+  "security-framework",
+  "security-framework-sys",
+  "webpki-root-certs",
+- "windows-sys 0.61.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+@@ -3963,36 +3035,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustversion"
+-version = "1.0.20"
++version = "1.0.22"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
++checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+ 
+ [[package]]
+ name = "ryu"
+-version = "1.0.20"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+-
+-[[package]]
+-name = "safetensors"
+-version = "0.4.5"
++version = "1.0.23"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
+-dependencies = [
+- "serde",
+- "serde_json",
+-]
+-
+-[[package]]
+-name = "safetensors"
+-version = "0.7.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+-dependencies = [
+- "hashbrown 0.16.1",
+- "serde",
+- "serde_json",
+-]
++checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+ 
+ [[package]]
+ name = "salsa20"
+@@ -4014,11 +3065,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "schannel"
+-version = "0.1.28"
++version = "0.1.29"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
++checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+ dependencies = [
+- "windows-sys 0.61.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+@@ -4045,7 +3096,6 @@ version = "0.29.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+ dependencies = [
+- "bitcoin_hashes 0.14.0",
+  "rand 0.8.5",
+  "secp256k1-sys",
+  "serde",
+@@ -4062,11 +3112,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "security-framework"
+-version = "3.5.1"
++version = "3.7.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
++checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags 2.11.0",
+  "core-foundation 0.10.1",
+  "core-foundation-sys",
+  "libc",
+@@ -4075,19 +3125,19 @@ dependencies = [
+ 
+ [[package]]
+ name = "security-framework-sys"
+-version = "2.15.0"
++version = "2.17.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
++checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+ dependencies = [
+  "core-foundation-sys",
+  "libc",
+ ]
+ 
+ [[package]]
+-name = "seq-macro"
+-version = "0.3.6"
++name = "semver"
++version = "1.0.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
++checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+ 
+ [[package]]
+ name = "serde"
+@@ -4099,6 +3149,18 @@ dependencies = [
+  "serde_derive",
+ ]
+ 
++[[package]]
++name = "serde-untagged"
++version = "0.1.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
++dependencies = [
++ "erased-serde",
++ "serde",
++ "serde_core",
++ "typeid",
++]
++
+ [[package]]
+ name = "serde_core"
+ version = "1.0.228"
+@@ -4119,29 +3181,17 @@ dependencies = [
+  "syn",
+ ]
+ 
+-[[package]]
+-name = "serde_html_form"
+-version = "0.4.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0946d52b4b7e28823148aebbeceb901012c595ad737920d504fa8634bb099e6f"
+-dependencies = [
+- "form_urlencoded",
+- "indexmap",
+- "itoa",
+- "ryu",
+- "serde_core",
+-]
+-
+ [[package]]
+ name = "serde_json"
+-version = "1.0.140"
++version = "1.0.149"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
++checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+ dependencies = [
+  "itoa",
+  "memchr",
+- "ryu",
+  "serde",
++ "serde_core",
++ "zmij",
+ ]
+ 
+ [[package]]
+@@ -4155,22 +3205,13 @@ dependencies = [
+  "serde_core",
+ ]
+ 
+-[[package]]
+-name = "serde_plain"
+-version = "1.0.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+-dependencies = [
+- "serde",
+-]
+-
+ [[package]]
+ name = "serde_spanned"
+-version = "0.6.8"
++version = "1.0.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
++checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+ dependencies = [
+- "serde",
++ "serde_core",
+ ]
+ 
+ [[package]]
+@@ -4198,9 +3239,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "sha2"
+-version = "0.10.8"
++version = "0.10.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
++checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+ dependencies = [
+  "cfg-if",
+  "cpufeatures",
+@@ -4241,30 +3282,27 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+ 
+ [[package]]
+ name = "slab"
+-version = "0.4.9"
++version = "0.4.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+-dependencies = [
+- "autocfg",
+-]
++checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+ 
+ [[package]]
+ name = "smallvec"
+-version = "1.14.0"
++version = "1.15.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
++checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+ dependencies = [
+  "serde",
+ ]
+ 
+ [[package]]
+ name = "socket2"
+-version = "0.5.9"
++version = "0.6.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
++checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+ dependencies = [
+  "libc",
+- "windows-sys 0.52.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+@@ -4299,9 +3337,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "sqlx"
+-version = "0.8.3"
++version = "0.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4410e73b3c0d8442c5f99b425d7a435b5ee0ae4167b3196771dd3f7a01be745f"
++checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+ dependencies = [
+  "sqlx-core",
+  "sqlx-macros",
+@@ -4312,10 +3350,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "sqlx-core"
+-version = "0.8.3"
++version = "0.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6a007b6936676aa9ab40207cde35daab0a04b823be8ae004368c0793b96a61e0"
++checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+ dependencies = [
++ "base64",
+  "bytes",
+  "chrono",
+  "crc",
+@@ -4326,7 +3365,7 @@ dependencies = [
+  "futures-intrusive",
+  "futures-io",
+  "futures-util",
+- "hashbrown 0.15.2",
++ "hashbrown 0.15.5",
+  "hashlink",
+  "indexmap",
+  "log",
+@@ -4337,7 +3376,7 @@ dependencies = [
+  "serde_json",
+  "sha2",
+  "smallvec",
+- "thiserror 2.0.12",
++ "thiserror 2.0.18",
+  "tokio",
+  "tokio-stream",
+  "tracing",
+@@ -4347,9 +3386,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "sqlx-macros"
+-version = "0.8.3"
++version = "0.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3112e2ad78643fef903618d78cf0aec1cb3134b019730edb039b69eaf531f310"
++checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -4360,9 +3399,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "sqlx-macros-core"
+-version = "0.8.3"
++version = "0.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4e9f90acc5ab146a99bf5061a7eb4976b573f560bc898ef3bf8435448dd5e7ad"
++checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+ dependencies = [
+  "dotenvy",
+  "either",
+@@ -4379,20 +3418,19 @@ dependencies = [
+  "sqlx-postgres",
+  "sqlx-sqlite",
+  "syn",
+- "tempfile",
+  "tokio",
+  "url",
+ ]
+ 
+ [[package]]
+ name = "sqlx-mysql"
+-version = "0.8.3"
++version = "0.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
++checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+ dependencies = [
+  "atoi",
+- "base64 0.22.1",
+- "bitflags 2.9.0",
++ "base64",
++ "bitflags 2.11.0",
+  "byteorder",
+  "bytes",
+  "chrono",
+@@ -4422,7 +3460,7 @@ dependencies = [
+  "smallvec",
+  "sqlx-core",
+  "stringprep",
+- "thiserror 2.0.12",
++ "thiserror 2.0.18",
+  "tracing",
+  "uuid",
+  "whoami",
+@@ -4430,13 +3468,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "sqlx-postgres"
+-version = "0.8.3"
++version = "0.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
++checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+ dependencies = [
+  "atoi",
+- "base64 0.22.1",
+- "bitflags 2.9.0",
++ "base64",
++ "bitflags 2.11.0",
+  "byteorder",
+  "chrono",
+  "crc",
+@@ -4461,7 +3499,7 @@ dependencies = [
+  "smallvec",
+  "sqlx-core",
+  "stringprep",
+- "thiserror 2.0.12",
++ "thiserror 2.0.18",
+  "tracing",
+  "uuid",
+  "whoami",
+@@ -4469,9 +3507,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "sqlx-sqlite"
+-version = "0.8.3"
++version = "0.8.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f85ca71d3a5b24e64e1d08dd8fe36c6c95c339a896cc33068148906784620540"
++checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+ dependencies = [
+  "atoi",
+  "chrono",
+@@ -4487,6 +3525,7 @@ dependencies = [
+  "serde",
+  "serde_urlencoded",
+  "sqlx-core",
++ "thiserror 2.0.18",
+  "tracing",
+  "url",
+  "uuid",
+@@ -4494,9 +3533,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "stable_deref_trait"
+-version = "1.2.0"
++version = "1.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
++checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+ 
+ [[package]]
+ name = "strength_reduce"
+@@ -4529,9 +3568,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+ 
+ [[package]]
+ name = "syn"
+-version = "2.0.100"
++version = "2.0.117"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
++checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -4549,36 +3588,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "synstructure"
+-version = "0.13.1"
++version = "0.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
++checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+  "syn",
+ ]
+ 
+-[[package]]
+-name = "sysctl"
+-version = "0.6.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+-dependencies = [
+- "bitflags 2.9.0",
+- "byteorder",
+- "enum-as-inner",
+- "libc",
+- "thiserror 1.0.69",
+- "walkdir",
+-]
+-
+ [[package]]
+ name = "system-configuration"
+ version = "0.7.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags 2.11.0",
+  "core-foundation 0.9.4",
+  "system-configuration-sys",
+ ]
+@@ -4595,15 +3620,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "tempfile"
+-version = "3.19.1"
++version = "3.27.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
++checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+ dependencies = [
+  "fastrand",
+- "getrandom 0.3.2",
++ "getrandom 0.4.2",
+  "once_cell",
+  "rustix",
+- "windows-sys 0.59.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+@@ -4626,11 +3651,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "thiserror"
+-version = "2.0.12"
++version = "2.0.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
++checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+ dependencies = [
+- "thiserror-impl 2.0.12",
++ "thiserror-impl 2.0.18",
+ ]
+ 
+ [[package]]
+@@ -4646,9 +3671,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "thiserror-impl"
+-version = "2.0.12"
++version = "2.0.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
++checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -4697,9 +3722,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tinystr"
+-version = "0.7.6"
++version = "0.8.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
++checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+ dependencies = [
+  "displaydoc",
+  "zerovec",
+@@ -4707,9 +3732,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tinyvec"
+-version = "1.9.0"
++version = "1.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
++checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+ dependencies = [
+  "tinyvec_macros",
+ ]
+@@ -4722,11 +3747,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+ 
+ [[package]]
+ name = "tokio"
+-version = "1.44.1"
++version = "1.50.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
++checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+ dependencies = [
+- "backtrace",
+  "bytes",
+  "libc",
+  "mio",
+@@ -4734,14 +3758,14 @@ dependencies = [
+  "signal-hook-registry",
+  "socket2",
+  "tokio-macros",
+- "windows-sys 0.52.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+ name = "tokio-macros"
+-version = "2.5.0"
++version = "2.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
++checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -4760,9 +3784,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tokio-rustls"
+-version = "0.26.2"
++version = "0.26.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
++checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+ dependencies = [
+  "rustls",
+  "tokio",
+@@ -4770,21 +3794,20 @@ dependencies = [
+ 
+ [[package]]
+ name = "tokio-stream"
+-version = "0.1.17"
++version = "0.1.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
++checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+ dependencies = [
+  "futures-core",
+  "pin-project-lite",
+  "tokio",
+- "tokio-util",
+ ]
+ 
+ [[package]]
+ name = "tokio-util"
+-version = "0.7.14"
++version = "0.7.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
++checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+ dependencies = [
+  "bytes",
+  "futures-core",
+@@ -4795,118 +3818,46 @@ dependencies = [
+ 
+ [[package]]
+ name = "toml"
+-version = "0.8.20"
++version = "1.0.6+spec-1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
++checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+ dependencies = [
+- "serde",
++ "serde_core",
+  "serde_spanned",
+  "toml_datetime",
+- "toml_edit",
++ "toml_parser",
++ "winnow",
+ ]
+ 
+ [[package]]
+ name = "toml_datetime"
+-version = "0.6.8"
++version = "1.0.0+spec-1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
++checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+ dependencies = [
+- "serde",
++ "serde_core",
+ ]
+ 
+ [[package]]
+-name = "toml_edit"
+-version = "0.22.24"
++name = "toml_parser"
++version = "1.0.9+spec-1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
++checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+ dependencies = [
+- "indexmap",
+- "serde",
+- "serde_spanned",
+- "toml_datetime",
+  "winnow",
+ ]
+ 
+-[[package]]
+-name = "tonic"
+-version = "0.14.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
+-dependencies = [
+- "async-trait",
+- "base64 0.22.1",
+- "bytes",
+- "http",
+- "http-body",
+- "http-body-util",
+- "hyper",
+- "hyper-timeout",
+- "hyper-util",
+- "percent-encoding",
+- "pin-project",
+- "sync_wrapper",
+- "tokio",
+- "tokio-rustls",
+- "tokio-stream",
+- "tower",
+- "tower-layer",
+- "tower-service",
+- "tracing",
+-]
+-
+-[[package]]
+-name = "tonic-build"
+-version = "0.14.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "27aac809edf60b741e2d7db6367214d078856b8a5bff0087e94ff330fb97b6fc"
+-dependencies = [
+- "prettyplease",
+- "proc-macro2",
+- "quote",
+- "syn",
+-]
+-
+-[[package]]
+-name = "tonic-prost"
+-version = "0.14.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
+-dependencies = [
+- "bytes",
+- "prost",
+- "tonic",
+-]
+-
+-[[package]]
+-name = "tonic-prost-build"
+-version = "0.14.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
+-dependencies = [
+- "prettyplease",
+- "proc-macro2",
+- "prost-build",
+- "prost-types",
+- "quote",
+- "syn",
+- "tempfile",
+- "tonic-build",
+-]
+-
+ [[package]]
+ name = "tower"
+-version = "0.5.2"
++version = "0.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
++checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+ dependencies = [
+  "futures-core",
+  "futures-util",
+- "indexmap",
+  "pin-project-lite",
+- "slab",
+  "sync_wrapper",
+  "tokio",
+- "tokio-util",
+  "tower-layer",
+  "tower-service",
+  "tracing",
+@@ -4918,7 +3869,7 @@ version = "0.6.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags 2.11.0",
+  "bytes",
+  "futures-core",
+  "futures-util",
+@@ -4954,9 +3905,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+ 
+ [[package]]
+ name = "tracing"
+-version = "0.1.41"
++version = "0.1.44"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
++checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+ dependencies = [
+  "log",
+  "pin-project-lite",
+@@ -4966,9 +3917,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tracing-attributes"
+-version = "0.1.28"
++version = "0.1.31"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
++checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -4977,9 +3928,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tracing-core"
+-version = "0.1.33"
++version = "0.1.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
++checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+ dependencies = [
+  "once_cell",
+ ]
+@@ -4994,12 +3945,6 @@ dependencies = [
+  "strength_reduce",
+ ]
+ 
+-[[package]]
+-name = "trim-in-place"
+-version = "0.1.7"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
+-
+ [[package]]
+ name = "try-lock"
+ version = "0.2.5"
+@@ -5007,16 +3952,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+ 
+ [[package]]
+-name = "typed-path"
+-version = "0.12.3"
++name = "typeid"
++version = "1.0.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
++checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+ 
+ [[package]]
+ name = "typenum"
+-version = "1.18.0"
++version = "1.19.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
++checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+ 
+ [[package]]
+ name = "ucd-trie"
+@@ -5024,40 +3969,6 @@ version = "0.1.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+ 
+-[[package]]
+-name = "ug"
+-version = "0.5.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "76b761acf8af3494640d826a8609e2265e19778fb43306c7f15379c78c9b05b0"
+-dependencies = [
+- "gemm 0.18.2",
+- "half",
+- "libloading 0.8.6",
+- "memmap2",
+- "num",
+- "num-traits",
+- "num_cpus",
+- "rayon",
+- "safetensors 0.4.5",
+- "serde",
+- "thiserror 1.0.69",
+- "tracing",
+- "yoke 0.7.5",
+-]
+-
+-[[package]]
+-name = "ug-cuda"
+-version = "0.5.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9f0a1fa748f26166778c33b8498255ebb7c6bffb472bcc0a72839e07ebb1d9b5"
+-dependencies = [
+- "cudarc 0.17.8",
+- "half",
+- "serde",
+- "thiserror 1.0.69",
+- "ug",
+-]
+-
+ [[package]]
+ name = "unicase"
+ version = "2.9.0"
+@@ -5072,24 +3983,24 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+ 
+ [[package]]
+ name = "unicode-ident"
+-version = "1.0.18"
++version = "1.0.24"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
++checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+ 
+ [[package]]
+ name = "unicode-normalization"
+-version = "0.1.22"
++version = "0.1.25"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
++checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+ dependencies = [
+  "tinyvec",
+ ]
+ 
+ [[package]]
+ name = "unicode-properties"
+-version = "0.1.3"
++version = "0.1.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
++checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+ 
+ [[package]]
+ name = "unicode-segmentation"
+@@ -5099,15 +4010,21 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+ 
+ [[package]]
+ name = "unicode-width"
+-version = "0.2.1"
++version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
++checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
++
++[[package]]
++name = "unicode-xid"
++version = "0.2.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+ 
+ [[package]]
+ name = "unit-prefix"
+-version = "0.5.1"
++version = "0.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
++checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+ 
+ [[package]]
+ name = "universal-hash"
+@@ -5131,7 +4048,7 @@ version = "3.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+ dependencies = [
+- "base64 0.22.1",
++ "base64",
+  "cookie_store",
+  "der",
+  "flate2",
+@@ -5155,7 +4072,7 @@ version = "0.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+ dependencies = [
+- "base64 0.22.1",
++ "base64",
+  "http",
+  "httparse",
+  "log",
+@@ -5163,14 +4080,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "url"
+-version = "2.5.4"
++version = "2.5.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
++checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+ dependencies = [
+  "form_urlencoded",
+  "idna",
+  "percent-encoding",
+  "serde",
++ "serde_derive",
+ ]
+ 
+ [[package]]
+@@ -5179,12 +4097,6 @@ version = "0.7.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+ 
+-[[package]]
+-name = "utf16_iter"
+-version = "1.0.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+-
+ [[package]]
+ name = "utf8_iter"
+ version = "1.0.4"
+@@ -5199,12 +4111,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+ 
+ [[package]]
+ name = "uuid"
+-version = "1.16.0"
++version = "1.22.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
++checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+ dependencies = [
+- "getrandom 0.3.2",
+- "serde",
++ "getrandom 0.4.2",
++ "js-sys",
++ "serde_core",
++ "wasm-bindgen",
+ ]
+ 
+ [[package]]
+@@ -5240,17 +4154,26 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasi"
+-version = "0.11.0+wasi-snapshot-preview1"
++version = "0.11.1+wasi-snapshot-preview1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
++checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+ 
+ [[package]]
+-name = "wasi"
+-version = "0.14.2+wasi-0.2.4"
++name = "wasip2"
++version = "1.0.2+wasi-0.2.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
++dependencies = [
++ "wit-bindgen",
++]
++
++[[package]]
++name = "wasip3"
++version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
++checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+ dependencies = [
+- "wit-bindgen-rt",
++ "wit-bindgen",
+ ]
+ 
+ [[package]]
+@@ -5261,9 +4184,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+ 
+ [[package]]
+ name = "wasm-bindgen"
+-version = "0.2.108"
++version = "0.2.114"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
++checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+ dependencies = [
+  "cfg-if",
+  "once_cell",
+@@ -5274,9 +4197,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-futures"
+-version = "0.4.58"
++version = "0.4.64"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
++checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+ dependencies = [
+  "cfg-if",
+  "futures-util",
+@@ -5288,9 +4211,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro"
+-version = "0.2.108"
++version = "0.2.114"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
++checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+ dependencies = [
+  "quote",
+  "wasm-bindgen-macro-support",
+@@ -5298,9 +4221,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro-support"
+-version = "0.2.108"
++version = "0.2.114"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
++checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+ dependencies = [
+  "bumpalo",
+  "proc-macro2",
+@@ -5311,13 +4234,35 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-shared"
+-version = "0.2.108"
++version = "0.2.114"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
++checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+ dependencies = [
+  "unicode-ident",
+ ]
+ 
++[[package]]
++name = "wasm-encoder"
++version = "0.244.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
++dependencies = [
++ "leb128fmt",
++ "wasmparser",
++]
++
++[[package]]
++name = "wasm-metadata"
++version = "0.244.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
++dependencies = [
++ "anyhow",
++ "indexmap",
++ "wasm-encoder",
++ "wasmparser",
++]
++
+ [[package]]
+ name = "wasm-streams"
+ version = "0.4.2"
+@@ -5344,11 +4289,23 @@ dependencies = [
+  "web-sys",
+ ]
+ 
++[[package]]
++name = "wasmparser"
++version = "0.244.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
++dependencies = [
++ "bitflags 2.11.0",
++ "hashbrown 0.15.5",
++ "indexmap",
++ "semver",
++]
++
+ [[package]]
+ name = "web-sys"
+-version = "0.3.85"
++version = "0.3.91"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
++checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+ dependencies = [
+  "js-sys",
+  "wasm-bindgen",
+@@ -5384,11 +4341,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "whoami"
+-version = "1.6.0"
++version = "1.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
++checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+ dependencies = [
+- "redox_syscall",
++ "libredox",
+  "wasite",
+ ]
+ 
+@@ -5410,11 +4367,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+ 
+ [[package]]
+ name = "winapi-util"
+-version = "0.1.9"
++version = "0.1.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
++checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+ dependencies = [
+- "windows-sys 0.59.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+@@ -5425,52 +4382,72 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+ 
+ [[package]]
+ name = "windows-core"
+-version = "0.52.0"
++version = "0.62.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
++checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+ dependencies = [
+- "windows-targets 0.52.6",
++ "windows-implement",
++ "windows-interface",
++ "windows-link",
++ "windows-result",
++ "windows-strings",
+ ]
+ 
+ [[package]]
+-name = "windows-link"
+-version = "0.1.1"
++name = "windows-implement"
++version = "0.60.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn",
++]
++
++[[package]]
++name = "windows-interface"
++version = "0.59.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
++checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn",
++]
+ 
+ [[package]]
+ name = "windows-link"
+-version = "0.2.0"
++version = "0.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
++checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+ 
+ [[package]]
+ name = "windows-registry"
+-version = "0.4.0"
++version = "0.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
++checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+ dependencies = [
++ "windows-link",
+  "windows-result",
+  "windows-strings",
+- "windows-targets 0.53.2",
+ ]
+ 
+ [[package]]
+ name = "windows-result"
+-version = "0.3.2"
++version = "0.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
++checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+ dependencies = [
+- "windows-link 0.1.1",
++ "windows-link",
+ ]
+ 
+ [[package]]
+ name = "windows-strings"
+-version = "0.3.1"
++version = "0.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
++checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+ dependencies = [
+- "windows-link 0.1.1",
++ "windows-link",
+ ]
+ 
+ [[package]]
+@@ -5500,31 +4477,22 @@ dependencies = [
+  "windows-targets 0.52.6",
+ ]
+ 
+-[[package]]
+-name = "windows-sys"
+-version = "0.59.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+-dependencies = [
+- "windows-targets 0.52.6",
+-]
+-
+ [[package]]
+ name = "windows-sys"
+ version = "0.60.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+ dependencies = [
+- "windows-targets 0.53.2",
++ "windows-targets 0.53.5",
+ ]
+ 
+ [[package]]
+ name = "windows-sys"
+-version = "0.61.0"
++version = "0.61.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
++checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+ dependencies = [
+- "windows-link 0.2.0",
++ "windows-link",
+ ]
+ 
+ [[package]]
+@@ -5575,18 +4543,19 @@ dependencies = [
+ 
+ [[package]]
+ name = "windows-targets"
+-version = "0.53.2"
++version = "0.53.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
++checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+ dependencies = [
+- "windows_aarch64_gnullvm 0.53.0",
+- "windows_aarch64_msvc 0.53.0",
+- "windows_i686_gnu 0.53.0",
+- "windows_i686_gnullvm 0.53.0",
+- "windows_i686_msvc 0.53.0",
+- "windows_x86_64_gnu 0.53.0",
+- "windows_x86_64_gnullvm 0.53.0",
+- "windows_x86_64_msvc 0.53.0",
++ "windows-link",
++ "windows_aarch64_gnullvm 0.53.1",
++ "windows_aarch64_msvc 0.53.1",
++ "windows_i686_gnu 0.53.1",
++ "windows_i686_gnullvm 0.53.1",
++ "windows_i686_msvc 0.53.1",
++ "windows_x86_64_gnu 0.53.1",
++ "windows_x86_64_gnullvm 0.53.1",
++ "windows_x86_64_msvc 0.53.1",
+ ]
+ 
+ [[package]]
+@@ -5609,9 +4578,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+ 
+ [[package]]
+ name = "windows_aarch64_gnullvm"
+-version = "0.53.0"
++version = "0.53.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
++checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+ 
+ [[package]]
+ name = "windows_aarch64_msvc"
+@@ -5633,9 +4602,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+ 
+ [[package]]
+ name = "windows_aarch64_msvc"
+-version = "0.53.0"
++version = "0.53.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
++checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+ 
+ [[package]]
+ name = "windows_i686_gnu"
+@@ -5657,9 +4626,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+ 
+ [[package]]
+ name = "windows_i686_gnu"
+-version = "0.53.0"
++version = "0.53.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
++checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+ 
+ [[package]]
+ name = "windows_i686_gnullvm"
+@@ -5669,9 +4638,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+ 
+ [[package]]
+ name = "windows_i686_gnullvm"
+-version = "0.53.0"
++version = "0.53.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
++checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+ 
+ [[package]]
+ name = "windows_i686_msvc"
+@@ -5693,9 +4662,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+ 
+ [[package]]
+ name = "windows_i686_msvc"
+-version = "0.53.0"
++version = "0.53.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
++checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+ 
+ [[package]]
+ name = "windows_x86_64_gnu"
+@@ -5717,9 +4686,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+ 
+ [[package]]
+ name = "windows_x86_64_gnu"
+-version = "0.53.0"
++version = "0.53.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
++checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+ 
+ [[package]]
+ name = "windows_x86_64_gnullvm"
+@@ -5741,9 +4710,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+ 
+ [[package]]
+ name = "windows_x86_64_gnullvm"
+-version = "0.53.0"
++version = "0.53.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
++checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+ 
+ [[package]]
+ name = "windows_x86_64_msvc"
+@@ -5765,84 +4734,133 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+ 
+ [[package]]
+ name = "windows_x86_64_msvc"
+-version = "0.53.0"
++version = "0.53.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
++checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+ 
+ [[package]]
+ name = "winnow"
+-version = "0.7.4"
++version = "0.7.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
++checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+ dependencies = [
+  "memchr",
+ ]
+ 
+ [[package]]
+-name = "wit-bindgen-rt"
+-version = "0.39.0"
++name = "wit-bindgen"
++version = "0.51.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
++checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+ dependencies = [
+- "bitflags 2.9.0",
++ "wit-bindgen-rust-macro",
+ ]
+ 
+ [[package]]
+-name = "write16"
+-version = "1.0.0"
++name = "wit-bindgen-core"
++version = "0.51.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
++checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
++dependencies = [
++ "anyhow",
++ "heck",
++ "wit-parser",
++]
+ 
+ [[package]]
+-name = "writeable"
+-version = "0.5.5"
++name = "wit-bindgen-rust"
++version = "0.51.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
++checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
++dependencies = [
++ "anyhow",
++ "heck",
++ "indexmap",
++ "prettyplease",
++ "syn",
++ "wasm-metadata",
++ "wit-bindgen-core",
++ "wit-component",
++]
+ 
+ [[package]]
+-name = "yaml-rust2"
+-version = "0.10.3"
++name = "wit-bindgen-rust-macro"
++version = "0.51.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4ce2a4ff45552406d02501cea6c18d8a7e50228e7736a872951fe2fe75c91be7"
++checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+ dependencies = [
+- "arraydeque",
+- "encoding_rs",
+- "hashlink",
++ "anyhow",
++ "prettyplease",
++ "proc-macro2",
++ "quote",
++ "syn",
++ "wit-bindgen-core",
++ "wit-bindgen-rust",
+ ]
+ 
+ [[package]]
+-name = "yoke"
+-version = "0.7.5"
++name = "wit-component"
++version = "0.244.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
++checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+ dependencies = [
++ "anyhow",
++ "bitflags 2.11.0",
++ "indexmap",
++ "log",
+  "serde",
+- "stable_deref_trait",
+- "yoke-derive 0.7.5",
+- "zerofrom",
++ "serde_derive",
++ "serde_json",
++ "wasm-encoder",
++ "wasm-metadata",
++ "wasmparser",
++ "wit-parser",
+ ]
+ 
+ [[package]]
+-name = "yoke"
+-version = "0.8.1"
++name = "wit-parser"
++version = "0.244.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
++checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+ dependencies = [
+- "stable_deref_trait",
+- "yoke-derive 0.8.1",
+- "zerofrom",
++ "anyhow",
++ "id-arena",
++ "indexmap",
++ "log",
++ "semver",
++ "serde",
++ "serde_derive",
++ "serde_json",
++ "unicode-xid",
++ "wasmparser",
+ ]
+ 
+ [[package]]
+-name = "yoke-derive"
+-version = "0.7.5"
++name = "writeable"
++version = "0.6.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
++
++[[package]]
++name = "yaml-rust2"
++version = "0.10.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
++checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+ dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn",
+- "synstructure",
++ "arraydeque",
++ "encoding_rs",
++ "hashlink",
++]
++
++[[package]]
++name = "yoke"
++version = "0.8.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
++dependencies = [
++ "stable_deref_trait",
++ "yoke-derive",
++ "zerofrom",
+ ]
+ 
+ [[package]]
+@@ -5859,18 +4877,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "zerocopy"
+-version = "0.8.24"
++version = "0.8.42"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
++checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+ dependencies = [
+  "zerocopy-derive",
+ ]
+ 
+ [[package]]
+ name = "zerocopy-derive"
+-version = "0.8.24"
++version = "0.8.42"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
++checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -5900,26 +4918,37 @@ dependencies = [
+ 
+ [[package]]
+ name = "zeroize"
+-version = "1.8.1"
++version = "1.8.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
++
++[[package]]
++name = "zerotrie"
++version = "0.2.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
++checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
++dependencies = [
++ "displaydoc",
++ "yoke",
++ "zerofrom",
++]
+ 
+ [[package]]
+ name = "zerovec"
+-version = "0.10.4"
++version = "0.11.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
++checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+ dependencies = [
+- "yoke 0.7.5",
++ "yoke",
+  "zerofrom",
+  "zerovec-derive",
+ ]
+ 
+ [[package]]
+ name = "zerovec-derive"
+-version = "0.10.3"
++version = "0.11.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
++checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -5927,13 +4956,7 @@ dependencies = [
+ ]
+ 
+ [[package]]
+-name = "zip"
+-version = "7.2.0"
++name = "zmij"
++version = "1.0.21"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+-dependencies = [
+- "crc32fast",
+- "indexmap",
+- "memchr",
+- "typed-path",
+-]
++checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+diff --git a/Cargo.toml b/Cargo.toml
+index df842e4..142b087 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -13,12 +13,11 @@ name = "route96"
+ [features]
+ default = ["nip96", "blossom", "react-ui", "r96util", "labels"]
+ media-compression = ["dep:ffmpeg-rs-raw", "dep:libc"]
+-labels = ["media-compression", "dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:hf-hub"]
+-cuda = ["labels", "candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
++labels = ["media-compression", "dep:hf-hub"]
++cuda = ["labels"]
+ nip96 = ["media-compression"]
+ blossom = []
+ react-ui = []
+-payments = ["dep:payments-rs"]
+ r96util = ["dep:walkdir", "dep:indicatif"]
+ 
+ [dependencies]
+@@ -57,13 +56,9 @@ image_hasher = "3"
+ 
+ libc = { version = "0.2", optional = true }
+ ffmpeg-rs-raw = { git = "https://github.com/v0l/ffmpeg-rs-raw.git", rev = "f6dc45ecea44b235476c4f2114f15ce935ab7201", optional = true }
+-candle-core = { git = "https://github.com/DrJesseGlass/candle", branch = "fix/disable-bf16-wmma-pre-ampere", optional = true }
+-candle-nn = { git = "https://github.com/DrJesseGlass/candle", branch = "fix/disable-bf16-wmma-pre-ampere", optional = true }
+-candle-transformers = { git = "https://github.com/DrJesseGlass/candle", branch = "fix/disable-bf16-wmma-pre-ampere", optional = true }
+ hf-hub = { version = "0.5", optional = true }
+ walkdir = { version = "2.5", optional = true }
+ indicatif = { version = "0.18", optional = true }
+-payments-rs = { git = "https://github.com/v0l/payments-rs.git", optional = true, rev = "60b0fbf3838385439fbd08d43565fb1d9ab810fb" }
+ 
+ [dev-dependencies]
+ tempfile = "3"
+-- 
+2.53.0
+

--- a/pkgs/route96/default.nix
+++ b/pkgs/route96/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  ffmpeg-headless,
+  pkg-config,
+  openssl,
+  libclang,
+  clang,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "route96";
+  version = "0.6.0-unstable-2026-03-13";
+
+  src = fetchFromGitHub {
+    owner = "v0l";
+    repo = "route96";
+    rev = "7bce1a2b8d97365df62eef3a17524976665122dc";
+    hash = "sha256-IQKO1v85T6I65zHDT7EpClV0lTyL+FfS3Yw7Oj2vN4o=";
+  };
+
+  cargoPatches = [
+    # Remove candle (ML) and payments-rs (Lightning) optional deps that
+    # break nix cargo vendoring due to broken Cargo.toml in the candle
+    # monorepo.  We don't need labels or payments features.
+    ./0001-remove-candle-payments-deps-for-nix-build.patch
+  ];
+
+  cargoHash = "sha256-zcoJnWNZpWQN10HLGzMuMatj4FgpaNTehwVumsBkR4M=";
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "blossom"
+    "nip96"
+    "media-compression"
+  ];
+
+  # Only build the main binary; r96util needs optional deps (walkdir, indicatif)
+  # that aren't enabled without the r96util feature.
+  cargoBuildFlags = [
+    "--bin"
+    "route96"
+  ];
+
+  # Tests require a MySQL database
+  doCheck = false;
+
+  nativeBuildInputs = [
+    pkg-config
+    clang
+  ];
+
+  buildInputs = [
+    ffmpeg-headless
+    openssl
+  ];
+
+  env.LIBCLANG_PATH = "${libclang.lib}/lib";
+
+  postInstall = ''
+    install -Dm644 index.html $out/share/route96/index.html
+  '';
+
+  meta = {
+    description = "Decentralized blob storage server with Nostr integration";
+    homepage = "https://github.com/v0l/route96";
+    license = lib.licenses.mit;
+    mainProgram = "route96";
+  };
+}


### PR DESCRIPTION

Deploy route96 (Blossom/NIP-96) as a self-hosted Nostr file storage
service at nostr-files.thalheim.io, replacing the third-party
blossom.nostr.build for opencrow.

- Package route96 with blossom, nip96, and media-compression features
- Patch out candle (ML) and payments-rs deps that break nix vendoring
- Add MariaDB with unix socket auth for the database backend
- Configure 90-day unaccessed file retention policy
- Wire up nginx reverse proxy with websocket support
