### PR TITLE
noctalia-shell: add alertmanager bar widget plugin

### DIFF
--- a/home/.config/noctalia/plugins/alertmanager/BarWidget.qml
+++ b/home/.config/noctalia/plugins/alertmanager/BarWidget.qml
@@ -1,0 +1,101 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import qs.Commons
+import qs.Modules.Bar.Extras
+import qs.Services.UI
+import qs.Widgets
+
+Item {
+  id: root
+
+  property var pluginApi: null
+  property var alertService: pluginApi?.mainInstance?.alertService || null
+
+  property ShellScreen screen
+  property string widgetId: ""
+  property string section: ""
+
+  property var cfg: pluginApi?.pluginSettings || ({})
+  property var defaults: pluginApi?.manifest?.metadata?.defaultSettings || ({})
+
+  readonly property string iconColorKey: cfg.iconColor ?? defaults.iconColor
+  readonly property int alertCount: alertService?.alertCount ?? 0
+  readonly property string fetchState: alertService?.fetchState ?? "idle"
+
+  readonly property string screenName: screen ? screen.name : ""
+  readonly property string barPosition: Settings.getBarPositionForScreen(screenName)
+  readonly property bool isVerticalBar: barPosition === "left" || barPosition === "right"
+
+  readonly property string currentIcon: {
+    if (fetchState === "loading") return "loader";
+    if (fetchState === "error") return "alert-triangle";
+    if (alertCount > 0) return "alert-circle";
+    return "circle-check";
+  }
+
+  readonly property color iconColor: {
+    if (fetchState === "error") return Color.mError;
+    if (alertCount > 0) return Color.mError;
+    return Color.resolveColorKey(iconColorKey);
+  }
+
+  implicitWidth: pill.width
+  implicitHeight: pill.height
+
+  BarPill {
+    id: pill
+    screen: root.screen
+    oppositeDirection: BarService.getPillDirection(root)
+    icon: root.currentIcon
+    text: root.alertCount.toString()
+    forceOpen: root.alertCount > 0
+    autoHide: true
+    customTextIconColor: root.iconColor
+
+    onClicked: {
+      if (pluginApi) {
+        pluginApi.openPanel(root.screen, root);
+      }
+    }
+
+    onRightClicked: {
+      PanelService.showContextMenu(contextMenu, root, screen);
+    }
+  }
+
+  NPopupContextMenu {
+    id: contextMenu
+
+    model: [
+      {
+        "label": "Refresh",
+        "action": "refresh",
+        "icon": "refresh"
+      },
+      {
+        "label": "Open Alertmanager",
+        "action": "open-url",
+        "icon": "external-link"
+      },
+      {
+        "label": "Settings",
+        "action": "settings",
+        "icon": "settings"
+      }
+    ]
+
+    onTriggered: function(action) {
+      contextMenu.close();
+      PanelService.closeContextMenu(screen);
+      if (action === "refresh") {
+        alertService?.fetchAlerts();
+      } else if (action === "open-url") {
+        var url = cfg.alertmanagerUrl ?? defaults.alertmanagerUrl;
+        Qt.openUrlExternally(url);
+      } else if (action === "settings") {
+        BarService.openPluginSettings(root.screen, pluginApi.manifest);
+      }
+    }
+  }
+}

