### PR TITLE
fluent-bit log shipping, noctalia supervision, recursive-nix builders

### DIFF
--- a/darwinModules/remote-builder.nix
+++ b/darwinModules/remote-builder.nix
@@ -17,6 +17,7 @@
         "big-parallel"
         "kvm"
         "nixos-test"
+        "recursive-nix"
       ];
     }
     {
@@ -30,6 +31,7 @@
         "big-parallel"
         "kvm"
         "nixos-test"
+        "recursive-nix"
       ];
     }
     #{

--- a/home/.config/niri/config.kdl
+++ b/home/.config/niri/config.kdl
@@ -63,9 +63,11 @@ layout {
 }
 
 // Startup processes
-// Run noctalia-shell in its own systemd scope so OOM-killer/coredumps are
-// attributed to it rather than niri, and `systemctl --user` can manage it.
-spawn-at-startup "systemd-run" "--user" "--scope" "--unit=noctalia-shell" "--collect" "--" "noctalia-shell"
+// noctalia-shell runs as systemd --user unit `noctalia-shell.service`
+// (Restart=always) bound to graphical-session.target; see nixosModules/niri.
+// Kick it explicitly too so a `niri msg action reload-config` after a manual
+// stop brings the shell back without having to remember systemctl.
+spawn-at-startup "systemctl" "--user" "restart" "noctalia-shell.service"
 spawn-at-startup "kanshi"
 
 prefer-no-csd

--- a/home/.config/noctalia/settings.json
+++ b/home/.config/noctalia/settings.json
@@ -342,7 +342,7 @@
         ]
     },
     "colorSchemes": {
-        "darkMode": false,
+        "darkMode": true,
         "generationMethod": "tonal-spot",
         "manualSunrise": "06:30",
         "manualSunset": "18:30",

--- a/machines/bernie/configuration.nix
+++ b/machines/bernie/configuration.nix
@@ -13,6 +13,7 @@
     ../../nixosModules/ip-update.nix
     ../../nixosModules/packages.nix
     ../../nixosModules/powertop.nix
+    ../../nixosModules/fluent-bit.nix
     ../../nixosModules/users.nix
     ../../nixosModules/remote-builder.nix
     ../../nixosModules/tracing.nix

--- a/machines/dorits-laptop/configuration.nix
+++ b/machines/dorits-laptop/configuration.nix
@@ -12,6 +12,7 @@
     ../../nixosModules/kde
     ../../nixosModules/packages.nix
     ../../nixosModules/powertop.nix
+    ../../nixosModules/fluent-bit.nix
     ../../nixosModules/users.nix
     ../../nixosModules/tracing.nix
     ../../nixosModules/pipewire.nix

--- a/machines/eva/configuration.nix
+++ b/machines/eva/configuration.nix
@@ -31,6 +31,7 @@
     ../../nixosModules/iperf.nix
     ../../nixosModules/radicle-mic92.nix
     ../../nixosModules/openldap/replica.nix
+    ../../nixosModules/fluent-bit.nix
     ../../nixosModules/users.nix
     ../../nixosModules/unbound.nix
   ];

--- a/machines/eva/modules/loki.nix
+++ b/machines/eva/modules/loki.nix
@@ -12,6 +12,27 @@ let
             for = "10s";
             annotations.description = "{{ $labels.instance }} {{ $labels.coredump_unit }} core dumped in last 10min.";
           }
+          {
+            # dead-man switch: every host running fluent-bit should produce at
+            # least *some* journal lines within 15m. Catches broken shippers,
+            # dead retiolum links and wedged journald long before telegraf
+            # notices anything.
+            alert = "LogIngestStalled";
+            expr = ''sum by (host) (count_over_time({job="systemd-journal"}[15m])) unless sum by (host) (count_over_time({job="systemd-journal"}[5m]))'';
+            for = "5m";
+            annotations.description = "{{ $labels.host }} has not shipped any journal logs to loki in the last 5 minutes (but did in the last 15m).";
+          }
+        ];
+      }
+      {
+        # recording rules: turn log patterns into prometheus series so they
+        # can be graphed/alerted on alongside telegraf metrics.
+        name = "log-derived-metrics";
+        rules = [
+          {
+            record = "loki:sshd_invalid_user:rate5m";
+            expr = ''sum by (host) (rate({job="systemd-journal", unit="sshd.service"} |= "Invalid user" [5m]))'';
+          }
         ];
       }
     ];
