### PR TITLE
live-text: add QR code and barcode scanning

### DIFF
--- a/pkgs/live-text/README.md
+++ b/pkgs/live-text/README.md
@@ -4,9 +4,10 @@ Interactive OCR overlay for Wayland (niri, sway, etc.) — the Linux equivalent 
 macOS Live Text.
 
 Takes a screenshot (or reads an image from stdin/file), runs OCR using RapidOCR
-(PaddleOCR v4 via ONNX Runtime), then shows an interactive overlay where you can
-select text, annotate with arrows/rectangles/text, and copy or save the result.
-OCR runs asynchronously so the overlay appears instantly.
+(PaddleOCR v4 via ONNX Runtime) and scans for QR codes/barcodes using pyzbar
+(zbar), then shows an interactive overlay where you can select text or codes,
+annotate with arrows/rectangles/text, and copy or save the result. OCR and
+barcode scanning run in parallel so the overlay appears instantly.
 
 ## Usage
 
@@ -34,7 +35,7 @@ grim - | live-text -
 
 The toolbar at the bottom lets you switch between four tools:
 
-- **Select** — Click or drag to select OCR-detected words
+- **Select** — Click or drag to select OCR-detected words or QR/barcodes
 - **Arrow** — Draw arrows on the screenshot
 - **Rect** — Draw rectangles on the screenshot
 - **Text** — Click to place text annotations
@@ -67,9 +68,9 @@ for picking the drawing color.
 
 | Key    | Action                                               |
 | ------ | ---------------------------------------------------- |
-| Ctrl+C | Copy selected text, or annotated image if none       |
-| Enter  | Copy selected text, or annotated image if none       |
-| Ctrl+A | Select all detected words                            |
+| Ctrl+C | Copy selected text/codes, or annotated image if none |
+| Enter  | Copy selected text/codes, or annotated image if none |
+| Ctrl+A | Select all detected words and codes                  |
 | Ctrl+S | Save annotated screenshot to ~/Pictures/Screenshots/ |
 | Ctrl+Z | Undo last annotation                                 |
 | Escape | Quit                                                 |
@@ -91,19 +92,22 @@ for picking the drawing color.
 
 ```
 live_text/
+├── barcode.py     # pyzbar (zbar) QR code and barcode scanner
 ├── main.py        # CLI entry point, argument parsing, screenshot dispatch
 ├── ocr.py         # RapidOCR wrapper, word-level bounding box splitting
 ├── overlay.py     # GTK4 Layer Shell overlay (selection + annotation + toolbar)
 └── screenshot.py  # grim/slurp integration, niri/sway output detection
 ```
 
-OCR runs in a background thread — the overlay shows a spinner until text
-detection completes, then word boxes become clickable.
+OCR and barcode scanning run in parallel background threads — the overlay shows
+a spinner until text detection completes, then word boxes and detected codes
+become clickable.
 
 ## Dependencies
 
 - `grim` — Wayland screenshot
 - `rapidocr` — OCR engine (PaddleOCR v4 via ONNX Runtime)
+- `pyzbar` — QR code and barcode detection (via zbar)
 - `wl-copy` — Wayland clipboard
 - `notify-send` — Desktop notifications (save confirmation, no text detected)
 - GTK4 + gtk4-layer-shell — Overlay window

--- a/pkgs/live-text/default.nix
+++ b/pkgs/live-text/default.nix
@@ -4,6 +4,7 @@
   hatchling,
   pygobject3,
   pycairo,
+  pyzbar,
   rapidocr,
   grim,
   slurp,
@@ -14,6 +15,9 @@
   wrapGAppsHook4,
   makeWrapper,
   fetchurl,
+  pytestCheckHook,
+  qrcode,
+  python-barcode,
 }:
 
 let
@@ -37,6 +41,7 @@ buildPythonApplication {
   dependencies = [
     pygobject3
     pycairo
+    pyzbar
     rapidocr
   ];
 
@@ -67,6 +72,12 @@ buildPythonApplication {
       }" \
       --set LIVE_TEXT_REC_MODEL "${en-rec-model}"
   '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    qrcode
+    python-barcode
+  ];
 
   # Tests require a Wayland session; run manually with pytest
   doCheck = false;

