### PR TITLE
bootstrap-dotfiles: run homeshick non-interactively

### DIFF
--- a/home-manager/flake-module.nix
+++ b/home-manager/flake-module.nix
@@ -89,9 +89,9 @@ in
         git clone --depth=1 https://github.com/Mic92/homeshick.git "$HOME/.homesick/repos/homeshick"
       fi
       if [ ! -d "$HOME/.homesick/repos/dotfiles" ]; then
-        "$HOME/.homesick/repos/homeshick/bin/homeshick" clone https://github.com/Mic92/dotfiles.git
+        "$HOME/.homesick/repos/homeshick/bin/homeshick" --batch clone https://github.com/Mic92/dotfiles.git
       fi
-      "$HOME/.homesick/repos/homeshick/bin/homeshick" symlink
+      "$HOME/.homesick/repos/homeshick/bin/homeshick" --batch --force symlink
       nix run ${self}#hm -- switch
     ''}/bin/bootstrap-dotfiles";
   };


### PR DESCRIPTION
When invoked as a container entrypoint or via nix run on a fresh system, the dev image's baked-in ~/.bashrc and friends already exist. homeshick symlink then prompts for each conflict, which hangs when stdin isn't a tty.

Pass --batch to skip prompts and --force to overwrite the existing files. The systemd/launchd updaters in modules/homeshick.nix intentionally keep --batch only so updates never clobber local edits.