### PR TITLE
niri: switch from SDDM+gnome-keyring to greetd+kwallet

### DIFF
--- a/machines/turingmachine/configuration.nix
+++ b/machines/turingmachine/configuration.nix
@@ -46,7 +46,7 @@
 
   services.openssh.settings.PasswordAuthentication = lib.mkForce true;
 
-  documentation.man.generateCaches = true;
+  documentation.man.cache.enable = true;
 
   services.dbus.implementation = "broker";
 

--- a/machines/turingmachine/modules/toggle-keyboard/default.nix
+++ b/machines/turingmachine/modules/toggle-keyboard/default.nix
@@ -16,6 +16,23 @@
     #'')
   ];
   powerManagement.enable = true;
-  # re-enable after suspend so we can login
-  powerManagement.powerUpCommands = "${pkgs.kmod}/bin/modprobe i8042";
+
+  # Re-enable i8042 keyboard after resume so we can login
+  systemd.services.i8042-resume = {
+    description = "Reload i8042 keyboard module after resume";
+    after = [
+      "suspend.target"
+      "hibernate.target"
+      "hybrid-sleep.target"
+    ];
+    wantedBy = [
+      "suspend.target"
+      "hibernate.target"
+      "hybrid-sleep.target"
+    ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.kmod}/bin/modprobe i8042";
+    };
+  };
 }

--- a/nixosModules/niri/default.nix
+++ b/nixosModules/niri/default.nix
@@ -12,6 +12,10 @@
     serviceConfig = {
       Type = "oneshot";
       ExecStart = pkgs.writeShellScript "lock-secrets" ''
+        # Lock KWallet/ksecretd
+        ${pkgs.libsecret}/bin/secret-tool lock --collection=kdewallet 2>/dev/null || true
+
+        # Lock rbw
         ${pkgs.rbw}/bin/rbw lock 2>/dev/null || true
       '';
     };
@@ -19,10 +23,24 @@
 
   programs.niri.enable = true;
 
-  # SDDM as display manager
-  services.xserver.enable = true;
-  services.displayManager.sddm.enable = true;
-  services.displayManager.sddm.wayland.enable = true;
+  # Use KDE Wallet instead of gnome-keyring for secret storage
+  services.gnome.gnome-keyring.enable = false;
+  security.pam.services.greetd.kwallet = {
+    enable = true;
+    package = pkgs.kdePackages.kwallet-pam;
+    forceRun = true;
+  };
+
+  # greetd + tuigreet as display manager (lightweight, no X dependency)
+  services.greetd = {
+    enable = true;
+    settings = {
+      default_session = {
+        command = "${pkgs.greetd.tuigreet}/bin/tuigreet --time --remember --remember-session --sessions ${config.services.displayManager.sessionData.desktops}/share/wayland-sessions";
+        user = "greeter";
+      };
+    };
+  };
 
   # PAM integration for swaylock is handled by wayland-session.nix
   # imported by the niri module
@@ -62,6 +80,10 @@
 
     # Printer configuration
     system-config-printer
+
+    # KDE Wallet (secret service provider + management UI)
+    kdePackages.kwallet
+    kdePackages.kwalletmanager
 
     # Screenshot tools
     grim


### PR DESCRIPTION

SDDM pulls in X11 dependencies unnecessarily for a pure Wayland
compositor. greetd with tuigreet is a lightweight alternative that
avoids this overhead.

gnome-keyring is the niri module default but KDE Wallet integrates
better with the existing KDE tooling (kdeconnect, choosers) already
used in this setup and provides the same org.freedesktop.secrets
D-Bus API for application compatibility.