--- a/pkgs/live-text/live_text/barcode.py
+++ b/pkgs/live-text/live_text/barcode.py
@@ -1,0 +1,66 @@
+"""QR code and barcode detection using pyzbar (zbar)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CodeBox:
+    """A detected QR code or barcode with bounding box and decoded value."""
+
+    data: str
+    code_type: str  # e.g. "QRCODE", "EAN13", "CODE128"
+    x: int
+    y: int
+    width: int
+    height: int
+
+    @property
+    def x2(self) -> int:
+        return self.x + self.width
+
+    @property
+    def y2(self) -> int:
+        return self.y + self.height
+
+    def contains_point(self, px: float, py: float) -> bool:
+        return self.x <= px <= self.x2 and self.y <= py <= self.y2
+
+    def intersects_rect(self, rx: int, ry: int, rw: int, rh: int) -> bool:
+        return not (
+            self.x2 < rx or self.x > rx + rw or self.y2 < ry or self.y > ry + rh
+        )
+
+
+def scan_codes(image_path: Path) -> list[CodeBox]:
+    """Scan an image for QR codes and barcodes.
+
+    Uses pyzbar (zbar) to detect and decode all barcodes and QR codes
+    in the image.  Returns a list of CodeBox with decoded data and
+    bounding rectangles.
+    """
+    from PIL import Image  # lazy import
+    from pyzbar.pyzbar import decode  # lazy import
+
+    img = Image.open(image_path)
+    results = decode(img)
+
+    codes: list[CodeBox] = []
+    for result in results:
+        data = result.data.decode("utf-8", errors="replace")
+        code_type = result.type
+        rect = result.rect
+        codes.append(
+            CodeBox(
+                data=data,
+                code_type=code_type,
+                x=rect.left,
+                y=rect.top,
+                width=rect.width,
+                height=rect.height,
+            )
+        )
+
+    return codes

--- a/pkgs/live-text/live_text/main.py
+++ b/pkgs/live-text/live_text/main.py
@@ -134,7 +134,7 @@ def _capture_window(stack: contextlib.ExitStack, args: argparse.Namespace) -> Pa
 
 
 def _run_overlay(screenshot_path: Path, wl_copy_cmd: str) -> None:
-    """Open the overlay UI with background OCR."""
+    """Open the overlay UI with background OCR and barcode scanning."""
     overlay = LiveTextOverlay(
         screenshot_path=screenshot_path,
         lines=[],
@@ -151,8 +151,20 @@ def _run_overlay(screenshot_path: Path, wl_copy_cmd: str) -> None:
             lines = []
         overlay.set_lines(lines)
 
-    thread = threading.Thread(target=_ocr_worker, daemon=True)
-    thread.start()
+    def _barcode_worker() -> None:
+        from .barcode import scan_codes
+
+        try:
+            codes = scan_codes(screenshot_path)
+        except Exception as e:
+            print(f"Barcode scan error: {e}", file=sys.stderr)
+            codes = []
+        overlay.set_codes(codes)
+
+    ocr_thread = threading.Thread(target=_ocr_worker, daemon=True)
+    barcode_thread = threading.Thread(target=_barcode_worker, daemon=True)
+    ocr_thread.start()
+    barcode_thread.start()
     overlay.run()
 
 

--- a/pkgs/live-text/live_text/overlay.py
+++ b/pkgs/live-text/live_text/overlay.py
@@ -23,6 +23,7 @@ gi.require_version("Gtk4LayerShell", "1.0")
 
 from gi.repository import Gdk, GLib, Gtk, Gtk4LayerShell  # noqa: E402
 
+from .barcode import CodeBox  # noqa: E402
 from .ocr import LineBox, WordBox  # noqa: E402
 
 # -- constants ----------------------------------------------------------------
@@ -58,6 +59,14 @@ TOOLBAR_ACTIVE_BG = (0.3, 0.5, 0.9, 0.9)
 TOOL_BTN_W = 70.0
 COLOR_BTN_SIZE = 22.0
 HINT_FONT_SIZE = 12.0
+
+# QR / barcode highlights
+CODE_BORDER_COLOR = (0.0, 0.8, 0.4, 0.9)
+CODE_FILL_COLOR = (0.0, 0.8, 0.4, 0.15)
+CODE_SELECTED_FILL = (0.0, 0.8, 0.4, 0.4)
+CODE_LABEL_FONT_SIZE = 11.0
+CODE_LABEL_BG = (0.0, 0.0, 0.0, 0.7)
+CODE_BORDER_WIDTH = 2.0
 
 
 # -- data types ---------------------------------------------------------------
@@ -104,16 +113,19 @@ class LiveTextOverlay:
         screenshot_path: Path,
         lines: list[LineBox],
         wl_copy_cmd: str = "wl-copy",
+        codes: list[CodeBox] | None = None,
     ) -> None:
         self.screenshot_path = screenshot_path
         self.lines = lines
         self.wl_copy_cmd = wl_copy_cmd
+        self.codes: list[CodeBox] = codes or []
 
         # Current tool
         self.tool = Tool.SELECT
 
         # Text selection state
         self.selected_words: set[WordId] = set()
+        self.selected_codes: set[int] = set()  # indices into self.codes
         self._over_text = False
         self._flashing = False
 
@@ -157,11 +169,23 @@ class LiveTextOverlay:
     def _apply_lines(self, lines: list[LineBox]) -> bool:
         """GLib.idle callback: apply OCR results on the main thread."""
         self.lines = lines
+        self.selected_words.clear()  # indices are invalidated by new list
         if self._spinner_timer is not None:
             GLib.source_remove(self._spinner_timer)
             self._spinner_timer = None
         self._drawing_area.queue_draw()
         return False  # don't repeat
+
+    def set_codes(self, codes: list[CodeBox]) -> None:
+        """Update detected codes from a background thread. Thread-safe."""
+        GLib.idle_add(self._apply_codes, codes)
+
+    def _apply_codes(self, codes: list[CodeBox]) -> bool:
+        """GLib.idle callback: apply barcode results on the main thread."""
+        self.codes = codes
+        self.selected_codes.clear()  # indices are invalidated by new list
+        self._drawing_area.queue_draw()
+        return False
 
     def run(self) -> None:
         self.app.run([])
@@ -256,6 +280,13 @@ class LiveTextOverlay:
                     return (li, wi)
         return None
 
+    def _hit_code(self, ix: float, iy: float) -> int | None:
+        """Return the index of the code at image coords, or None."""
+        for ci, code in enumerate(self.codes):
+            if code.contains_point(ix, iy):
+                return ci
+        return None
+
     # -- drawing --------------------------------------------------------------
 
     def _draw(
@@ -283,6 +314,39 @@ class LiveTextOverlay:
             for li, wi in self.selected_words:
                 cr.rectangle(*_word_rect(self.lines[li].words[wi]))
             cr.fill()
+
+        # QR / barcode overlays
+        for ci, code in enumerate(self.codes):
+            is_selected = ci in self.selected_codes
+            # Fill
+            if is_selected and self._flashing:
+                cr.set_source_rgba(0.0, 0.8, 0.4, 0.6)
+            elif is_selected:
+                cr.set_source_rgba(*CODE_SELECTED_FILL)
+            else:
+                cr.set_source_rgba(*CODE_FILL_COLOR)
+            cr.rectangle(code.x, code.y, code.width, code.height)
+            cr.fill()
+            # Border
+            cr.set_source_rgba(*CODE_BORDER_COLOR)
+            cr.set_line_width(CODE_BORDER_WIDTH / scale)
+            cr.rectangle(code.x, code.y, code.width, code.height)
+            cr.stroke()
+            # Label (type + truncated data)
+            label = code.code_type
+            preview = code.data[:40] + ("…" if len(code.data) > 40 else "")
+            label_text = f"{label}: {preview}"
+            cr.set_font_size(CODE_LABEL_FONT_SIZE)
+            ext = cr.text_extents(label_text)
+            lx = code.x
+            ly = code.y - 4  # above the box
+            # Background pill for readability
+            cr.set_source_rgba(*CODE_LABEL_BG)
+            cr.rectangle(lx - 2, ly - ext.height - 2, ext.width + 6, ext.height + 4)
+            cr.fill()
+            cr.set_source_rgba(0.0, 1.0, 0.5, 1.0)
+            cr.move_to(lx, ly)
+            cr.show_text(label_text)
 
         # Committed annotations
         for ann in self.annotations:
@@ -386,10 +450,14 @@ class LiveTextOverlay:
             if not self.lines and self._spinner_timer is not None:
                 frame = SPINNER_FRAMES[self._spinner_idx]
                 hint = f"{frame} Detecting text…  · Ctrl+S save · Esc quit"
-            elif not self.lines:
+            elif not self.lines and not self.codes:
                 hint = "No text detected  · Ctrl+S save · Esc quit"
             else:
-                hint = "Ctrl+C copy text · Ctrl+S save · Ctrl+A select all · Esc quit"
+                n_codes = len(self.codes)
+                code_hint = (
+                    f" · {n_codes} code{'s' if n_codes != 1 else ''}" if n_codes else ""
+                )
+                hint = f"Ctrl+C copy · Ctrl+S save · Ctrl+A select all{code_hint} · Esc quit"
         else:
             hint = "Ctrl+C copy image · Ctrl+S save · Ctrl+Z undo · Esc quit"
         cr.set_source_rgba(1, 1, 1, 0.6)
@@ -406,7 +474,7 @@ class LiveTextOverlay:
         if self.tool != Tool.SELECT:
             return
         ix, iy = self._widget_to_image(x, y)
-        over = self._hit_word(ix, iy) is not None
+        over = self._hit_word(ix, iy) is not None or self._hit_code(ix, iy) is not None
         if over != self._over_text:
             self._over_text = over
             self._drawing_area.set_cursor(
@@ -508,12 +576,15 @@ class LiveTextOverlay:
         )
 
         self.selected_words.clear()
+        self.selected_codes.clear()
+        rect = (int(ix1), int(iy1), int(ix2 - ix1), int(iy2 - iy1))
         for li, line in enumerate(self.lines):
             for wi, word in enumerate(line.words):
-                if word.intersects_rect(
-                    int(ix1), int(iy1), int(ix2 - ix1), int(iy2 - iy1)
-                ):
+                if word.intersects_rect(*rect):
                     self.selected_words.add((li, wi))
+        for ci, code in enumerate(self.codes):
+            if code.intersects_rect(*rect):
+                self.selected_codes.add(ci)
         self._drawing_area.queue_draw()
 
     def _end_select(self, offset_x: float, offset_y: float) -> None:
@@ -528,15 +599,24 @@ class LiveTextOverlay:
         rx = self.drag_start_x + offset_x
         ry = self.drag_start_y + offset_y
         ix, iy = self._widget_to_image(rx, ry)
-        clicked = self._hit_word(ix, iy)
+        clicked_word = self._hit_word(ix, iy)
+        clicked_code = self._hit_code(ix, iy)
 
-        if clicked is not None:
+        if clicked_word is not None:
             if self._drag_shift:
-                self.selected_words.symmetric_difference_update({clicked})
+                self.selected_words.symmetric_difference_update({clicked_word})
             else:
-                self.selected_words = {clicked}
+                self.selected_words = {clicked_word}
+                self.selected_codes.clear()
+        elif clicked_code is not None:
+            if self._drag_shift:
+                self.selected_codes.symmetric_difference_update({clicked_code})
+            else:
+                self.selected_codes = {clicked_code}
+                self.selected_words.clear()
         else:
             self.selected_words.clear()
+            self.selected_codes.clear()
         self._drawing_area.queue_draw()
 
     # -- toolbar --------------------------------------------------------------
@@ -622,14 +702,14 @@ class LiveTextOverlay:
             return True
 
         if ctrl and keyval == Gdk.KEY_c:
-            if self.selected_words:
+            if self._has_selection():
                 self._copy_selected_text()
             else:
                 self._copy_annotated_image()
             return True
 
         if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
-            if self.selected_words:
+            if self._has_selection():
                 self._copy_selected_text()
             else:
                 self._copy_annotated_image()
@@ -652,6 +732,7 @@ class LiveTextOverlay:
                 for li, line in enumerate(self.lines)
                 for wi in range(len(line.words))
             }
+            self.selected_codes = set(range(len(self.codes)))
             self._drawing_area.queue_draw()
             return True
 
@@ -664,13 +745,21 @@ class LiveTextOverlay:
         self._drawing_area.queue_draw()
         return False
 
+    def _has_selection(self) -> bool:
+        return bool(self.selected_words) or bool(self.selected_codes)
+
     def _copy_selected_text(self) -> None:
-        if not self.selected_words:
+        if not self._has_selection():
             return
-        line_texts: dict[int, list[str]] = {}
-        for li, wi in sorted(self.selected_words):
-            line_texts.setdefault(li, []).append(self.lines[li].words[wi].text)
-        text = "\n".join(" ".join(words) for words in line_texts.values())
+        parts: list[str] = []
+        if self.selected_words:
+            line_texts: dict[int, list[str]] = {}
+            for li, wi in sorted(self.selected_words):
+                line_texts.setdefault(li, []).append(self.lines[li].words[wi].text)
+            parts.append("\n".join(" ".join(words) for words in line_texts.values()))
+        for ci in sorted(self.selected_codes):
+            parts.append(self.codes[ci].data)
+        text = "\n".join(parts)
         try:
             subprocess.run([self.wl_copy_cmd], input=text.encode(), check=True)
         except (subprocess.CalledProcessError, FileNotFoundError) as e:

--- a/pkgs/live-text/pyproject.toml
+++ b/pkgs/live-text/pyproject.toml
@@ -12,6 +12,7 @@ license = {text = "MIT"}
 dependencies = [
     "PyGObject",
     "pycairo",
+    "pyzbar",
     "rapidocr",
 ]
 
@@ -21,6 +22,8 @@ live-text = "live_text.main:main"
 [project.optional-dependencies]
 test = [
     "pytest>=7.0",
+    "qrcode",
+    "python-barcode[images]",
 ]
 
 [tool.pytest.ini_options]
@@ -34,5 +37,5 @@ target-version = "py313"
 python_version = "3.13"
 
 [[tool.mypy.overrides]]
-module = ["gi", "gi.repository", "cairo", "rapidocr"]
+module = ["gi", "gi.*", "cairo", "pyzbar", "pyzbar.*", "rapidocr", "PIL", "PIL.*", "pytest"]
 ignore_missing_imports = true

--- a/pkgs/live-text/tests/test_barcode.py
+++ b/pkgs/live-text/tests/test_barcode.py
@@ -1,0 +1,166 @@
+"""Tests for QR code and barcode detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from live_text.barcode import CodeBox, scan_codes
+
+
+def _code(
+    data: str = "https://example.com",
+    code_type: str = "QRCODE",
+    x: int = 10,
+    y: int = 20,
+    width: int = 100,
+    height: int = 100,
+) -> CodeBox:
+    """Create a CodeBox with sensible defaults for tests."""
+    return CodeBox(data=data, code_type=code_type, x=x, y=y, width=width, height=height)
+
+
+class TestCodeBox:
+    def test_contains_point(self) -> None:
+        c = _code(x=10, y=20, width=100, height=80)
+        assert c.contains_point(50, 50)  # inside
+        assert c.contains_point(10, 20)  # top-left edge
+        assert c.contains_point(110, 100)  # bottom-right edge
+        assert not c.contains_point(5, 50)  # left of
+        assert not c.contains_point(50, 105)  # below
+
+    def test_intersects_rect(self) -> None:
+        c = _code(x=10, y=20, width=100, height=80)
+        assert c.intersects_rect(0, 0, 200, 200)  # containing
+        assert c.intersects_rect(50, 50, 10, 10)  # inside code
+        assert c.intersects_rect(100, 90, 30, 30)  # partial overlap
+        assert not c.intersects_rect(120, 110, 50, 50)  # no overlap
+        assert not c.intersects_rect(0, 0, 5, 5)  # completely left/above
+
+
+def _has_pyzbar() -> bool:
+    try:
+        from pyzbar.pyzbar import decode  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _has_pillow() -> bool:
+    try:
+        from PIL import Image  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(
+    not (_has_pyzbar() and _has_pillow()), reason="pyzbar or Pillow not installed"
+)
+class TestScanCodes:
+    def test_no_codes_on_blank_image(self, tmp_path: Path) -> None:
+        """A blank white image should produce no codes."""
+        from PIL import Image
+
+        blank = Image.new("RGB", (200, 200), "white")
+        blank_path = tmp_path / "blank.png"
+        blank.save(str(blank_path))
+
+        codes = scan_codes(blank_path)
+        assert codes == []
+
+    def test_detects_qr_code(self, tmp_path: Path) -> None:
+        """Generate a QR code image and verify it's detected with correct data."""
+        qrcode = pytest.importorskip("qrcode")
+
+        qr = qrcode.QRCode(version=1, box_size=10, border=4)
+        qr.add_data("https://example.com/test")
+        qr.make(fit=True)
+        img = qr.make_image(fill_color="black", back_color="white")
+        qr_path = tmp_path / "qr.png"
+        img.save(str(qr_path))
+
+        codes = scan_codes(qr_path)
+        assert len(codes) == 1
+        assert codes[0].data == "https://example.com/test"
+        assert codes[0].code_type == "QRCODE"
+        assert codes[0].width > 0
+        assert codes[0].height > 0
+
+    def test_detects_barcode(self, tmp_path: Path) -> None:
+        """Generate a Code128 barcode and verify detection."""
+        barcode_mod = pytest.importorskip("barcode")
+
+        code128 = barcode_mod.get(
+            "code128", "TEST12345", writer=barcode_mod.writer.ImageWriter()
+        )
+        barcode_path = tmp_path / "barcode"
+        saved_path = code128.save(str(barcode_path))
+
+        codes = scan_codes(Path(saved_path))
+        assert len(codes) >= 1
+        assert any("TEST12345" in c.data for c in codes)
+
+    def test_multiple_qr_codes(self, tmp_path: Path) -> None:
+        """An image with two QR codes should detect both."""
+        qrcode = pytest.importorskip("qrcode")
+        from PIL import Image
+
+        qr1 = qrcode.QRCode(version=1, box_size=5, border=2)
+        qr1.add_data("CODE_ONE")
+        qr1.make(fit=True)
+        img1 = qr1.make_image(fill_color="black", back_color="white").get_image()
+
+        qr2 = qrcode.QRCode(version=1, box_size=5, border=2)
+        qr2.add_data("CODE_TWO")
+        qr2.make(fit=True)
+        img2 = qr2.make_image(fill_color="black", back_color="white").get_image()
+
+        # Compose side by side on a white canvas
+        w1, h1 = img1.size
+        w2, h2 = img2.size
+        canvas = Image.new("RGB", (w1 + w2 + 40, max(h1, h2) + 20), "white")
+        canvas.paste(img1, (10, 10))
+        canvas.paste(img2, (w1 + 30, 10))
+        composite_path = tmp_path / "multi_qr.png"
+        canvas.save(str(composite_path))
+
+        codes = scan_codes(composite_path)
+        decoded_data = {c.data for c in codes}
+        assert "CODE_ONE" in decoded_data
+        assert "CODE_TWO" in decoded_data
+
+    def test_bounding_boxes_dont_overlap_for_separate_codes(
+        self, tmp_path: Path
+    ) -> None:
+        """Two QR codes placed far apart should have non-overlapping boxes."""
+        qrcode = pytest.importorskip("qrcode")
+        from PIL import Image
+
+        qr1 = qrcode.QRCode(version=1, box_size=5, border=2)
+        qr1.add_data("LEFT")
+        qr1.make(fit=True)
+        img1 = qr1.make_image(fill_color="black", back_color="white").get_image()
+
+        qr2 = qrcode.QRCode(version=1, box_size=5, border=2)
+        qr2.add_data("RIGHT")
+        qr2.make(fit=True)
+        img2 = qr2.make_image(fill_color="black", back_color="white").get_image()
+
+        w1, h1 = img1.size
+        w2, h2 = img2.size
+        gap = 200
+        canvas = Image.new("RGB", (w1 + w2 + gap, max(h1, h2) + 20), "white")
+        canvas.paste(img1, (10, 10))
+        canvas.paste(img2, (w1 + gap, 10))
+        path = tmp_path / "separated.png"
+        canvas.save(str(path))
+
+        codes = scan_codes(path)
+        assert len(codes) == 2
+        # Boxes should not overlap: one should be entirely left of the other
+        left, right = sorted(codes, key=lambda c: c.x)
+        assert left.x2 < right.x