@@ -23,7 +44,13 @@ in
   systemd.tmpfiles.rules = [
     "d /var/lib/loki 0700 loki loki - -"
     "d /var/lib/loki/rules 0700 loki loki - -"
-    "L+ /var/lib/loki/ruler/ruler.yml - - - - ${rulerFile}"
+    # ruler local storage layout is <dir>/<tenant>/*.yml; with
+    # auth_enabled=false the tenant is the literal string "fake". Ownership
+    # must match the parent dir or tmpfiles refuses the L+ with an
+    # "unsafe path transition" error.
+    "d /var/lib/loki/ruler 0755 loki loki - -"
+    "d /var/lib/loki/ruler/fake 0755 loki loki - -"
+    "L+ /var/lib/loki/ruler/fake/ruler.yml - - - - ${rulerFile}"
   ];
   services.loki = {
     enable = true;

--- a/machines/eve/configuration.nix
+++ b/machines/eve/configuration.nix
@@ -86,6 +86,7 @@
     ../../nixosModules/iperf.nix
     ../../nixosModules/nncp.nix
     ../../nixosModules/openldap
+    ../../nixosModules/fluent-bit.nix
     ../../nixosModules/rtorrent.nix
     ../../nixosModules/flood.nix
     ../../nixosModules/samba-dl.nix

--- a/machines/eve/modules/nostr-relay.nix
+++ b/machines/eve/modules/nostr-relay.nix
@@ -48,6 +48,15 @@ in
         writePolicy {
           plugin = ""
         }
+
+        logging {
+          # The default (invalidEvents = true) logs every rejected event,
+          # which on a public relay means ~95k "ephemeral event expired"
+          # lines per 10 minutes from clients replaying stale kind-2xxxx
+          # events. journald was already rate-limiting on top. Nothing
+          # actionable in there, so silence it.
+          invalidEvents = false
+        }
       }
     '';
   };

--- a/machines/eve/modules/remote-builder.nix
+++ b/machines/eve/modules/remote-builder.nix
@@ -25,7 +25,10 @@
         "x86_64-darwin"
       ];
       maxJobs = 8;
-      supportedFeatures = [ "big-parallel" ];
+      supportedFeatures = [
+        "big-parallel"
+        "recursive-nix"
+      ];
     }
     # direct connection sometimes break, too many connections?
     {
@@ -42,6 +45,7 @@
         "big-parallel"
         "kvm"
         "nixos-test"
+        "recursive-nix"
       ];
     }
     {
@@ -55,6 +59,7 @@
         "big-parallel"
         "kvm"
         "nixos-test"
+        "recursive-nix"
       ];
     }
   ];

--- a/machines/matchbox/configuration.nix
+++ b/machines/matchbox/configuration.nix
@@ -17,6 +17,7 @@
 
     ../../nixosModules/users.nix
     ../../nixosModules/sshd/tor.nix
+    ../../nixosModules/fluent-bit.nix
   ];
 
   boot.loader.systemd-boot.enable = true;

