### PR TITLE
librewolf: skip pywalfox addon on macOS

### DIFF
--- a/darwinModules/nix-casks.nix
+++ b/darwinModules/nix-casks.nix
@@ -21,6 +21,7 @@ in
     self.inputs.nix-casks.packages.${pkgs.stdenv.hostPlatform.system}.handy
     (myPkgs.librewolf-macos.override {
       policies = import ../pkgs/librewolf-policies.nix {
+        inherit (pkgs) lib stdenv;
         inherit (micsSkills) browser-cli-extension;
         inherit (firefoxExtensions) chrome-tab-gc-extension;
       };

--- a/home-manager/modules/librewolf.nix
+++ b/home-manager/modules/librewolf.nix
@@ -23,6 +23,7 @@ in
     pkgs.pywalfox-native
     (pkgs.librewolf.override {
       extraPolicies = import ../../pkgs/librewolf-policies.nix {
+        inherit (pkgs) lib stdenv;
         inherit (micsSkillsPkgs) browser-cli-extension;
         inherit (firefoxExtensions) chrome-tab-gc-extension;
       };

--- a/pkgs/librewolf-policies.nix
+++ b/pkgs/librewolf-policies.nix
@@ -1,4 +1,6 @@
 {
+  lib,
+  stdenv,
   browser-cli-extension,
   chrome-tab-gc-extension,
 }:
@@ -12,8 +14,12 @@
       installation_mode = "force_installed";
       install_url = "file://${chrome-tab-gc-extension}/chrome-tab-gc-extension.xpi";
     };
+  }
+  // lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
     # Live-themes the browser chrome from noctalia's generated palette so
-    # LibreWolf matches the niri/bar colours.
+    # LibreWolf matches the niri/bar colours. The noctalia/pywal pipeline only
+    # exists on Linux, so on macOS the addon would just complain about a
+    # missing native messaging host.
     "pywalfox@frewacom.org" = {
       installation_mode = "force_installed";
       install_url = "https://addons.mozilla.org/firefox/downloads/latest/pywalfox/latest.xpi";


### PR DESCRIPTION

The pywalfox extension is fed by noctalia/niri, which only run on
Linux. On macOS it has no native messaging host to talk to and just
nags about it, so gate the policy entry on !isDarwin and thread
lib/stdenv through to the policies file.