--- a/pkgs/live-text/tests/test_overlay.py
+++ b/pkgs/live-text/tests/test_overlay.py
@@ -1,8 +1,19 @@
-"""Tests for overlay text assembly logic."""
+"""Tests for overlay selection and copy logic.
+
+These tests exercise the actual LiveTextOverlay state machine — selection,
+clipboard assembly, and code/word interaction — by manipulating state directly
+rather than duplicating the logic in a test helper.
+"""
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from live_text.barcode import CodeBox
 from live_text.ocr import LineBox, WordBox
+from live_text.overlay import LiveTextOverlay
 
 
 def _w(text: str, x: int, y: int, w: int, h: int) -> WordBox:
@@ -34,37 +45,164 @@ def _make_lines() -> list[LineBox]:
     ]
 
 
-def _assemble_text(lines: list[LineBox], selected: set[tuple[int, int]]) -> str:
-    """Reproduce the overlay's _copy_selection text assembly."""
-    line_texts: dict[int, list[str]] = {}
-    for li, wi in sorted(selected):
-        line_texts.setdefault(li, []).append(lines[li].words[wi].text)
-    return "\n".join(" ".join(words) for words in line_texts.values())
+def _make_codes() -> list[CodeBox]:
+    return [
+        CodeBox("https://example.com", "QRCODE", 300, 50, 100, 100),
+        CodeBox("1234567890", "EAN13", 300, 200, 150, 60),
+    ]
 
 
-class TestSelectedTextAssembly:
-    """Test the word-level text assembly logic mirroring _copy_selection."""
+def _make_overlay(
+    lines: list[LineBox] | None = None,
+    codes: list[CodeBox] | None = None,
+) -> LiveTextOverlay:
+    """Create an overlay with test data, without starting the GTK app."""
+    return LiveTextOverlay(
+        screenshot_path=Path("/dev/null"),
+        lines=lines or [],
+        wl_copy_cmd="wl-copy",
+        codes=codes,
+    )
 
