### PR TITLE
pi: preload libnostore to block readdir on /nix/store

### DIFF
--- a/home-manager/modules/ai.nix
+++ b/home-manager/modules/ai.nix
@@ -10,6 +10,8 @@ let
   selfPkgs = self.packages.${pkgs.stdenv.hostPlatform.system};
   micsSkillsPkgs = inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system};
   piAgentDeps = pkgs.callPackage ../../home/.pi/agent/default.nix { };
+  nostorePreload = selfPkgs.nostore-preload;
+  nostoreLib = "${nostorePreload}/lib/libnostore${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}";
 in
 {
   imports = [
@@ -74,6 +76,9 @@ in
     selfPkgs.claude-md
     selfPkgs.pim
     (pkgs.writeShellScriptBin "pi" ''
+      # Block readdir(/nix/store) for the agent and its children; exported
+      # before pueued so queued tasks inherit it too.
+      export ${nostorePreload.passthru.envVar}="${nostoreLib}''${${nostorePreload.passthru.envVar}:+:$${nostorePreload.passthru.envVar}}"
       ${pkgs.pueue}/bin/pueued -d >/dev/null 2>&1 || true
       # Extensions are symlinked from dotfiles, so node walk-up misses
       # their npm deps. NODE_PATH points jiti at the prebuilt node_modules.

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -44,6 +44,7 @@ in
     # Package updater CLI
     kimai-cli = pkgs.callPackage ./kimai-cli { };
     bk-wait = pkgs.callPackage ./bk-wait { };
+    nostore-preload = pkgs.callPackage ./nostore-preload { };
     updater = pkgs.callPackage ./updater { };
     # pi with local fix for the offscreen-spinner full-redraw storm.
     # Upstream PR: https://github.com/badlogic/pi-mono/pull/3105

--- a/pkgs/nostore-preload/default.nix
+++ b/pkgs/nostore-preload/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  patchelf,
+}:
+stdenv.mkDerivation (_finalAttrs: {
+  pname = "nostore-preload";
+  version = "0.1.0";
+
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./nostore.c
+      ./test.c
+    ];
+  };
+
+  nativeBuildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [ patchelf ];
+
+  libName = "libnostore${stdenv.hostPlatform.extensions.sharedLibrary}";
+
+  buildPhase = ''
+    runHook preBuild
+    $CC -Wall -Wextra -std=c11 -O2 -fPIC -fno-stack-protector \
+      nostore.c -shared -o "$libName" \
+      ${lib.optionalString stdenv.hostPlatform.isDarwin "-Wl,-install_name,$out/lib/$libName"} \
+      ${lib.optionalString (!stdenv.hostPlatform.isDarwin) "-ldl"}
+    ${lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+      # Bind to whichever libc the host process already loaded; prevents the
+      # double-libc failure mode when preloaded into binaries from other
+      # nixpkgs revisions.
+      patchelf --remove-rpath "$libName"
+    ''}
+    $CC -Wall -std=c11 -O2 test.c -o test
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 "$libName" "$out/lib/$libName"
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    mkdir -p /nix/store 2>/dev/null || true
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        ''DYLD_INSERT_LIBRARIES="$out/lib/$libName" ./test''
+      else
+        ''LD_PRELOAD="$out/lib/$libName" ./test''
+    }
+    runHook postInstallCheck
+  '';
+
+  passthru.envVar = if stdenv.hostPlatform.isDarwin then "DYLD_INSERT_LIBRARIES" else "LD_PRELOAD";
+
+  meta = {
+    description = "LD_PRELOAD guard rail blocking readdir() on /nix/store";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/nostore-preload/nostore.c
+++ b/pkgs/nostore-preload/nostore.c
@@ -1,0 +1,223 @@
+/*
+ * nostore — LD_PRELOAD / DYLD_INSERT_LIBRARIES guard rail that makes
+ * readdir() on /nix/store fail with EACCES so AI coding agents don't drown
+ * in millions of store entries.  Accident-preventer, not a security boundary.
+ *
+ * The variadic `mode` is forwarded unconditionally; the kernel ignores it
+ * when O_CREAT/O_TMPFILE are absent, so no flag introspection is needed.
+ */
+
+#define _GNU_SOURCE
+#include <dirent.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <unistd.h>
+
+#ifdef __APPLE__
+struct dyld_interpose {
+  const void *replacement;
+  const void *replacee;
+};
+#define WRAPPER(ret, name) static ret _nostore_##name
+#define LOOKUP_REAL(name) (&(name))
+#define WRAPPER_DEF(name)                                                      \
+  __attribute__((used)) static struct dyld_interpose _nostore_ip_##name        \
+      __attribute__((section("__DATA,__interpose"))) = {                       \
+          (const void *)&_nostore_##name, (const void *)&(name)};
+#else
+#define WRAPPER(ret, name) ret name
+#define LOOKUP_REAL(name) dlsym(RTLD_NEXT, #name)
+#define WRAPPER_DEF(name)
+/* Pin pre-2.34 dlsym so the .so loads into binaries from any glibc era. */
+#if defined(__GLIBC__) && defined(__x86_64__)
+__asm__(".symver dlsym,dlsym@GLIBC_2.2.5");
+#elif defined(__GLIBC__) && defined(__aarch64__)
+__asm__(".symver dlsym,dlsym@GLIBC_2.17");
+#endif
+#endif
+
+static int is_store_root(const char *p) {
+  static const char want[] = "/nix/store";
+  if (!p)
+    return 0;
+  unsigned i = 0;
+  while (i < sizeof(want) - 1) {
+    if (p[i] != want[i])
+      return 0;
+    i++;
+  }
+  while (p[i] == '/')
+    i++;
+  return p[i] == '\0';
+}
+
+static void hint(void) {
+  static volatile int done;
+  if (done)
+    return;
+  done = 1;
+  static const char msg[] =
+      "nostore-preload: listing /nix/store is intentionally blocked for AI "
+      "agents (millions of entries). Use a known store path, nix-locate, "
+      "`nix eval`/`nix path-info`, or devshell env vars (e.g. "
+      "$NIX_CFLAGS_COMPILE, $PKG_CONFIG_PATH, $buildInputs, `env | rg "
+      "/nix/store`) to discover dependencies. sudo will not bypass this.\n";
+  ssize_t r = write(2, msg, sizeof(msg) - 1);
+  (void)r;
+}
+
+static int deny(void) {
+  hint();
+  errno = EACCES;
+  return -1;
+}
+
+/* nix itself open()s /nix/store with plain O_RDONLY just to fstat() it
+ * (LocalFSStore type probe), so only refuse O_DIRECTORY opens. */
+#define DENY_DIR_OPEN(path, flags)                                             \
+  if (((flags) & O_DIRECTORY) && is_store_root(path))                          \
+    return deny();
+
+WRAPPER(int, open)(const char *path, int flags, ...) {
+  DENY_DIR_OPEN(path, flags);
+  static int (*real)(const char *, int, ...);
+  if (!real)
+    real = LOOKUP_REAL(open);
+  va_list ap;
+  va_start(ap, flags);
+  unsigned mode = va_arg(ap, unsigned);
+  va_end(ap);
+  return real(path, flags, mode);
+}
+WRAPPER_DEF(open)
+
+WRAPPER(int, openat)(int dirfd, const char *path, int flags, ...) {
+  DENY_DIR_OPEN(path, flags);
+  static int (*real)(int, const char *, int, ...);
+  if (!real)
+    real = LOOKUP_REAL(openat);
+  va_list ap;
+  va_start(ap, flags);
+  unsigned mode = va_arg(ap, unsigned);
+  va_end(ap);
+  return real(dirfd, path, flags, mode);
+}
+WRAPPER_DEF(openat)
+
+#ifndef __APPLE__
+WRAPPER(int, open64)(const char *path, int flags, ...) {
+  DENY_DIR_OPEN(path, flags);
+  static int (*real)(const char *, int, ...);
+  if (!real)
+    real = LOOKUP_REAL(open64);
+  va_list ap;
+  va_start(ap, flags);
+  unsigned mode = va_arg(ap, unsigned);
+  va_end(ap);
+  return real(path, flags, mode);
+}
+WRAPPER(int, openat64)(int dirfd, const char *path, int flags, ...) {
+  DENY_DIR_OPEN(path, flags);
+  static int (*real)(int, const char *, int, ...);
+  if (!real)
+    real = LOOKUP_REAL(openat64);
+  va_list ap;
+  va_start(ap, flags);
+  unsigned mode = va_arg(ap, unsigned);
+  va_end(ap);
+  return real(dirfd, path, flags, mode);
+}
+WRAPPER(int, __open_2)(const char *path, int flags) {
+  DENY_DIR_OPEN(path, flags);
+  static int (*real)(const char *, int);
+  if (!real)
+    real = LOOKUP_REAL(__open_2);
+  return real(path, flags);
+}
+WRAPPER(int, __open64_2)(const char *path, int flags) {
+  DENY_DIR_OPEN(path, flags);
+  static int (*real)(const char *, int);
+  if (!real)
+    real = LOOKUP_REAL(__open64_2);
+  return real(path, flags);
+}
+WRAPPER(int, __openat_2)(int dirfd, const char *path, int flags) {
+  DENY_DIR_OPEN(path, flags);
+  static int (*real)(int, const char *, int);
+  if (!real)
+    real = LOOKUP_REAL(__openat_2);
+  return real(dirfd, path, flags);
+}
+WRAPPER(int, __openat64_2)(int dirfd, const char *path, int flags) {
+  DENY_DIR_OPEN(path, flags);
+  static int (*real)(int, const char *, int);
+  if (!real)
+    real = LOOKUP_REAL(__openat64_2);
+  return real(dirfd, path, flags);
+}
+#endif
+
+/* glibc opendir/scandir call an internal __openat that bypasses the PLT,
+ * so they need their own wrappers. */
+
+WRAPPER(DIR *, opendir)(const char *path) {
+  if (is_store_root(path)) {
+    hint();
+    errno = EACCES;
+    return 0;
+  }
+  static DIR *(*real)(const char *);
+  if (!real)
+    real = LOOKUP_REAL(opendir);
+  return real(path);
+}
+WRAPPER_DEF(opendir)
+
+WRAPPER(int,
+        scandir)(const char *path, struct dirent ***namelist,
+                 int (*sel)(const struct dirent *),
+                 int (*cmp)(const struct dirent **, const struct dirent **)) {
+  if (is_store_root(path))
+    return deny();
+  static int (*real)(const char *, struct dirent ***,
+                     int (*)(const struct dirent *),
+                     int (*)(const struct dirent **, const struct dirent **));
+  if (!real)
+    real = LOOKUP_REAL(scandir);
+  return real(path, namelist, sel, cmp);
+}
+WRAPPER_DEF(scandir)
+
+#ifndef __APPLE__
+WRAPPER(int, scandir64)(const char *path, struct dirent64 ***namelist,
+                        int (*sel)(const struct dirent64 *),
+                        int (*cmp)(const struct dirent64 **,
+                                   const struct dirent64 **)) {
+  if (is_store_root(path))
+    return deny();
+  static int (*real)(
+      const char *, struct dirent64 ***, int (*)(const struct dirent64 *),
+      int (*)(const struct dirent64 **, const struct dirent64 **));
+  if (!real)
+    real = LOOKUP_REAL(scandir64);
+  return real(path, namelist, sel, cmp);
+}
+#endif
+
+#ifdef __APPLE__
+extern DIR *__opendir2(const char *, int);
+WRAPPER(DIR *, __opendir2)(const char *path, int flags) {
+  if (is_store_root(path)) {
+    hint();
+    errno = EACCES;
+    return 0;
+  }
+  static DIR *(*real)(const char *, int);
+  if (!real)
+    real = LOOKUP_REAL(__opendir2);
+  return real(path, flags);
+}
+WRAPPER_DEF(__opendir2)
+#endif

--- a/pkgs/nostore-preload/test.c
+++ b/pkgs/nostore-preload/test.c
@@ -1,0 +1,40 @@
+#define _GNU_SOURCE
+#include <assert.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main(void) {
+  errno = 0;
+  assert(opendir("/nix/store") == NULL && errno == EACCES);
+  errno = 0;
+  assert(opendir("/nix/store/") == NULL && errno == EACCES);
+  errno = 0;
+  assert(open("/nix/store", O_RDONLY | O_DIRECTORY) == -1 && errno == EACCES);
+  errno = 0;
+  assert(openat(AT_FDCWD, "/nix/store", O_RDONLY | O_DIRECTORY) == -1 &&
+         errno == EACCES);
+  /* nix probes the store dir with plain O_RDONLY to fstat(); must succeed. */
+  int probe = open("/nix/store", O_RDONLY | O_CLOEXEC);
+  assert(probe >= 0);
+  close(probe);
+  errno = 0;
+  struct dirent **nl;
+  assert(scandir("/nix/store", &nl, NULL, NULL) == -1 && errno == EACCES);
+
+  DIR *d = opendir("/");
+  assert(d != NULL);
+  closedir(d);
+  d = opendir("/nix");
+  assert(d != NULL);
+  closedir(d);
+  int fd = open("/nix/store/.links", O_RDONLY | O_DIRECTORY);
+  assert(fd >= 0 || errno != EACCES);
+  if (fd >= 0)
+    close(fd);
+
+  puts("nostore-preload: all tests passed");
+  return 0;
+}


### PR DESCRIPTION

Agents occasionally `ls`/`find`/`rg`/glob the store root and flood the
context window iterating millions of entries.  A small preload that
fails opendir/scandir and O_DIRECTORY opens on exactly that path is the
cheapest cross-platform guard rail and is inherited by every child.

The shim sticks to GLIBC_2.2.5 symbols with RUNPATH stripped to survive
mixed-glibc closures, lets plain O_RDONLY through for the nix client's
store-dir probe, and prints a hint so the model reaches for
nix-locate/env vars instead of sudo.