--- a/home/.config/noctalia/plugins/alertmanager/Main.qml
+++ b/home/.config/noctalia/plugins/alertmanager/Main.qml
@@ -1,0 +1,104 @@
+import QtQuick
+import Quickshell.Io
+import qs.Commons
+
+Item {
+  id: root
+
+  property var pluginApi: null
+
+  // Expose service to bar widget via mainInstance
+  property alias alertService: alertService
+
+  QtObject {
+    id: alertService
+
+    property var activeAlerts: []
+    property int alertCount: 0
+    property string fetchState: "idle" // "idle", "loading", "success", "error"
+    property string errorMessage: ""
+
+    function fetchAlerts() {
+      var cfg = pluginApi?.pluginSettings || {};
+      var defaults = pluginApi?.manifest?.metadata?.defaultSettings || {};
+      var url = cfg.alertmanagerUrl ?? defaults.alertmanagerUrl;
+
+      fetchState = "loading";
+
+      var fetchCmd = "wget -q -O - '" + url + "/api/v2/alerts' 2>/dev/null";
+
+      fetchProcess.command = ["sh", "-c", fetchCmd];
+      fetchProcess.running = true;
+    }
+  }
+
+  Process {
+    id: fetchProcess
+    stdout: StdioCollector {}
+
+    onExited: function(exitCode) {
+      if (exitCode !== 0) {
+        alertService.fetchState = "error";
+        alertService.errorMessage = "Failed to fetch alerts (exit " + exitCode + ")";
+        Logger.w("Alertmanager", "Fetch failed with exit code:", exitCode);
+        return;
+      }
+
+      var response = stdout.text;
+      if (!response || response.trim() === "") {
+        alertService.fetchState = "error";
+        alertService.errorMessage = "Empty response";
+        return;
+      }
+
+      try {
+        var alerts = JSON.parse(response);
+        if (Array.isArray(alerts)) {
+          // Filter: active, not silenced, not inhibited, not muted
+          var active = alerts.filter(function(alert) {
+            return alert.status.state === "active"
+                && alert.status.silencedBy.length === 0
+                && alert.status.inhibitedBy.length === 0
+                && (!alert.status.mutedBy || alert.status.mutedBy.length === 0);
+          });
+          alertService.activeAlerts = active;
+          alertService.alertCount = active.length;
+          alertService.fetchState = "success";
+          Logger.d("Alertmanager", "Fetched", active.length, "active alerts");
+        }
+      } catch (e) {
+        alertService.fetchState = "error";
+        alertService.errorMessage = "Parse error: " + e;
+        Logger.e("Alertmanager", "Failed to parse alerts:", e);
+      }
+    }
+  }
+
+  Timer {
+    id: pollTimer
+    repeat: true
+    running: pluginApi !== null
+    triggeredOnStart: true
+    interval: {
+      var cfg = pluginApi?.pluginSettings || {};
+      var defaults = pluginApi?.manifest?.metadata?.defaultSettings || {};
+      var secs = cfg.pollInterval ?? defaults.pollInterval;
+      return secs * 1000;
+    }
+    onTriggered: alertService.fetchAlerts()
+  }
+
+  IpcHandler {
+    target: "plugin:alertmanager"
+    function refresh() {
+      alertService.fetchAlerts();
+    }
+    function toggle() {
+      if (pluginApi) {
+        pluginApi.withCurrentScreen(function(screen) {
+          pluginApi.togglePanel(screen);
+        });
+      }
+    }
+  }
+}