-    def test_single_word(self) -> None:
+
+class TestCopySelectedText:
+    """Test _copy_selected_text sends the right data to wl-copy."""
+
+    def _copy_and_capture(self, overlay: LiveTextOverlay) -> str:
+        """Run _copy_selected_text and return what was sent to wl-copy."""
+        captured: bytes = b""
+
+        def fake_run(
+            cmd: list[str], **kwargs: object
+        ) -> subprocess.CompletedProcess[bytes]:
+            nonlocal captured
+            captured = kwargs.get("input", b"")  # type: ignore[assignment]
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with patch("live_text.overlay.subprocess.run", side_effect=fake_run):
+            # Suppress GLib.timeout_add (no GTK main loop in tests)
+            with patch("live_text.overlay.GLib.timeout_add"):
+                overlay._drawing_area = MagicMock()
+                overlay._copy_selected_text()
+        return captured.decode()
+
+    def test_copies_single_word(self) -> None:
+        overlay = _make_overlay(lines=_make_lines())
+        overlay.selected_words = {(0, 0)}
+        assert self._copy_and_capture(overlay) == "Hello"
+
+    def test_copies_words_across_lines(self) -> None:
+        overlay = _make_overlay(lines=_make_lines())
+        overlay.selected_words = {(0, 1), (2, 0)}
+        assert self._copy_and_capture(overlay) == "World\nLive"
+
+    def test_copies_full_text(self) -> None:
         lines = _make_lines()
