### PR TITLE
nixfmt: drop dedicated flake input in favor of nixpkgs

### DIFF
--- a/devshell/flake-module.nix
+++ b/devshell/flake-module.nix
@@ -69,11 +69,7 @@ let
       "home/.config/noctalia/plugins/*/*.js"
     ];
     programs.nixfmt.enable = true;
-    # Upstream package lacks meta.mainProgram, so treefmt's lib.getExe would
-    # guess the pname ("nixfmt-rs") instead of the actual binary ("nixfmt").
-    programs.nixfmt.package = inputs'.nixfmt-rs.default.overrideAttrs {
-      meta.mainProgram = "nixfmt";
-    };
+    programs.nixfmt.package = pkgs.nixfmt-rs;
     programs.shellcheck.enable = true;
 
     settings.formatter.shellcheck.options = [

--- a/flake.lock
+++ b/flake.lock
@@ -770,29 +770,6 @@
         "type": "github"
       }
     },
-    "nixfmt-rs": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "treefmt-nix": [
-          "treefmt-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777501565,
-        "narHash": "sha256-Slg4Uz8WANTLTYtJBwH7w9aYv7CMU/d59FA6SVARFQM=",
-        "owner": "Mic92",
-        "repo": "nixfmt-rs",
-        "rev": "003e41df70548fee3d647e3367968e2c32b8a057",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Mic92",
-        "repo": "nixfmt-rs",
-        "type": "github"
-      }
-    },
     "nixos-hardware": {
       "locked": {
         "lastModified": 1777917524,
@@ -810,10 +787,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777284412,
-        "narHash": "sha256-+FbxqUNi6edY8wnDQgcWWf5mFKQk01q8g7ZAUzhFYzE=",
+        "lastModified": 1777822695,
+        "narHash": "sha256-8sLpyJgqgoDqxL+0V1WmJSieVH0vbFHAx8hhCg+UHPw=",
         "ref": "main",
-        "rev": "db0586faf1733f3764a26173e8ae1aaf4d3ff2c6",
+        "rev": "78548a76ebd75655b05fd9b35dfee698f60f049a",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/Mic92/nixpkgs"
@@ -960,7 +937,6 @@
         "nix-diff-rs": "nix-diff-rs",
         "nix-index-database": "nix-index-database",
         "nix-tree-rs": "nix-tree-rs",
-        "nixfmt-rs": "nixfmt-rs",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
         "noctalia-plugins": "noctalia-plugins",

--- a/flake.nix
+++ b/flake.nix
@@ -29,10 +29,6 @@
     nix-index-database.url = "github:nix-community/nix-index-database";
     nix-index-database.inputs.nixpkgs.follows = "nixpkgs";
 
-    nixfmt-rs.url = "github:Mic92/nixfmt-rs";
-    nixfmt-rs.inputs.nixpkgs.follows = "nixpkgs";
-    nixfmt-rs.inputs.treefmt-nix.follows = "treefmt-nix";
-
     noctalia-plugins.url = "github:Mic92/noctalia-plugins/nostr";
     noctalia-plugins.inputs.nixpkgs.follows = "nixpkgs";
 

--- a/home-manager/modules/neovim/flake-module.nix
+++ b/home-manager/modules/neovim/flake-module.nix
@@ -1,7 +1,6 @@
 {
   pkgs,
   lib,
-  inputs',
   ...
 }:
 let
@@ -29,7 +28,7 @@ let
     #marksman
     nil
     nixd
-    inputs'.nixfmt-rs.default
+    nixfmt-rs
     deadnix
     statix
     prettierd

--- a/home/.config/nvim/lua/plugins/astrolsp.lua
+++ b/home/.config/nvim/lua/plugins/astrolsp.lua
@@ -31,6 +31,16 @@ return {
 		opts.formatting.format_on_save = false
 
 		opts.config = opts.config or {}
+		-- notify-rs fsevent backend livelocks on macOS rebuilding the
+		-- FSEventStream for every watched dir (O(n^2)), pinning a core.
+		-- Let the editor handle file watching instead.
+		opts.config.rust_analyzer = vim.tbl_deep_extend("force", opts.config.rust_analyzer or {}, {
+			settings = {
+				["rust-analyzer"] = {
+					files = { watcher = "client" },
+				},
+			},
+		})
 		opts.config.clangd = opts.config.clangd or {}
 		opts.config.clangd.capabilities = {
 			offsetEncoding = "utf-8",

--- a/machines/eve/modules/remote-builder.nix
+++ b/machines/eve/modules/remote-builder.nix
@@ -66,6 +66,12 @@
     }
   ];
   programs.ssh.extraConfig = ''
+    # Detect dead TCP connections to remote builders so build-remote does not
+    # hang forever holding all build slots when the network blips mid-transfer.
+    Host mac02 jamie eliza login-tum
+      ServerAliveInterval 30
+      ServerAliveCountMax 4
+
     Host mac02
       User customer
       HostName mac02.numtide.com


### PR DESCRIPTION

nixfmt-rs is now packaged in nixpkgs with a correct meta.mainProgram, so
there is no longer a reason to track the upstream repo as a separate
input or to carry the overrideAttrs workaround for treefmt.
