### PR TITLE
pkgs/pi: rebase pause-status-loader patch for pi-tui 0.70.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,16 +105,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776182890,
-        "narHash": "sha256-+/VOe8XGq5klpU+I19D+3TcaR7o+Cwbq67KNF7mcFak=",
-        "owner": "Mic92",
+        "lastModified": 1776192490,
+        "narHash": "sha256-5gYQNEs0/vDkHhg63aHS5g0IwG/8HNvU1Vr00cElofk=",
+        "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "648d293c51e981aec9cb07ba4268bc19e7a8c575",
+        "rev": "6ef9f144616eedea90b364bb408ef2e1de7b310a",
         "type": "github"
       },
       "original": {
-        "owner": "Mic92",
-        "ref": "catalog-support",
+        "owner": "nix-community",
+        "ref": "staging-2.1.0",
         "repo": "bun2nix",
         "type": "github"
       }
@@ -582,11 +582,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776655129,
-        "narHash": "sha256-8qPKHx9VVTY2aHYkUWyRxO/l4YJurFa2U2/iYU7D9/A=",
+        "lastModified": 1777266861,
+        "narHash": "sha256-cdSr2nIz4I+ysG1gAZxbKQo+f79vCCKfQCdiRYnyPec=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "37b4c128405f91c43e8be96b5760140a03b71fd0",
+        "rev": "c8f7c7882804510f2b807021cac0a69c1aeb4829",
         "type": "github"
       },
       "original": {

--- a/pkgs/pi-patches/pause-status-loader.patch
+++ b/pkgs/pi-patches/pause-status-loader.patch
@@ -11,23 +11,17 @@ Drop once a release contains the Loader.pause() fix.
 
 --- a/node_modules/@mariozechner/pi-tui/dist/components/loader.js
 +++ b/node_modules/@mariozechner/pi-tui/dist/components/loader.js
-@@ -9,6 +9,7 @@ export class Loader extends Text {
-     frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+@@ -12,6 +12,7 @@
+     intervalMs = DEFAULT_INTERVAL_MS;
      currentFrame = 0;
      intervalId = null;
 +    paused = false;
      ui = null;
-     constructor(ui, spinnerColorFn, messageColorFn, message = "Loading...") {
-         super("", 1, 0);
-@@ -24,10 +25,24 @@ export class Loader extends Text {
-     start() {
-         this.updateDisplay();
-         this.intervalId = setInterval(() => {
-+            if (this.paused)
-+                return;
-             this.currentFrame = (this.currentFrame + 1) % this.frames.length;
-             this.updateDisplay();
-         }, 80);
+     renderIndicatorVerbatim = false;
+     constructor(ui, spinnerColorFn, messageColorFn, message = "Loading...", indicator) {
+@@ -35,6 +36,18 @@
+             this.intervalId = null;
+         }
      }
 +    pause() {
 +        this.paused = true;
@@ -41,9 +35,18 @@ Drop once a release contains the Loader.pause() fix.
 +            this.updateDisplay();
 +        }
 +    }
-     stop() {
-         if (this.intervalId) {
-             clearInterval(this.intervalId);
+     setMessage(message) {
+         this.message = message;
+         this.updateDisplay();
+@@ -52,6 +65,8 @@
+             return;
+         }
+         this.intervalId = setInterval(() => {
++            if (this.paused)
++                return;
+             this.currentFrame = (this.currentFrame + 1) % this.frames.length;
+             this.updateDisplay();
+         }, this.intervalMs);
 --- a/dist/modes/interactive/interactive-mode.js
 +++ b/dist/modes/interactive/interactive-mode.js
 @@ -1200,6 +1200,16 @@ export class InteractiveMode {


### PR DESCRIPTION

Upstream refactored Loader.start() into restartAnimation() with a
configurable indicator/interval, so the old hunk against the inline
setInterval no longer applied. Regenerate the loader.js diff against the
new layout and bump the llm-agents input so the patch and the pinned
pi version stay in sync.