-        assert _assemble_text(lines, {(0, 0)}) == "Hello"
-
-    def test_partial_line_selection(self) -> None:
-        lines = _make_lines()
-        # Select "is a" from the second line
-        assert _assemble_text(lines, {(1, 1), (1, 2)}) == "is a"
-
-    def test_words_across_lines(self) -> None:
-        lines = _make_lines()
-        # Select "World" from line 0 and "Live" from line 2
-        selected = {(0, 1), (2, 0)}
-        assert _assemble_text(lines, selected) == "World\nLive"
-
-    def test_full_selection_sorted(self) -> None:
-        lines = _make_lines()
-        # Select all words
-        selected = {
+        overlay = _make_overlay(lines=lines)
+        overlay.selected_words = {
             (li, wi) for li, line in enumerate(lines) for wi in range(len(line.words))
         }
-        text = _assemble_text(lines, selected)
-        assert text == "Hello World\nThis is a test\nLive Text"
+        assert (
+            self._copy_and_capture(overlay) == "Hello World\nThis is a test\nLive Text"
+        )
+
+    def test_copies_single_code(self) -> None:
+        overlay = _make_overlay(codes=_make_codes())
+        overlay.selected_codes = {0}
+        assert self._copy_and_capture(overlay) == "https://example.com"
+
+    def test_copies_multiple_codes(self) -> None:
+        overlay = _make_overlay(codes=_make_codes())
+        overlay.selected_codes = {0, 1}
+        assert self._copy_and_capture(overlay) == "https://example.com\n1234567890"
+
+    def test_copies_words_and_codes_together(self) -> None:
+        overlay = _make_overlay(lines=_make_lines(), codes=_make_codes())
+        overlay.selected_words = {(0, 0)}
+        overlay.selected_codes = {1}
+        text = self._copy_and_capture(overlay)
+        assert text == "Hello\n1234567890"
+
+    def test_nothing_copied_when_no_selection(self) -> None:
+        overlay = _make_overlay(lines=_make_lines(), codes=_make_codes())
+        with patch("live_text.overlay.subprocess.run") as mock_run:
+            overlay._drawing_area = MagicMock()
+            overlay._copy_selected_text()
+            mock_run.assert_not_called()
+
+
+class TestHitDetection:
+    """Test that _hit_word and _hit_code find the right targets."""
+
+    def test_hit_word(self) -> None:
+        overlay = _make_overlay(lines=_make_lines())
+        # Click inside "World" (x=70..125, y=50..65)
+        assert overlay._hit_word(80, 55) == (0, 1)
+        # Click inside "test" (x=107..147, y=100..115)
+        assert overlay._hit_word(120, 105) == (1, 3)
+        # Click on empty space
+        assert overlay._hit_word(200, 200) is None
+
+    def test_hit_code(self) -> None:
+        overlay = _make_overlay(codes=_make_codes())
+        # Click inside first code (x=300..400, y=50..150)
+        assert overlay._hit_code(350, 100) == 0
+        # Click inside second code (x=300..450, y=200..260)
+        assert overlay._hit_code(400, 230) == 1
+        # Click on empty space
+        assert overlay._hit_code(10, 10) is None
+
+    def test_word_takes_priority_when_overlapping_code(self) -> None:
+        """When a word and code overlap, clicking should find both independently."""
+        lines = [LineBox(words=(_w("overlap", 300, 50, 80, 15),))]
+        codes = [CodeBox("data", "QRCODE", 300, 50, 100, 100)]
+        overlay = _make_overlay(lines=lines, codes=codes)
+        # Both should be detectable at same coords
+        assert overlay._hit_word(340, 55) == (0, 0)
+        assert overlay._hit_code(340, 55) == 0
+
+
+class TestHasSelection:
+    def test_no_selection(self) -> None:
+        overlay = _make_overlay(lines=_make_lines(), codes=_make_codes())
+        assert not overlay._has_selection()
+
+    def test_word_selected(self) -> None:
+        overlay = _make_overlay(lines=_make_lines())
+        overlay.selected_words = {(0, 0)}
+        assert overlay._has_selection()
+
+    def test_code_selected(self) -> None:
+        overlay = _make_overlay(codes=_make_codes())
+        overlay.selected_codes = {0}
+        assert overlay._has_selection()
+
+
+class TestSetCodes:
+    """Test that set_codes invalidates stale selections."""
+
+    def test_clears_selected_codes_on_update(self) -> None:
+        overlay = _make_overlay(codes=_make_codes())
+        overlay.selected_codes = {0, 1}
+
+        new_codes = [CodeBox("new", "QRCODE", 0, 0, 50, 50)]
+        overlay._drawing_area = MagicMock()
+        overlay._apply_codes(new_codes)
+
+        assert overlay.codes == new_codes
+        assert overlay.selected_codes == set()
+
+
+class TestSetLines:
+    """Test that set_lines invalidates stale selections."""
+
+    def test_clears_selected_words_on_update(self) -> None:
+        overlay = _make_overlay(lines=_make_lines())
+        overlay.selected_words = {(0, 0), (1, 3)}
+
+        new_lines = [LineBox(words=(_w("New", 0, 0, 30, 10),))]
+        overlay._drawing_area = MagicMock()
+        overlay._apply_lines(new_lines)
+
+        assert overlay.lines == new_lines
+        assert overlay.selected_words == set()


### PR DESCRIPTION

Screenshots often contain QR codes and barcodes that users want to copy
just as much as text. Running pyzbar in parallel with OCR detects these
instantly and presents them as selectable overlay elements with the same
click-to-select, Ctrl+C-to-copy workflow as OCR words.

Clear stale selected_words/selected_codes indices when background
threads deliver new results, preventing IndexError crashes if the user
could somehow select items before the async workers finish.

Overlay tests now exercise the real LiveTextOverlay methods instead of
duplicating the clipboard assembly logic in a test helper.