--- a/home/.config/noctalia/plugins/alertmanager/Panel.qml
+++ b/home/.config/noctalia/plugins/alertmanager/Panel.qml
@@ -1,0 +1,188 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Widgets
+
+Item {
+  id: root
+
+  property var pluginApi: null
+  property var alertService: pluginApi?.mainInstance?.alertService || null
+
+  readonly property var activeAlerts: alertService?.activeAlerts ?? []
+  readonly property int alertCount: alertService?.alertCount ?? 0
+  readonly property string fetchState: alertService?.fetchState ?? "idle"
+
+  implicitWidth: 420
+  implicitHeight: contentColumn.implicitHeight + Style.marginL * 2
+
+  ColumnLayout {
+    id: contentColumn
+    anchors.fill: parent
+    anchors.margins: Style.marginL
+    spacing: Style.marginM
+
+    // Header
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: Style.marginM
+
+      NIcon {
+        icon: root.alertCount > 0 ? "alert-circle" : "circle-check"
+        pointSize: Style.fontSizeXL
+        color: root.alertCount > 0 ? Color.mError : Color.mPrimary
+      }
+
+      NText {
+        text: {
+          if (root.fetchState === "error")
+            return "Error fetching alerts";
+          if (root.alertCount === 0)
+            return "All clear — no active alerts";
+          return root.alertCount + " active alert" + (root.alertCount !== 1 ? "s" : "");
+        }
+        font.pixelSize: Style.fontSizeL
+        font.bold: true
+        color: Color.mOnSurface
+        Layout.fillWidth: true
+      }
+
+      NIconButton {
+        icon: "refresh"
+        baseSize: 32
+        tooltipText: "Refresh"
+        onClicked: alertService?.fetchAlerts()
+      }
+
+      NIconButton {
+        icon: "external-link"
+        baseSize: 32
+        tooltipText: "Open Alertmanager"
+        onClicked: {
+          var cfg = pluginApi?.pluginSettings || {};
+          var defaults = pluginApi?.manifest?.metadata?.defaultSettings || {};
+          var url = cfg.alertmanagerUrl ?? defaults.alertmanagerUrl;
+          Qt.openUrlExternally(url);
+        }
+      }
+    }
+
+    NDivider {}
+
+    // Alert list
+    Flickable {
+      Layout.fillWidth: true
+      Layout.fillHeight: true
+      Layout.preferredHeight: Math.min(alertList.implicitHeight, 400)
+      contentHeight: alertList.implicitHeight
+      clip: true
+
+      ColumnLayout {
+        id: alertList
+        width: parent.width
+        spacing: Style.marginS
+
+        // Error state
+        NText {
+          visible: root.fetchState === "error"
+          text: alertService?.errorMessage ?? "Unknown error"
+          color: Color.mError
+          Layout.fillWidth: true
+          wrapMode: Text.WordWrap
+        }
+
+        // Empty state
+        NText {
+          visible: root.fetchState === "success" && root.alertCount === 0
+          text: "✅ No active alerts"
+          color: Color.mOnSurfaceVariant
+          Layout.fillWidth: true
+          horizontalAlignment: Text.AlignHCenter
+          font.pixelSize: Style.fontSizeL
+        }
+
+        // Alert items
+        Repeater {
+          model: root.activeAlerts
+
+          delegate: Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: alertItemColumn.implicitHeight + Style.marginM * 2
+            radius: Style.radiusM
+            color: Color.mSurfaceVariant
+
+            ColumnLayout {
+              id: alertItemColumn
+              anchors.fill: parent
+              anchors.margins: Style.marginM
+              spacing: Style.marginXS
+
+              RowLayout {
+                Layout.fillWidth: true
+                spacing: Style.marginS
+
+                NIcon {
+                  icon: {
+                    var severity = modelData.labels.severity || "warning";
+                    if (severity === "critical") return "alert-octagon";
+                    if (severity === "warning") return "alert-triangle";
+                    return "info";
+                  }
+                  pointSize: Style.fontSizeM
+                  color: {
+                    var severity = modelData.labels.severity || "warning";
+                    if (severity === "critical") return Color.mError;
+                    if (severity === "warning") return Color.mTertiary;
+                    return Color.mPrimary;
+                  }
+                }
+
+                NText {
+                  text: modelData.labels.alertname || "Unknown"
+                  font.bold: true
+                  font.pixelSize: Style.fontSizeM
+                  color: Color.mOnSurface
+                  Layout.fillWidth: true
+                }
+
+                NText {
+                  text: modelData.labels.host || modelData.labels.instance || ""
+                  font.pixelSize: Style.fontSizeS
+                  color: Color.mOnSurfaceVariant
+                }
+              }
+
+              NText {
+                visible: text !== ""
+                text: {
+                  if (modelData.annotations) {
+                    return modelData.annotations.description
+                      || modelData.annotations.summary
+                      || "";
+                  }
+                  return "";
+                }
+                font.pixelSize: Style.fontSizeS
+                color: Color.mOnSurfaceVariant
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                maximumLineCount: 3
+                elide: Text.ElideRight
+              }
+            }
+
+            MouseArea {
+              anchors.fill: parent
+              cursorShape: Qt.PointingHandCursor
+              onClicked: {
+                if (modelData.generatorURL) {
+                  Qt.openUrlExternally(modelData.generatorURL);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/home/.config/noctalia/plugins/alertmanager/Settings.qml
+++ b/home/.config/noctalia/plugins/alertmanager/Settings.qml
@@ -1,0 +1,62 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Widgets
+
+ColumnLayout {
+  id: root
+
+  property var pluginApi: null
+
+  property var cfg: pluginApi?.pluginSettings || ({})
+  property var defaults: pluginApi?.manifest?.metadata?.defaultSettings || ({})
+
+  spacing: Style.marginM
+
+  NHeader {
+    text: "Alertmanager Settings"
+    Layout.fillWidth: true
+  }
+
+  NDivider {}
+
+  NLabel {
+    text: "Alertmanager URL"
+  }
+
+  NTextInput {
+    Layout.fillWidth: true
+    text: cfg.alertmanagerUrl ?? defaults.alertmanagerUrl
+    placeholderText: "http://alertmanager.r"
+    onEditingFinished: {
+      cfg.alertmanagerUrl = text;
+      pluginApi?.saveSettings();
+    }
+  }
+
+  NLabel {
+    text: "Poll interval (seconds)"
+  }
+
+  NSpinBox {
+    from: 5
+    to: 3600
+    value: cfg.pollInterval ?? defaults.pollInterval
+    onValueModified: {
+      cfg.pollInterval = value;
+      pluginApi?.saveSettings();
+    }
+  }
+
+  NLabel {
+    text: "Icon color"
+  }
+
+  NColorChoice {
+    selectedColor: cfg.iconColor ?? defaults.iconColor
+    onColorSelected: function(color) {
+      cfg.iconColor = color;
+      pluginApi?.saveSettings();
+    }
+  }
+}

--- a/home/.config/noctalia/plugins/alertmanager/i18n/en.json
+++ b/home/.config/noctalia/plugins/alertmanager/i18n/en.json
@@ -1,0 +1,10 @@
+{
+  "widget": {
+    "tooltip": "Alertmanager"
+  },
+  "menu": {
+    "settings": "Settings",
+    "refresh": "Refresh",
+    "open-alertmanager": "Open Alertmanager"
+  }
+}

--- a/home/.config/noctalia/plugins/alertmanager/manifest.json
+++ b/home/.config/noctalia/plugins/alertmanager/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "alertmanager",
+  "name": "Alertmanager",
+  "version": "1.0.0",
+  "author": "Jörg Thalheim",
+  "official": false,
+  "license": "MIT",
+  "description": "Shows active Prometheus Alertmanager alerts in the bar",
+  "tags": ["Bar", "System", "Network"],
+  "entryPoints": {
+    "main": "Main.qml",
+    "barWidget": "BarWidget.qml",
+    "panel": "Panel.qml",
+    "settings": "Settings.qml"
+  },
+  "dependencies": {
+    "plugins": []
+  },
+  "metadata": {
+    "defaultSettings": {
+      "alertmanagerUrl": "http://alertmanager.r",
+      "pollInterval": 30,
+      "iconColor": "primary"
+    }
+  }
+}


### PR DESCRIPTION

Port the alertmanager monitoring widget from KDE plasmoid and macOS
menu bar to noctalia-shell (quickshell). The plugin polls the
Alertmanager API for active (non-silenced, non-inhibited, non-muted)
alerts and displays count + status in the bar.

Features:
- Bar widget with alert count, color-coded (green/red)
- Tooltip with grouped alert details
- Panel with full alert list, severity icons, clickable links
- Settings for URL, poll interval, icon color
- IPC support for refresh and toggle
- Right-click context menu (refresh, open alertmanager, settings)