--- a/nixosModules/fluent-bit.nix
+++ b/nixosModules/fluent-bit.nix
@@ -1,0 +1,147 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  # Re-use the existing shared `promtail` var so the already-provisioned
+  # loki basic-auth password keeps working without re-prompting on every host.
+  passwordFile = config.clan.core.vars.generators.promtail.files."password".path;
+
+  # fluent-bit has no expression language comparable to promtail's
+  # pipeline_stages, so the bits that the loki ruler relies on (the
+  # `core dumped` rewrite, the `unit`/`coredump_unit` labels and the
+  # noise drops) are reproduced in a small Lua filter instead.
+  luaFilter = pkgs.writeText "fluent-bit-journal.lua" ''
+    function process(tag, timestamp, record)
+      local msg = record["MESSAGE"]
+
+      -- noise that used to be handled by promtail `drop` stages
+      if msg ~= nil then
+        if string.find(msg, "ignored inotify event for", 1, true)
+          or string.find(msg, "hwmon hwmon1: Undervoltage detected!", 1, true)
+          or string.find(msg, "hwmon hwmon1: Voltage normalised", 1, true)
+          or string.find(msg, "refused connection: IN=", 1, true)
+        then
+          return -1, timestamp, record
+        end
+      end
+
+      -- unit label: fall back to transport (audit/kernel) like promtail did
+      local unit = record["_SYSTEMD_UNIT"]
+      if unit == nil or unit == "" then
+        unit = record["_TRANSPORT"]
+      end
+      -- collapse session-1234.scope -> session.scope to keep label cardinality low
+      if unit ~= nil then
+        unit = string.gsub(unit, "^session%-%d+%.scope$", "session.scope")
+      end
+      record["unit"] = unit
+      record["host"] = record["_HOSTNAME"]
+
+      -- coredump enrichment so the loki ruler alert (`|~ "core dumped"`) keeps firing
+      local cgroup = record["COREDUMP_CGROUP"]
+      if cgroup ~= nil then
+        record["coredump_unit"] = string.match(cgroup, "([^/]+)$")
+        local exe = record["COREDUMP_EXE"] or "?"
+        local uid = record["COREDUMP_UID"] or "?"
+        local gid = record["COREDUMP_GID"] or "?"
+        local cmd = record["COREDUMP_CMDLINE"] or "?"
+        record["MESSAGE"] = string.format(
+          "%s core dumped (user: %s/%s, command: %s)",
+          exe, uid, gid, cmd
+        )
+      end
+
+      -- emit only the fields we care about; loki will turn host/unit/coredump_unit
+      -- into stream labels and the remaining MESSAGE becomes the log line
+      -- (drop_single_key=on)
+      local out = {
+        MESSAGE = record["MESSAGE"],
+        host = record["host"],
+        unit = record["unit"],
+        coredump_unit = record["coredump_unit"],
+      }
+      return 2, timestamp, out
+    end
+  '';
+in
+{
+  clan.core.vars.generators.promtail = {
+    files."password" = { };
+    prompts.password.type = "hidden";
+    share = true;
+  };
+
+  services.fluent-bit = {
+    enable = true;
+    settings = {
+      service = {
+        flush = 1;
+        log_level = "warn";
+        # expose /api/v2/metrics/prometheus on the same port promtail used so
+        # the existing telegraf scrape keeps working unchanged
+        http_server = "on";
+        http_listen = "127.0.0.1";
+        http_port = 9080;
+      };
+      pipeline = {
+        inputs = [
+          {
+            name = "systemd";
+            tag = "journal";
+            db = "/var/lib/fluent-bit/journal.db";
+            read_from_tail = "on";
+            max_entries = 1000;
+            strip_underscores = "off";
+          }
+        ];
+        filters = [
+          {
+            name = "lua";
+            match = "journal";
+            script = "${luaFilter}";
+            call = "process";
+          }
+        ];
+        outputs = [
+          {
+            name = "loki";
+            match = "journal";
+            host = "loki.r";
+            port = 80;
+            uri = "/loki/api/v1/push";
+            http_user = "promtail@thalheim.io";
+            http_passwd = "\${LOKI_PASSWORD}";
+            labels = "job=systemd-journal";
+            label_keys = "$host,$unit,$coredump_unit";
+            remove_keys = lib.concatStringsSep "," [
+              "host"
+              "unit"
+              "coredump_unit"
+            ];
+            line_format = "key_value";
+            drop_single_key = "on";
+          }
+        ];
+      };
+    };
+  };
+
+  systemd.services.fluent-bit = {
+    serviceConfig = {
+      StateDirectory = "fluent-bit";
+      RuntimeDirectory = "fluent-bit";
+      LoadCredential = "loki-password:${passwordFile}";
+      EnvironmentFile = "-/run/fluent-bit/env";
+    };
+    # fluent-bit's loki output cannot read the password from a file, so turn the
+    # credential into an env var before the main process starts.
+    preStart = ''
+      umask 0077
+      printf 'LOKI_PASSWORD=%s\n' "$(cat "$CREDENTIALS_DIRECTORY/loki-password")" \
+        > /run/fluent-bit/env
+    '';
+  };
+}

