### PR TITLE
homeshick: switch to Mic92 fork for .homesickignore support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ $ nix run github:Mic92/dotfiles
 
 ```console
 $ nix-shell -p git
-nix-shell> git clone --depth=1 https://github.com/andsens/homeshick.git $HOME/.homesick/repos/homeshick
+nix-shell> git clone --depth=1 https://github.com/Mic92/homeshick.git $HOME/.homesick/repos/homeshick
 nix-shell> alias homeshick="$HOME/.homesick/repos/homeshick/bin/homeshick"
 nix-shell> homeshick clone https://github.com/Mic92/dotfiles.git
 ```

--- a/home-manager/flake-module.nix
+++ b/home-manager/flake-module.nix
@@ -86,7 +86,7 @@ in
         ]
       }
       if [ ! -d "$HOME/.homesick/repos/homeshick" ]; then
-        git clone --depth=1 https://github.com/andsens/homeshick.git "$HOME/.homesick/repos/homeshick"
+        git clone --depth=1 https://github.com/Mic92/homeshick.git "$HOME/.homesick/repos/homeshick"
       fi
       if [ ! -d "$HOME/.homesick/repos/dotfiles" ]; then
         "$HOME/.homesick/repos/homeshick/bin/homeshick" clone https://github.com/Mic92/dotfiles.git


### PR DESCRIPTION
Switch homeshick clone URLs from upstream (andsens/homeshick) to our fork (Mic92/homeshick).

The fork adds `.homesickignore` support — a per-castle file that allows skipping specific dotfiles on certain hosts using INI-style hostname sections:

```ini
# Skip everywhere
.globalignored

[utm-vm]
.config/gui-app

[server-*]
bin/dev-only-script
```

Changes:
- `home-manager/flake-module.nix`: bootstrap script clone URL
- `Readme.md`: manual install instructions