### PR TITLE
noctalia: wire up mail-count plugin

### DIFF
--- a/home/.config/noctalia/plugins/mail-count/BarWidget.qml
+++ b/home/.config/noctalia/plugins/mail-count/BarWidget.qml
@@ -1,0 +1,1 @@
+../../shared-plugins/mail-count/BarWidget.qml

--- a/home/.config/noctalia/plugins/mail-count/Main.qml
+++ b/home/.config/noctalia/plugins/mail-count/Main.qml
@@ -1,0 +1,1 @@
+../../shared-plugins/mail-count/Main.qml

--- a/home/.config/noctalia/plugins/mail-count/README.md
+++ b/home/.config/noctalia/plugins/mail-count/README.md
@@ -1,0 +1,1 @@
+../../shared-plugins/mail-count/README.md

--- a/home/.config/noctalia/plugins/mail-count/Settings.qml
+++ b/home/.config/noctalia/plugins/mail-count/Settings.qml
@@ -1,0 +1,1 @@
+../../shared-plugins/mail-count/Settings.qml

--- a/home/.config/noctalia/plugins/mail-count/i18n
+++ b/home/.config/noctalia/plugins/mail-count/i18n
@@ -1,0 +1,1 @@
+../../shared-plugins/mail-count/i18n

--- a/home/.config/noctalia/plugins/mail-count/manifest.json
+++ b/home/.config/noctalia/plugins/mail-count/manifest.json
@@ -1,0 +1,1 @@
+../../shared-plugins/mail-count/manifest.json

--- a/home/.config/noctalia/plugins/mail-count/settings.json
+++ b/home/.config/noctalia/plugins/mail-count/settings.json
@@ -1,0 +1,4 @@
+{
+  "countCommand": "notmuch count '(folder:thalheim.io OR folder:thalheim.io/.Netzwerke OR folder:thalheim.io/.Benachrichtigung OR folder:thalheim.io/.Geld OR folder:thalheim.io/.Privat OR folder:thalheim.io/.Arbeit OR folder:thalheim.io/.Uni) AND date:7d.. AND tag:unread AND NOT tag:trash'",
+  "clickCommand": "ghostty -e aerc"
+}

--- a/home/.config/noctalia/plugins/mail-count/settings.json
+++ b/home/.config/noctalia/plugins/mail-count/settings.json
@@ -1,4 +1,5 @@
 {
   "countCommand": "notmuch count '(folder:thalheim.io OR folder:thalheim.io/.Netzwerke OR folder:thalheim.io/.Benachrichtigung OR folder:thalheim.io/.Geld OR folder:thalheim.io/.Privat OR folder:thalheim.io/.Arbeit OR folder:thalheim.io/.Uni) AND date:7d.. AND tag:unread AND NOT tag:trash'",
-  "clickCommand": "ghostty -e aerc"
+  "clickCommand": "ghostty -e aerc",
+  "hideWhenZero": true
 }

--- a/home/.notmuch/hooks/post-new
+++ b/home/.notmuch/hooks/post-new
@@ -6,3 +6,6 @@ afew --tag --new
 
 # Remove the 'new' tag from all messages
 notmuch tag -new -- tag:new
+
+# Refresh noctalia mail-count widget (no-op if shell not running)
+qs -c noctalia-shell ipc call plugin:mail-count refresh 2>/dev/null || true


### PR DESCRIPTION

Enable the new mail-count widget with a notmuch query matching the
aerc INBOX view (7-day window across main folders). Refresh via IPC
from the notmuch post-new hook so the count updates immediately after
mbsync runs instead of waiting for the poll timer.
