### PR TITLE
limine: copy secureboot keys instead of symlinking

### DIFF
--- a/nixosModules/limine.nix
+++ b/nixosModules/limine.nix
@@ -10,9 +10,10 @@ let
     dirOf (dirOf config.clan.core.vars.generators.secureboot.files."keys/PK/PK.key".path)
   );
 
-  # Create sbctl configuration file pointing to clan vars activation directory
+  # Create sbctl configuration file pointing to the copied keys in /var/lib/sbctl
+  # (not the sops activation directory, which has restrictive 0700 permissions)
   sbctlConfig = pkgs.writeText "sbctl.conf" ''
-    keydir: ${securebootDir}/keys
+    keydir: /var/lib/sbctl/keys
   '';
 in
 {
@@ -51,9 +52,15 @@ in
     '';
   };
 
-  # Also create symlinks in /var/lib/sbctl for runtime sbctl operations
+  # Copy keys to /var/lib/sbctl so sbctl can access them without traversing
+  # the restrictive 0700 sops activation directories (sbctl uses landlock
+  # sandboxing and fails with "permission denied" through symlinks).
   systemd.tmpfiles.rules = [
-    "d /var/lib/sbctl 0755 root root -"
-    "L+ /var/lib/sbctl/keys - - - - ${securebootDir}/keys"
+    "d /var/lib/sbctl 0700 root root -"
   ];
+  system.activationScripts.sbctl-keys.text = ''
+    rm -rf /var/lib/sbctl/keys
+    cp -a ${securebootDir}/keys /var/lib/sbctl/keys
+    chmod -R u+rw /var/lib/sbctl/keys
+  '';
 }

--- a/nixosModules/niri/kwallet-tpm/default.nix
+++ b/nixosModules/niri/kwallet-tpm/default.nix
@@ -38,13 +38,15 @@ in
 
   systemd.user.services.kwallet-tpm-unlock = {
     description = "Unlock KWallet using TPM-sealed credentials";
-    after = [ "dbus.socket" ];
-    before = [ "graphical-session-pre.target" ];
-    wantedBy = [ "graphical-session-pre.target" ];
+    after = [
+      "dbus.socket"
+      "graphical-session.target"
+    ];
+    wantedBy = [ "graphical-session.target" ];
     serviceConfig = {
       Type = "oneshot";
       ExecStart = "${kwallet-tpm-unlock}/bin/kwallet-tpm-unlock %h/.config/kwallet-tpm/password.cred";
-      # Retry once on failure (e.g. kwalletd6 not ready yet)
+      # Retry on failure (e.g. kwalletd6 not ready yet)
       Restart = "on-failure";
       RestartSec = 2;
       RestartMode = "direct";


### PR DESCRIPTION

sbctl uses landlock sandboxing which prevents it from traversing the
0700 sops activation directories through a symlink. Copy the keys to
/var/lib/sbctl/keys with an activation script instead, so both the
limine boot installer and manual sbctl operations work without
permission errors.
