### PR TITLE
hm: select coder profile on devspace pods

### DIFF
--- a/home-manager/flake-module.nix
+++ b/home-manager/flake-module.nix
@@ -58,7 +58,7 @@ in
         profile=''${profiles["$host-$user"]};
       elif [[ -n ''${profiles[$host]:-} ]]; then
         profile=''${profiles[$host]}
-      elif [[ "$host" == coder-* ]]; then
+      elif [[ "$host" == coder-* || "$host" == *-devspace-* ]]; then
         profile="coder"
       fi
       if [[ "''${1:-}" == profile ]]; then


### PR DESCRIPTION
Devspace pods get StatefulSet hostnames like nix1-devspace-0 which don't match the coder-* glob, so hm fell back to the common profile.