--- a/nixosModules/fluent-bit.nix
+++ b/nixosModules/fluent-bit.nix
@@ -9,6 +9,23 @@ let
   # loki basic-auth password keeps working without re-prompting on every host.
   passwordFile = config.clan.core.vars.generators.promtail.files."password".path;
 
+  # Stream labels (low cardinality, indexed by loki).
+  labelKeys = [
+    "host"
+    "unit"
+    "coredump_unit"
+  ];
+
+  # Per-line structured metadata (high cardinality, queryable but not indexed).
+  # Loki 3.x stores these alongside the log line so `{host="eve"} | priority <= "3"`
+  # works without blowing up the label index.
+  metadataKeys = [
+    "priority"
+    "syslog_identifier"
+    "pid"
+    "container_name"
+  ];
+
   # fluent-bit has no expression language comparable to promtail's
   # pipeline_stages, so the bits that the loki ruler relies on (the
   # `core dumped` rewrite, the `unit`/`coredump_unit` labels and the
@@ -37,31 +54,37 @@ let
       if unit ~= nil then
         unit = string.gsub(unit, "^session%-%d+%.scope$", "session.scope")
       end
-      record["unit"] = unit
-      record["host"] = record["_HOSTNAME"]
 
       -- coredump enrichment so the loki ruler alert (`|~ "core dumped"`) keeps firing
+      local coredump_unit
       local cgroup = record["COREDUMP_CGROUP"]
       if cgroup ~= nil then
-        record["coredump_unit"] = string.match(cgroup, "([^/]+)$")
+        coredump_unit = string.match(cgroup, "([^/]+)$")
         local exe = record["COREDUMP_EXE"] or "?"
         local uid = record["COREDUMP_UID"] or "?"
         local gid = record["COREDUMP_GID"] or "?"
         local cmd = record["COREDUMP_CMDLINE"] or "?"
-        record["MESSAGE"] = string.format(
+        msg = string.format(
           "%s core dumped (user: %s/%s, command: %s)",
           exe, uid, gid, cmd
         )
       end
 
-      -- emit only the fields we care about; loki will turn host/unit/coredump_unit
-      -- into stream labels and the remaining MESSAGE becomes the log line
-      -- (drop_single_key=on)
+      -- emit only the fields we care about: stream labels + structured metadata
+      -- + MESSAGE. After label_keys/remove_keys/structured_metadata are applied
+      -- only MESSAGE remains in the record so drop_single_key=on yields the
+      -- plain log line.
       local out = {
-        MESSAGE = record["MESSAGE"],
-        host = record["host"],
-        unit = record["unit"],
-        coredump_unit = record["coredump_unit"],
+        MESSAGE = msg,
+        -- stream labels
+        host = record["_HOSTNAME"],
+        unit = unit,
+        coredump_unit = coredump_unit,
+        -- structured metadata
+        priority = record["PRIORITY"],
+        syslog_identifier = record["SYSLOG_IDENTIFIER"],
+        pid = record["_PID"],
+        container_name = record["CONTAINER_NAME"],
       }
       return 2, timestamp, out
     end
@@ -85,6 +108,13 @@ in
         http_server = "on";
         http_listen = "127.0.0.1";
         http_port = 9080;
+        # filesystem-backed buffering so logs survive a loki outage / network
+        # blip on roaming hosts (matchbox, laptops) instead of being dropped
+        # once the in-memory buffer fills.
+        "storage.path" = "/var/lib/fluent-bit/storage";
+        "storage.sync" = "normal";
+        "storage.max_chunks_up" = 64;
+        "storage.backlog.mem_limit" = "16M";
       };
       pipeline = {
         inputs = [
@@ -95,14 +125,33 @@ in
             read_from_tail = "on";
             max_entries = 1000;
             strip_underscores = "off";
+            "storage.type" = "filesystem";
           }
         ];
         filters = [
+          {
+            # fold multi-line stacktraces (go/python/java) into a single loki
+            # entry so `|= "panic"` / `|= "Traceback"` returns the whole trace.
+            name = "multiline";
+            match = "journal";
+            "multiline.key_content" = "MESSAGE";
+            "multiline.parser" = "go,python,java";
+          }
           {
             name = "lua";
             match = "journal";
             script = "${luaFilter}";
             call = "process";
+          }
+          {
+            # eve's strfry alone produces ~10k lines/min; cap any single
+            # journal stream so it cannot eat the 120h retention budget.
+            name = "throttle";
+            match = "journal";
+            rate = 200;
+            window = 60;
+            interval = "1s";
+            print_status = false;
           }
         ];
         outputs = [
@@ -115,14 +164,14 @@ in
             http_user = "promtail@thalheim.io";
             http_passwd = "\${LOKI_PASSWORD}";
             labels = "job=systemd-journal";
-            label_keys = "$host,$unit,$coredump_unit";
-            remove_keys = lib.concatStringsSep "," [
-              "host"
-              "unit"
-              "coredump_unit"
-            ];
+            label_keys = lib.concatMapStringsSep "," (k: "$" + k) labelKeys;
+            structured_metadata = lib.concatMapStringsSep "," (k: "${k}=$" + k) metadataKeys;
+            remove_keys = lib.concatStringsSep "," (labelKeys ++ metadataKeys);
             line_format = "key_value";
             drop_single_key = "on";
+            # cap on-disk backlog for the loki output so a long outage on a
+            # small box (matchbox) cannot fill the disk.
+            "storage.total_limit_size" = "256M";
           }
         ];
       };

--- a/nixosModules/niri/default.nix
+++ b/nixosModules/niri/default.nix
@@ -36,6 +36,27 @@
     };
   };
 
+  # noctalia-shell as a supervised service so quickshell crashes (segfaults in
+  # the QML engine, GPU resets, OOM kills) don't leave the session without a
+  # bar/launcher/lock-screen. spawn-at-startup + systemd-run --scope gave us
+  # cgroup isolation but no restart; a real unit gets both.
+  systemd.user.services.noctalia-shell = {
+    description = "Noctalia desktop shell (quickshell)";
+    partOf = [ "graphical-session.target" ];
+    after = [ "graphical-session.target" ];
+    requisite = [ "graphical-session.target" ];
+    wantedBy = [ "graphical-session.target" ];
+    # Back off if it crash-loops on a broken config instead of pegging a core.
+    startLimitIntervalSec = 30;
+    startLimitBurst = 5;
+    serviceConfig = {
+      ExecStart = "${pkgs.noctalia-shell}/bin/noctalia-shell";
+      Restart = "always";
+      RestartSec = 1;
+      Slice = "app-graphical.slice";
+    };
+  };
+
   # noctalia-shell rewrites plugins.json via atomic rename, which clobbers the
   # homeshick symlink with a plain file. Watch for that and fold the new
   # content back into the dotfiles repo, then restore the link — so plugin

--- a/nixosModules/remote-builder.nix
+++ b/nixosModules/remote-builder.nix
@@ -17,6 +17,7 @@
         "big-parallel"
         "kvm"
         "nixos-test"
+        "recursive-nix"
       ];
     }
     {
@@ -30,6 +31,7 @@
         "big-parallel"
         "kvm"
         "nixos-test"
+        "recursive-nix"
       ];
     }
     {
@@ -42,7 +44,10 @@
         "x86_64-darwin"
       ];
       maxJobs = 8;
-      supportedFeatures = [ "big-parallel" ];
+      supportedFeatures = [
+        "big-parallel"
+        "recursive-nix"
+      ];
     }
   ];
 

--- a/nixosModules/workstation.nix
+++ b/nixosModules/workstation.nix
@@ -17,6 +17,7 @@
     ./packages.nix
     ./pipewire.nix
     ./powertop.nix
+    ./fluent-bit.nix
     ./remote-builder.nix
     ./ssh-tpm-agent.nix
     ./tracing.nix


### PR DESCRIPTION
Restore journald-to-loki shipping after promtail's removal from nixpkgs left every host without logs, replacing it with a fluent-bit pipeline light enough for the rpi-class boxes that reproduces the labels and coredump rewrite the loki ruler depends on, adds filesystem buffering and structured metadata, and fixes the long-broken ruler rules directory while adding a dead-man alert for stalled ingest. Alongside that: silence strfry's ~95k/10min invalid-event spam on eve, move noctalia-shell from a one-shot spawn into a Restart=always user service so quickshell crashes self-heal, sync the dark-mode palette it generated, and advertise recursive-nix on all remote builders so derivations requiring it actually get dispatched there now that the remotes have the experimental feature enabled.