### PR TITLE
pkgs: add minihydra, a per-commit nixpkgs eval/build differ

### DIFF
--- a/devshell/flake-module.nix
+++ b/devshell/flake-module.nix
@@ -67,6 +67,8 @@ let
     # parse it. No QML-aware JS formatter exists, so just skip these.
     settings.formatter.deno.excludes = [
       "home/.config/noctalia/plugins/*/*.js"
+      # Jinja2 templates use {% ... %} / {{ ... }} which deno fmt rejects.
+      "pkgs/minihydra/src/minihydra/templates/*.html"
     ];
     programs.nixfmt.enable = true;
     programs.nixfmt.package = pkgs.nixfmt-rs;

--- a/flake.lock
+++ b/flake.lock
@@ -787,10 +787,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777822695,
-        "narHash": "sha256-8sLpyJgqgoDqxL+0V1WmJSieVH0vbFHAx8hhCg+UHPw=",
+        "lastModified": 1778094615,
+        "narHash": "sha256-qAgHQC9A3ghXGkyznl0o+4KqHcg2FHj/PlZRRcjq/O8=",
         "ref": "main",
-        "rev": "78548a76ebd75655b05fd9b35dfee698f60f049a",
+        "rev": "460f18d53b10f075710a4932f847eb8a38e25b69",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/Mic92/nixpkgs"

--- a/flake.lock
+++ b/flake.lock
@@ -999,11 +999,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776912132,
-        "narHash": "sha256-UDR6PtHacMhAQJ8SPNbPROaxbtl2Pgjww0TzipTsTZE=",
+        "lastModified": 1777862740,
+        "narHash": "sha256-W6g53anJ2XSZWeysVBiKzk9kMyWlB2lknUYpTA2SiQY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e9ff039a72ff2c06271d5002eb431c443abf69fa",
+        "rev": "1131c2898d718b2c35cbee54056db3df24abdb74",
         "type": "github"
       },
       "original": {

--- a/machines/eve/modules/gitea/retiolum-hook.sh
+++ b/machines/eve/modules/gitea/retiolum-hook.sh
@@ -35,7 +35,7 @@ EOF
 
 cat >wiregrill.nix <<'EOF'
 with import <nixpkgs/nixos> {};
-with import <stockholm/lib>;
+with lib;
 let
   self = config.krebs.build.host.nets.wiregrill;
   isRouter = !isNull self.via;

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -39,6 +39,8 @@ in
     calendar-bot = pkgs.python3.pkgs.callPackage ./calendar_bot { };
     # Nix evaluation warnings extractor
     nix-eval-warnings = pkgs.callPackage ./nix-eval-warnings { };
+    # Per-commit nixpkgs eval/build differ ("minihydra")
+    minihydra = pkgs.callPackage ./minihydra { };
     # Reference all flake inputs to ensure they get cached
     flake-inputs = pkgs.callPackage ./flake-inputs { inherit inputs; };
     # Package updater CLI

--- a/pkgs/minihydra/README.md
+++ b/pkgs/minihydra/README.md
@@ -1,0 +1,70 @@
+# minihydra
+
+Per-commit nixpkgs eval/build differ. Answers: "what does this commit change?"
+
+## Usage
+
+```sh
+# In a nixpkgs (or any flake) checkout. Worktree HEAD = "head" side,
+# --base REV = "base" side. Default base is HEAD~1.
+minihydra run --attr legacyPackages.x86_64-linux --base HEAD~1
+minihydra run --attr hydraJobs.tested.x86_64-linux --build
+minihydra run --flake .#hydraJobs --base origin/master
+
+# Web UI
+minihydra serve --db ~/.local/share/minihydra/minihydra.db
+```
+
+State lives in a single sqlite file (`$XDG_DATA_HOME/minihydra/minihydra.db` by
+default). Copy it around freely.
+
+## LLM-friendly interface
+
+All read-only subcommands wrap the same JSON API the web UI uses, so the CLI and
+`minihydra serve` agree on shapes.
+
+```sh
+minihydra list --json                      # all runs
+minihydra show 7 --json                    # run metadata + summary
+minihydra diff 7 --json                    # full diff (all sections)
+minihydra diff 7 --section newly_broken    # one section
+minihydra summary 7                        # compact text for LLM context
+minihydra job 7 42                         # raw json-eval-jobs record
+```
+
+The HTTP API mirrors the CLI exactly — `GET /api/runs`, `/api/run/{id}`,
+`/api/run/{id}/diff`, `/api/run/{id}/section/{name}`,
+`/api/run/{id}/job/{job_id}`.
+
+## Security
+
+This tool exists to evaluate **arbitrary Nix code** at two revisions and
+optionally build it. Treat it like `nix flake show` on an untrusted PR.
+
+- Do not point `--base`/`--head` at refs you have not vetted. Nix evaluation
+  triggers fetchers, IFD, and (on older nixes) `builtins.exec`. The git worktree
+  checkout itself can run filters/hooks configured in the repo.
+- The web UI has no authentication. It binds to `127.0.0.1` by default; binding
+  to anything else requires `--allow-public` and is not recommended without a
+  reverse proxy that adds auth.
+- The sqlite DB is intended to be copied around. The build-log endpoint refuses
+  to read paths outside `MINIHYDRA_LOG_ROOT` (set automatically by
+  `minihydra serve`) so a tampered or stale `build_log_path` can't be used to
+  exfiltrate arbitrary files.
+- All subprocess calls use list arguments (no shell). The git worktree
+  invocation uses a `--` sentinel so a hostile rev cannot be parsed as an
+  option.
+
+## Output
+
+Per run, sqlite stores both sides' attribute results (name, drvPath, outputs,
+error, system) and an optional build status row. The diff view groups attributes
+into:
+
+- `added` – present on head only
+- `removed` – present on base only
+- `changed` – drvPath differs
+- `newly-broken` – evaluated on base, errored on head
+- `newly-fixed` – errored on base, evaluated on head
+- `still-broken` – errored on both, error message diff
+- `unchanged` – identical drvPath

--- a/pkgs/minihydra/default.nix
+++ b/pkgs/minihydra/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  python3,
+  nix-eval-jobs,
+  nix,
+  git,
+  makeWrapper,
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "minihydra";
+  version = "0.1.0";
+
+  src = ./.;
+  pyproject = true;
+
+  build-system = [ python3.pkgs.hatchling ];
+
+  dependencies = with python3.pkgs; [
+    fastapi
+    uvicorn
+    jinja2
+    rich
+    httpx
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  nativeCheckInputs =
+    with python3.pkgs;
+    [
+      pytestCheckHook
+    ]
+    ++ [
+      git
+      nix
+      nix-eval-jobs
+    ];
+
+  postFixup = ''
+    wrapProgram $out/bin/minihydra \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          nix-eval-jobs
+          nix
+          git
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Per-commit nixpkgs eval/build differ with web UI";
+    mainProgram = "minihydra";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/minihydra/pyproject.toml
+++ b/pkgs/minihydra/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "minihydra"
+version = "0.1.0"
+description = "Per-commit nixpkgs eval/build differ with web UI"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+  "fastapi",
+  "uvicorn",
+  "jinja2",
+  "rich",
+  "httpx",
+]
+
+[project.scripts]
+minihydra = "minihydra.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minihydra"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/pkgs/minihydra/src/minihydra/__init__.py
+++ b/pkgs/minihydra/src/minihydra/__init__.py
@@ -1,0 +1,9 @@
+"""minihydra: per-commit nixpkgs eval/build differ.
+
+The top-level package intentionally avoids importing :mod:`minihydra.cli` so
+that scripts can `from minihydra import db` without pulling httpx, rich, etc.
+The `minihydra` console script is wired to ``minihydra.cli:main`` directly
+via ``[project.scripts]``.
+"""
+
+__all__: list[str] = []

--- a/pkgs/minihydra/src/minihydra/build.py
+++ b/pkgs/minihydra/src/minihydra/build.py
@@ -1,0 +1,53 @@
+"""Local build driver: realise drv paths sequentially, capture per-job logs."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+from minihydra import db
+
+
+def build_jobs(
+    conn: sqlite3.Connection,
+    run_id: int,
+    *,
+    side: str = "head",
+    log_dir: Path,
+    on_progress: Callable[[int, int, str], None] | None = None,
+) -> None:
+    """Realise every drv from *side* that hasn't been built yet.
+
+    Sequential by design (the user picked sequential concurrency). We rely on
+    nix's own daemon-side scheduling for parallelism within a single drv.
+    """
+    log_dir.mkdir(parents=True, exist_ok=True)
+    rows = [
+        r
+        for r in db.jobs_for(conn, run_id, side=side)
+        if r["drv_path"] and not r["error"]
+    ]
+    total = len(rows)
+    for i, row in enumerate(rows, start=1):
+        drv = row["drv_path"]
+        attr = row["attr"]
+        if on_progress is not None:
+            on_progress(i, total, attr)
+        log_path = log_dir / f"{row['id']}.log"
+        with log_path.open("wb") as fh:
+            proc = subprocess.run(
+                ["nix-store", "--realise", drv],
+                stdout=fh,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+        status = "ok" if proc.returncode == 0 else "failed"
+        with db.transaction(conn):
+            db.update_build_status(conn, [row["id"]], status, log_path=str(log_path))
+
+
+def have_nix_store() -> bool:
+    return shutil.which("nix-store") is not None

--- a/pkgs/minihydra/src/minihydra/cli.py
+++ b/pkgs/minihydra/src/minihydra/cli.py
@@ -1,0 +1,638 @@
+"""Command-line entrypoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from rich.table import Table
+
+from minihydra import build as build_mod
+from minihydra import db, diff
+from minihydra import eval as eval_mod
+
+
+def default_db_path() -> Path:
+    base = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local/share")
+    return Path(base) / "minihydra" / "minihydra.db"
+
+
+def default_log_root() -> Path:
+    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base) / "minihydra" / "logs"
+
+
+def make_progress() -> Progress:
+    return Progress(
+        SpinnerColumn(),
+        TextColumn("[bold blue]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# API client. Read-only subcommands wrap the FastAPI app in-process via ASGI,
+# so `minihydra list/show/diff/summary/job` and `minihydra serve` share data
+# shapes. No network is opened, so no auth concerns for the CLI path.
+# ---------------------------------------------------------------------------
+
+
+def _api_client(db_path: Path) -> httpx.Client:
+    if not db_path.exists():
+        msg = f"db not found: {db_path}"
+        raise SystemExit(msg)
+    os.environ["MINIHYDRA_DB"] = str(db_path)
+    from minihydra.web import app
+
+    return httpx.Client(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://minihydra",
+    )
+
+
+def _get(client: httpx.Client, path: str) -> Any:
+    r = client.get(path)
+    if r.status_code == 404:
+        msg = r.json().get("detail", "not found")
+        print(msg, file=sys.stderr)
+        raise SystemExit(1)
+    r.raise_for_status()
+    return r.json()
+
+
+def _eval_side(
+    *,
+    conn: db.sqlite3.Connection,
+    prog: Progress,
+    run_id: int,
+    repo: Path,
+    side: str,
+    rev: str,
+    attr: str,
+    flake_override: str | None,
+    workers: int,
+) -> None:
+    """Evaluate one side and stream rows into the run.
+
+    Extracted so ``cmd_run`` and ``cmd_rerun`` can share the same eval loop;
+    rerun calls this only for the head side, with the base copied from a
+    prior run.
+    """
+    task = prog.add_task(f"eval {side} ({rev[:8]})", total=None)
+    db.update_progress(
+        conn,
+        run_id,
+        f"eval-{side}",
+        current=0,
+        total=0,
+        message=f"starting {rev[:8]}",
+    )
+    with eval_mod.worktree_at(repo, rev) as wt:
+        flake_ref = flake_override or str(wt)
+
+        def _cb(n: int, t: object = task, s: str = side) -> None:
+            prog.update(t, completed=n, total=max(n, n + 1))
+            db.update_progress(
+                conn,
+                run_id,
+                f"eval-{s}",
+                current=n,
+                total=n,
+                message=f"evaluated {n} attrs",
+            )
+
+        eval_mod.evaluate_side(
+            conn,
+            run_id=run_id,
+            side=side,
+            flake_ref=flake_ref,
+            attr=attr,
+            workers=workers,
+            on_progress=_cb,
+        )
+    prog.update(task, total=prog.tasks[task].completed)
+
+
+def _maybe_build_head(
+    *,
+    conn: db.sqlite3.Connection,
+    console: Console,
+    run_id: int,
+    log_root: Path,
+    want_build: bool,
+) -> None:
+    if not want_build:
+        return
+    if not build_mod.have_nix_store():
+        console.print("[red]nix-store not in PATH; skipping build[/]")
+        return
+    with make_progress() as prog:
+        head_rows = [
+            r
+            for r in db.jobs_for(conn, run_id, side="head")
+            if r["drv_path"] and not r["error"]
+        ]
+        task = prog.add_task("build head", total=len(head_rows))
+
+        def cb(i: int, total: int, attr: str) -> None:
+            prog.update(task, completed=i, total=total, description=f"build {attr}")
+            db.update_progress(
+                conn,
+                run_id,
+                "build",
+                current=i,
+                total=total,
+                message=attr,
+            )
+
+        build_mod.build_jobs(
+            conn,
+            run_id,
+            side="head",
+            log_dir=log_root / "build",
+            on_progress=cb,
+        )
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    console = Console()
+    repo_dir = Path(args.repo or ".").resolve()
+    repo = eval_mod.find_repo_root(repo_dir)
+
+    head_rev = args.head or "HEAD"
+    base_rev = args.base or "HEAD~1"
+    head_resolved = eval_mod.resolve_rev(repo, head_rev)
+    base_resolved = eval_mod.resolve_rev(repo, base_rev)
+
+    if base_resolved == head_resolved:
+        console.print(
+            "[yellow]base and head resolve to same commit; nothing to diff[/]"
+        )
+        return 1
+
+    db_path = Path(args.db) if args.db else default_db_path()
+    conn = db.connect(db_path)
+    run_id = db.create_run(
+        conn,
+        flake_ref=args.flake or str(repo),
+        attr=args.attr,
+        base_rev=base_rev,
+        head_rev=head_rev,
+        base_resolved=base_resolved,
+        head_resolved=head_resolved,
+    )
+    console.print(
+        f"[bold]run #{run_id}[/] db=[cyan]{db_path}[/] "
+        f"base=[magenta]{base_resolved[:12]}[/] head=[green]{head_resolved[:12]}[/] "
+        f"attr=[bold]{args.attr}[/]"
+    )
+
+    log_root = default_log_root() / f"run-{run_id}"
+
+    try:
+        with make_progress() as prog:
+            for side, rev in (("base", base_resolved), ("head", head_resolved)):
+                _eval_side(
+                    conn=conn,
+                    prog=prog,
+                    run_id=run_id,
+                    repo=repo,
+                    side=side,
+                    rev=rev,
+                    attr=args.attr,
+                    workers=args.workers,
+                )
+
+        _maybe_build_head(
+            conn=conn,
+            console=console,
+            run_id=run_id,
+            log_root=log_root,
+            want_build=args.build,
+        )
+        db.set_run_status(conn, run_id, "done")
+    except Exception as e:
+        db.set_run_status(conn, run_id, f"error: {e}")
+        raise
+
+    base_rows = db.jobs_for(conn, run_id, side="base")
+    head_rows = db.jobs_for(conn, run_id, side="head")
+    d = diff.compute(base_rows, head_rows)
+    summary = d.summary()
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "run_id": run_id,
+                    "db": str(db_path),
+                    "base": base_resolved,
+                    "head": head_resolved,
+                    "attr": args.attr,
+                    "summary": summary,
+                },
+                indent=2,
+            )
+        )
+    else:
+        console.print()
+        console.print("[bold]diff summary[/]")
+        for k, v in summary.items():
+            console.print(f"  {k:14s} {v}")
+        console.print(
+            f"\nweb UI: [cyan]minihydra serve --db {db_path}[/] "
+            f"then http://127.0.0.1:8765/run/{run_id}"
+        )
+    return 0
+
+
+def cmd_rerun(args: argparse.Namespace) -> int:
+    """Re-evaluate head against an existing run's base, skipping base eval.
+
+    The base eval on a real nixpkgs takes minutes; if you're iterating on a
+    fix while ``base`` doesn't move (e.g. it tracks ``origin/main``), there's
+    no reason to re-run it. ``rerun`` copies the source run's base rows and
+    only evaluates the new head.
+    """
+    console = Console()
+    db_path = Path(args.db) if args.db else default_db_path()
+    conn = db.connect(db_path)
+
+    src = db.get_run(conn, args.run_id) if args.run_id else db.latest_run(conn)
+    if src is None:
+        print(
+            "no prior run to rerun. use `minihydra run` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    repo_dir = Path(args.repo or ".").resolve()
+    repo = eval_mod.find_repo_root(repo_dir)
+    head_rev = args.head or "HEAD"
+    head_resolved = eval_mod.resolve_rev(repo, head_rev)
+
+    if head_resolved == src["head_resolved"] and not args.force:
+        console.print(
+            f"[yellow]head {head_resolved[:12]} matches run #{src['id']}'s head; "
+            f"nothing to re-evaluate. pass --force to do it anyway.[/]"
+        )
+        return 1
+    if head_resolved == src["base_resolved"]:
+        console.print("[yellow]new head equals base; nothing to diff[/]")
+        return 1
+
+    run_id = db.create_run(
+        conn,
+        flake_ref=args.flake or src["flake_ref"],
+        attr=src["attr"],
+        base_rev=src["base_rev"],
+        head_rev=head_rev,
+        base_resolved=src["base_resolved"],
+        head_resolved=head_resolved,
+    )
+
+    with db.transaction(conn):
+        copied = db.copy_side_jobs(conn, src["id"], run_id, "base")
+    db.update_progress(
+        conn,
+        run_id,
+        "eval-base",
+        current=copied,
+        total=copied,
+        message=f"reused base from run #{src['id']}",
+    )
+    console.print(
+        f"[bold]run #{run_id}[/] db=[cyan]{db_path}[/] "
+        f"base=[magenta]{src['base_resolved'][:12]}[/] (reused from #{src['id']}, "
+        f"{copied} rows) head=[green]{head_resolved[:12]}[/] "
+        f"attr=[bold]{src['attr']}[/]"
+    )
+
+    log_root = default_log_root() / f"run-{run_id}"
+    try:
+        with make_progress() as prog:
+            _eval_side(
+                conn=conn,
+                prog=prog,
+                run_id=run_id,
+                repo=repo,
+                side="head",
+                rev=head_resolved,
+                attr=src["attr"],
+                flake_override=args.flake,
+                workers=args.workers,
+            )
+        _maybe_build_head(
+            conn=conn,
+            console=console,
+            run_id=run_id,
+            log_root=log_root,
+            want_build=args.build,
+        )
+        db.set_run_status(conn, run_id, "done")
+    except Exception as e:
+        db.set_run_status(conn, run_id, f"error: {e}")
+        raise
+
+    base_rows = db.jobs_for(conn, run_id, side="base")
+    head_rows = db.jobs_for(conn, run_id, side="head")
+    d = diff.compute(base_rows, head_rows)
+    summary = d.summary()
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "run_id": run_id,
+                    "src_run_id": src["id"],
+                    "db": str(db_path),
+                    "base": src["base_resolved"],
+                    "head": head_resolved,
+                    "attr": src["attr"],
+                    "summary": summary,
+                },
+                indent=2,
+            )
+        )
+    else:
+        console.print()
+        console.print("[bold]diff summary[/]")
+        for k, v in summary.items():
+            console.print(f"  {k:14s} {v}")
+        console.print(
+            f"\nweb UI: [cyan]minihydra serve --db {db_path}[/] "
+            f"then http://127.0.0.1:8765/run/{run_id}"
+        )
+    return 0
+
+
+_LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+
+
+def cmd_serve(args: argparse.Namespace) -> int:
+    import uvicorn
+
+    db_path = Path(args.db) if args.db else default_db_path()
+    if not db_path.exists():
+        print(f"db not found: {db_path}", file=sys.stderr)
+        return 1
+    if args.host not in _LOOPBACK_HOSTS and not args.allow_public:
+        print(
+            f"refusing to bind {args.host}: web UI has no auth. "
+            "pass --allow-public if you really mean it.",
+            file=sys.stderr,
+        )
+        return 2
+    os.environ["MINIHYDRA_DB"] = str(db_path)
+    # Confine log-file reads to the default log root. Without this, a poisoned
+    # build_log_path in a copied-around DB could exfiltrate arbitrary files
+    # readable by the server user.
+    os.environ.setdefault("MINIHYDRA_LOG_ROOT", str(default_log_root()))
+    uvicorn.run(
+        "minihydra.web:app",
+        host=args.host,
+        port=args.port,
+        log_level="info",
+        reload=False,
+    )
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    console = Console()
+    db_path = Path(args.db) if args.db else default_db_path()
+    with _api_client(db_path) as c:
+        runs = _get(c, "/api/runs")
+    if args.json:
+        print(json.dumps(runs, indent=2, default=str))
+        return 0
+    t = Table(title="runs")
+    for col in ("id", "attr", "base", "head", "status", "created"):
+        t.add_column(col)
+    for r in runs:
+        t.add_row(
+            str(r["id"]),
+            r["attr"],
+            (r["base_resolved"] or "")[:12],
+            (r["head_resolved"] or "")[:12],
+            r["status"],
+            f"{r['created_at']:.0f}",
+        )
+    console.print(t)
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    console = Console()
+    db_path = Path(args.db) if args.db else default_db_path()
+    with _api_client(db_path) as c:
+        payload = _get(c, f"/api/run/{args.run_id}")
+    if args.json:
+        print(json.dumps(payload, indent=2, default=str))
+        return 0
+    run = payload["run"]
+    console.print(
+        f"[bold]run #{run['id']}[/] [{run['status']}] attr=[cyan]{run['attr']}[/]"
+    )
+    console.print(
+        f"  base {run['base_rev']} ({run['base_resolved'][:12]})\n"
+        f"  head {run['head_rev']} ({run['head_resolved'][:12]})"
+    )
+    console.print("[bold]summary[/]")
+    for k, v in payload["summary"].items():
+        console.print(f"  {k:14s} {v}")
+    return 0
+
+
+def cmd_diff(args: argparse.Namespace) -> int:
+    console = Console()
+    db_path = Path(args.db) if args.db else default_db_path()
+    with _api_client(db_path) as c:
+        if args.section:
+            payload = _get(c, f"/api/run/{args.run_id}/section/{args.section}")
+        else:
+            payload = _get(c, f"/api/run/{args.run_id}/diff")
+    if args.json:
+        print(json.dumps(payload, indent=2, default=str))
+        return 0
+    if args.section:
+        for e in payload["entries"]:
+            console.print(f"  {e['attr']}")
+    else:
+        for name, entries in payload.items():
+            if name == "summary" or not entries:
+                continue
+            console.print(f"[bold]{name}[/] ({len(entries)})")
+            for e in entries[: args.limit]:
+                console.print(f"  {e['attr']}")
+            if len(entries) > args.limit:
+                console.print(f"  ... {len(entries) - args.limit} more")
+    return 0
+
+
+def cmd_summary(args: argparse.Namespace) -> int:
+    """Compact text summary, suitable to paste into an LLM context window."""
+    db_path = Path(args.db) if args.db else default_db_path()
+    with _api_client(db_path) as c:
+        meta = _get(c, f"/api/run/{args.run_id}")
+        diff_payload = _get(c, f"/api/run/{args.run_id}/diff")
+    run = meta["run"]
+    lines = [
+        f"minihydra run #{run['id']} attr={run['attr']}",
+        (
+            f"base={run['base_resolved'][:12]} "
+            f"head={run['head_resolved'][:12]} status={run['status']}"
+        ),
+        "summary: " + ", ".join(f"{k}={v}" for k, v in meta["summary"].items()),
+    ]
+    for name in ("newly_broken", "newly_fixed", "added", "removed", "changed"):
+        entries = diff_payload.get(name, [])
+        if not entries:
+            continue
+        attrs = [e["attr"] for e in entries[: args.limit]]
+        more = (
+            f" (+{len(entries) - args.limit} more)" if len(entries) > args.limit else ""
+        )
+        lines.append(f"{name}: {', '.join(attrs)}{more}")
+        if name in ("newly_broken", "still_broken"):
+            for e in entries[: args.limit]:
+                err = (e.get("head") or {}).get("error") or ""
+                if err:
+                    first = err.splitlines()[0][:200]
+                    lines.append(f"  {e['attr']}: {first}")
+    print("\n".join(lines))
+    return 0
+
+
+def cmd_job(args: argparse.Namespace) -> int:
+    db_path = Path(args.db) if args.db else default_db_path()
+    with _api_client(db_path) as c:
+        payload = _get(c, f"/api/run/{args.run_id}/job/{args.job_id}")
+    print(json.dumps(payload, indent=2, default=str))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="minihydra")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    r = sub.add_parser("run", help="evaluate base + head and store diff")
+    r.add_argument("--repo", help="git repo path (default: cwd)")
+    r.add_argument("--flake", help="flake ref override (default: worktree path)")
+    r.add_argument(
+        "--attr",
+        required=True,
+        help="attribute path to evaluate, e.g. legacyPackages.x86_64-linux",
+    )
+    r.add_argument("--base", help="baseline revision (default HEAD~1)")
+    r.add_argument("--head", help="head revision (default HEAD)")
+    r.add_argument("--workers", type=int, default=4)
+    r.add_argument("--build", action="store_true", help="build head drvs after eval")
+    r.add_argument("--db", help="sqlite db path")
+    r.add_argument("--json", action="store_true", help="emit final summary as JSON")
+    r.set_defaults(func=cmd_run)
+
+    rr = sub.add_parser(
+        "rerun",
+        help="re-evaluate head against a prior run's base (skips base eval)",
+    )
+    rr.add_argument(
+        "run_id",
+        nargs="?",
+        type=int,
+        help="source run id (default: most recent run in the db)",
+    )
+    rr.add_argument("--repo", help="git repo path (default: cwd)")
+    rr.add_argument("--flake", help="flake ref override")
+    rr.add_argument("--head", help="head revision (default: HEAD)")
+    rr.add_argument("--workers", type=int, default=4)
+    rr.add_argument("--build", action="store_true")
+    rr.add_argument("--db", help="sqlite db path")
+    rr.add_argument("--json", action="store_true")
+    rr.add_argument(
+        "--force",
+        action="store_true",
+        help="re-evaluate even if head matches the source run's head",
+    )
+    rr.set_defaults(func=cmd_rerun)
+
+    s = sub.add_parser("serve", help="run web UI (loopback by default)")
+    s.add_argument("--db", help="sqlite db path")
+    s.add_argument("--host", default="127.0.0.1")
+    s.add_argument("--port", type=int, default=8765)
+    s.add_argument(
+        "--allow-public",
+        action="store_true",
+        help=(
+            "required to bind a non-loopback address. The web UI has no "
+            "authentication and exposes eval errors and build log paths."
+        ),
+    )
+    s.set_defaults(func=cmd_serve)
+
+    ls = sub.add_parser("list", help="list runs (use --json for LLM/agents)")
+    ls.add_argument("--db")
+    ls.add_argument("--json", action="store_true")
+    ls.set_defaults(func=cmd_list)
+
+    sh = sub.add_parser("show", help="show run metadata + summary")
+    sh.add_argument("run_id", type=int)
+    sh.add_argument("--db")
+    sh.add_argument("--json", action="store_true")
+    sh.set_defaults(func=cmd_show)
+
+    df = sub.add_parser("diff", help="diff sections (--json for full data)")
+    df.add_argument("run_id", type=int)
+    df.add_argument(
+        "--section",
+        choices=[
+            "added",
+            "removed",
+            "changed",
+            "unchanged",
+            "newly_broken",
+            "newly_fixed",
+            "still_broken",
+        ],
+    )
+    df.add_argument("--limit", type=int, default=20)
+    df.add_argument("--db")
+    df.add_argument("--json", action="store_true")
+    df.set_defaults(func=cmd_diff)
+
+    sm = sub.add_parser("summary", help="compact text summary for LLM context")
+    sm.add_argument("run_id", type=int)
+    sm.add_argument("--limit", type=int, default=10)
+    sm.add_argument("--db")
+    sm.set_defaults(func=cmd_summary)
+
+    jb = sub.add_parser("job", help="dump full json for a single job")
+    jb.add_argument("run_id", type=int)
+    jb.add_argument("job_id", type=int)
+    jb.add_argument("--db")
+    jb.set_defaults(func=cmd_job)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pkgs/minihydra/src/minihydra/db.py
+++ b/pkgs/minihydra/src/minihydra/db.py
@@ -1,0 +1,258 @@
+"""SQLite layer.
+
+Single-file database keyed by run id. Schema is intentionally narrow: a row
+per (run, side, system, attr). Build status piggy-backs on the same row so we
+can join in the UI without extra tables.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS runs (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at  REAL    NOT NULL,
+    flake_ref   TEXT    NOT NULL,
+    attr        TEXT    NOT NULL,
+    base_rev    TEXT    NOT NULL,
+    head_rev    TEXT    NOT NULL,
+    base_resolved TEXT  NOT NULL,
+    head_resolved TEXT  NOT NULL,
+    status      TEXT    NOT NULL DEFAULT 'pending',
+    note        TEXT
+);
+
+CREATE TABLE IF NOT EXISTS jobs (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id      INTEGER NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    side        TEXT    NOT NULL CHECK (side IN ('base', 'head')),
+    attr        TEXT    NOT NULL,
+    system      TEXT,
+    name        TEXT,
+    drv_path    TEXT,
+    outputs     TEXT,        -- json: {name: store_path}
+    error       TEXT,
+    cache_status TEXT,
+    raw         TEXT,        -- full nix-eval-jobs json line
+    build_status TEXT,        -- null | queued | building | ok | failed | skipped
+    build_log_path TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_run_side ON jobs(run_id, side);
+CREATE INDEX IF NOT EXISTS idx_jobs_run_attr ON jobs(run_id, attr);
+CREATE INDEX IF NOT EXISTS idx_jobs_drv ON jobs(run_id, drv_path);
+
+CREATE TABLE IF NOT EXISTS progress (
+    run_id      INTEGER NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    phase       TEXT    NOT NULL,
+    current     INTEGER NOT NULL DEFAULT 0,
+    total       INTEGER NOT NULL DEFAULT 0,
+    message     TEXT,
+    updated_at  REAL    NOT NULL,
+    PRIMARY KEY (run_id, phase)
+);
+"""
+
+
+def connect(path: Path) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, isolation_level=None, timeout=30)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.executescript(SCHEMA)
+    return conn
+
+
+@contextmanager
+def transaction(conn: sqlite3.Connection) -> Iterator[None]:
+    conn.execute("BEGIN")
+    try:
+        yield
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    else:
+        conn.execute("COMMIT")
+
+
+def create_run(
+    conn: sqlite3.Connection,
+    *,
+    flake_ref: str,
+    attr: str,
+    base_rev: str,
+    head_rev: str,
+    base_resolved: str,
+    head_resolved: str,
+) -> int:
+    cur = conn.execute(
+        """INSERT INTO runs
+           (created_at, flake_ref, attr, base_rev, head_rev,
+            base_resolved, head_resolved, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 'running')""",
+        (
+            time.time(),
+            flake_ref,
+            attr,
+            base_rev,
+            head_rev,
+            base_resolved,
+            head_resolved,
+        ),
+    )
+    rid = cur.lastrowid
+    assert rid is not None
+    return rid
+
+
+def set_run_status(conn: sqlite3.Connection, run_id: int, status: str) -> None:
+    conn.execute("UPDATE runs SET status = ? WHERE id = ?", (status, run_id))
+
+
+def insert_job(
+    conn: sqlite3.Connection,
+    *,
+    run_id: int,
+    side: str,
+    record: dict[str, Any],
+) -> None:
+    attr = record.get("attr") or record.get("attrPath") or ""
+    if isinstance(attr, list):
+        attr = ".".join(attr)
+    outputs = record.get("outputs")
+    conn.execute(
+        """INSERT INTO jobs
+           (run_id, side, attr, system, name, drv_path, outputs, error,
+            cache_status, raw)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            run_id,
+            side,
+            attr,
+            record.get("system"),
+            record.get("name"),
+            record.get("drvPath"),
+            json.dumps(outputs) if outputs is not None else None,
+            record.get("error"),
+            json.dumps(record.get("cacheStatus"))
+            if record.get("cacheStatus") is not None
+            else None,
+            json.dumps(record),
+        ),
+    )
+
+
+def update_progress(
+    conn: sqlite3.Connection,
+    run_id: int,
+    phase: str,
+    *,
+    current: int = 0,
+    total: int = 0,
+    message: str | None = None,
+) -> None:
+    conn.execute(
+        """INSERT INTO progress (run_id, phase, current, total, message, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?)
+           ON CONFLICT(run_id, phase) DO UPDATE SET
+              current = excluded.current,
+              total = excluded.total,
+              message = excluded.message,
+              updated_at = excluded.updated_at""",
+        (run_id, phase, current, total, message, time.time()),
+    )
+
+
+def runs(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    return list(conn.execute("SELECT * FROM runs ORDER BY created_at DESC").fetchall())
+
+
+def get_run(conn: sqlite3.Connection, run_id: int) -> sqlite3.Row | None:
+    return conn.execute("SELECT * FROM runs WHERE id = ?", (run_id,)).fetchone()
+
+
+def latest_run(conn: sqlite3.Connection) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM runs ORDER BY created_at DESC LIMIT 1"
+    ).fetchone()
+
+
+def copy_side_jobs(
+    conn: sqlite3.Connection,
+    src_run_id: int,
+    dst_run_id: int,
+    side: str,
+) -> int:
+    """Copy every job row from one run/side onto another run/side.
+
+    Used by ``minihydra rerun`` to reuse a base eval across iterations
+    instead of re-running ``nix-eval-jobs`` against the same base revision.
+    Returns the number of rows copied.
+    """
+    # Copy every column except `id` (autoincremented) and `run_id` (the
+    # whole point). Including build_status / build_log_path means a future
+    # caller that copies the head side keeps build results intact, instead
+    # of silently losing them.
+    cur = conn.execute(
+        """INSERT INTO jobs
+             (run_id, side, attr, system, name, drv_path, outputs,
+              error, cache_status, raw, build_status, build_log_path)
+           SELECT ?, side, attr, system, name, drv_path, outputs,
+                  error, cache_status, raw, build_status, build_log_path
+             FROM jobs
+            WHERE run_id = ? AND side = ?""",
+        (dst_run_id, src_run_id, side),
+    )
+    return cur.rowcount or 0
+
+
+def progress_for(conn: sqlite3.Connection, run_id: int) -> list[sqlite3.Row]:
+    return list(
+        conn.execute(
+            "SELECT * FROM progress WHERE run_id = ? ORDER BY updated_at",
+            (run_id,),
+        ).fetchall()
+    )
+
+
+def jobs_for(
+    conn: sqlite3.Connection,
+    run_id: int,
+    *,
+    side: str | None = None,
+) -> list[sqlite3.Row]:
+    if side:
+        return list(
+            conn.execute(
+                "SELECT * FROM jobs WHERE run_id = ? AND side = ? ORDER BY attr",
+                (run_id, side),
+            ).fetchall()
+        )
+    return list(
+        conn.execute(
+            "SELECT * FROM jobs WHERE run_id = ? ORDER BY side, attr",
+            (run_id,),
+        ).fetchall()
+    )
+
+
+def update_build_status(
+    conn: sqlite3.Connection,
+    job_ids: Iterable[int],
+    status: str,
+    *,
+    log_path: str | None = None,
+) -> None:
+    for jid in job_ids:
+        conn.execute(
+            "UPDATE jobs SET build_status = ?, build_log_path = COALESCE(?, build_log_path) WHERE id = ?",
+            (status, log_path, jid),
+        )

--- a/pkgs/minihydra/src/minihydra/diff.py
+++ b/pkgs/minihydra/src/minihydra/diff.py
@@ -1,0 +1,67 @@
+"""Compute high-level diff between base and head sides of a run."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class DiffEntry:
+    attr: str
+    base: dict[str, Any] | None
+    head: dict[str, Any] | None
+
+
+@dataclass
+class Diff:
+    added: list[DiffEntry] = field(default_factory=list)
+    removed: list[DiffEntry] = field(default_factory=list)
+    changed: list[DiffEntry] = field(default_factory=list)
+    unchanged: list[DiffEntry] = field(default_factory=list)
+    newly_broken: list[DiffEntry] = field(default_factory=list)
+    newly_fixed: list[DiffEntry] = field(default_factory=list)
+    still_broken: list[DiffEntry] = field(default_factory=list)
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "added": len(self.added),
+            "removed": len(self.removed),
+            "changed": len(self.changed),
+            "unchanged": len(self.unchanged),
+            "newly_broken": len(self.newly_broken),
+            "newly_fixed": len(self.newly_fixed),
+            "still_broken": len(self.still_broken),
+        }
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    return {k: row[k] for k in row.keys()}  # noqa: SIM118 (sqlite3.Row has no __contains__)
+
+
+def compute(base_rows: list[Any], head_rows: list[Any]) -> Diff:
+    base = {r["attr"]: _row_to_dict(r) for r in base_rows}
+    head = {r["attr"]: _row_to_dict(r) for r in head_rows}
+    diff = Diff()
+    for attr in sorted(set(base) | set(head)):
+        b = base.get(attr)
+        h = head.get(attr)
+        entry = DiffEntry(attr=attr, base=b, head=h)
+        b_err = bool(b and b.get("error"))
+        h_err = bool(h and h.get("error"))
+        if b is None and h is not None:
+            (diff.newly_broken if h_err else diff.added).append(entry)
+        elif h is None and b is not None:
+            diff.removed.append(entry)
+        elif b is not None and h is not None:
+            if b_err and h_err:
+                diff.still_broken.append(entry)
+            elif b_err and not h_err:
+                diff.newly_fixed.append(entry)
+            elif h_err and not b_err:
+                diff.newly_broken.append(entry)
+            elif b.get("drv_path") != h.get("drv_path"):
+                diff.changed.append(entry)
+            else:
+                diff.unchanged.append(entry)
+    return diff

--- a/pkgs/minihydra/src/minihydra/eval.py
+++ b/pkgs/minihydra/src/minihydra/eval.py
@@ -1,0 +1,147 @@
+"""Drive nix-eval-jobs against a flake checkout and stream results to sqlite."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from minihydra import db
+
+
+def git(repo: Path, *args: str) -> str:
+    res = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return res.stdout.strip()
+
+
+def resolve_rev(repo: Path, rev: str) -> str:
+    return git(repo, "rev-parse", rev)
+
+
+def find_repo_root(start: Path) -> Path:
+    return Path(git(start, "rev-parse", "--show-toplevel"))
+
+
+@contextmanager
+def worktree_at(repo: Path, rev: str) -> Iterator[Path]:
+    """Create a detached git worktree at *rev* and clean it up afterwards.
+
+    Using `git worktree` instead of stash/checkout means concurrent edits in
+    the user's main checkout are unaffected.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="minihydra-wt-"))
+    wt = tmp / "wt"
+    try:
+        # `--` sentinel keeps a hostile rev like `--upload-pack=...` from
+        # being interpreted as a git option. `git worktree add` takes
+        # `<path> <commit-ish>` as positionals after `--`.
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "worktree",
+                "add",
+                "--detach",
+                "--",
+                str(wt),
+                rev,
+            ],
+            check=True,
+        )
+        yield wt
+    finally:
+        subprocess.run(
+            ["git", "-C", str(repo), "worktree", "remove", "--force", str(wt)],
+            check=False,
+        )
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def run_nix_eval_jobs(
+    flake_ref: str,
+    attr: str,
+    *,
+    workers: int = 4,
+    extra_args: list[str] | None = None,
+    on_record: Callable[[dict[str, object]], None],
+    on_progress: Callable[[int], None] | None = None,
+) -> int:
+    """Stream `nix-eval-jobs` JSONL output, invoking *on_record* per attribute.
+
+    Returns the count of records seen. Exit code is checked so callers can
+    distinguish a tool crash from per-attribute eval errors (which are
+    reported in-band via the `error` field).
+    """
+    cmd = [
+        "nix-eval-jobs",
+        "--flake",
+        f"{flake_ref}#{attr}" if attr else flake_ref,
+        "--workers",
+        str(workers),
+        "--force-recurse",
+        "--no-instantiate",
+        *(extra_args or []),
+    ]
+    seen = 0
+    with subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=sys.stderr,
+        text=True,
+        bufsize=1,
+    ) as proc:
+        assert proc.stdout is not None
+        for raw_line in proc.stdout:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            on_record(record)
+            seen += 1
+            if on_progress is not None:
+                on_progress(seen)
+        rc = proc.wait()
+    if rc != 0:
+        msg = f"nix-eval-jobs exited with status {rc}"
+        raise RuntimeError(msg)
+    return seen
+
+
+def evaluate_side(
+    conn: sqlite3.Connection,
+    *,
+    run_id: int,
+    side: str,
+    flake_ref: str,
+    attr: str,
+    workers: int,
+    on_progress: Callable[[int], None] | None = None,
+) -> int:
+    """Evaluate one side and persist all rows in a single transaction."""
+
+    def store(record: dict[str, object]) -> None:
+        db.insert_job(conn, run_id=run_id, side=side, record=record)
+
+    with db.transaction(conn):
+        return run_nix_eval_jobs(
+            flake_ref,
+            attr,
+            workers=workers,
+            on_record=store,
+            on_progress=on_progress,
+        )

--- a/pkgs/minihydra/src/minihydra/templates/_diff_area.html
+++ b/pkgs/minihydra/src/minihydra/templates/_diff_area.html
@@ -1,0 +1,30 @@
+{# Renders the headline summary plus every section, paginated.
+
+   Used for both the initial run page and the search endpoint, so the
+   filter input and "load more" buttons see a consistent layout. #}
+
+<div class="summary">
+  {% for k, v in summary.items() %}
+    <span class="pill {{ k }}">{{ k }}: {{ v }}</span>
+  {% endfor %}
+</div>
+
+{% set has_any = summary.values() | sum > 0 %}
+{% if not has_any %}
+  <p class="empty">{% if q %}no attributes match <b>{{ q }}</b>.{% else %}no diff yet.{% endif %}</p>
+{% endif %}
+
+{% for name in SECTIONS %}
+  {% set entries = diff | attr(name) %}
+  {% if entries %}
+    <details class="section" {% if name in SECTIONS_OPEN_BY_DEFAULT or q %}open{% endif %}>
+      <summary>
+        <span class="pill {{ name }}">{{ name }}</span>
+        <span class="tabnum">{{ entries | length }}</span>
+      </summary>
+      <div class="section-body" id="sect-{{ name }}-body">
+        {% include "_section.html" %}
+      </div>
+    </details>
+  {% endif %}
+{% endfor %}

--- a/pkgs/minihydra/src/minihydra/templates/_log.html
+++ b/pkgs/minihydra/src/minihydra/templates/_log.html
@@ -1,0 +1,9 @@
+{# HTMX-loaded log fragment. Tail only the last N lines so a runaway build
+   doesn't dump megabytes into the diff page; full log is one click away. #}
+<pre>{{ body }}</pre>
+{% if truncated %}
+<div class="meta">
+  showing last {{ shown }} of {{ total }} lines.
+  <a href="/run/{{ run_id }}/log/{{ job_id }}" target="_blank">full log →</a>
+</div>
+{% endif %}

--- a/pkgs/minihydra/src/minihydra/templates/_progress.html
+++ b/pkgs/minihydra/src/minihydra/templates/_progress.html
@@ -1,0 +1,14 @@
+{% if not progress %}
+<p><i>no progress recorded yet</i></p>
+{% else %}
+{% for p in progress %}
+<div class="progress-row">
+  <div><b>{{ p['phase'] }}</b> — {{ p['message'] or "" }}
+    <span class="mono">({{ p['current'] }}/{{ p['total'] }})</span></div>
+  <div class="bar">
+    {% set pct = (100 * p['current'] // p['total']) if p['total'] else 0 %}
+    <span style="width: {{ pct }}%"></span>
+  </div>
+</div>
+{% endfor %}
+{% endif %}

--- a/pkgs/minihydra/src/minihydra/templates/_section.html
+++ b/pkgs/minihydra/src/minihydra/templates/_section.html
@@ -1,0 +1,141 @@
+{# Per-bucket table. Renders the first `limit` entries plus a "load more"
+   button if there's more, so we never blow up the page on a 30k-row
+   `unchanged` section. The limit is cumulative: clicking "load more" hits
+   the same endpoint with a higher limit and replaces the whole section
+   body. #}
+
+{% set total = entries | length %}
+{% set shown = entries[:limit] %}
+
+{% macro drv_link(side) -%}
+  {% if side and side.drv_path -%}
+    <a href="/run/{{ run['id'] }}/job/{{ side.id }}"
+       title="{{ side.drv_path }}">{{ side.drv_path | drv_short }}</a>
+  {%- endif %}
+{%- endmacro %}
+
+{% macro build_pill(side) -%}
+  {% if side and side.build_status -%}
+    <span class="pill {{ side.build_status }}">{{ side.build_status }}</span>
+    {% if side.build_log_path -%}
+      {# Lazy-load the log on demand into the page-level dialog. Putting the
+         <pre> inside the table cell broke row layout once the log got
+         long, so we use a single shared modal popover instead. #}
+      <button type="button" class="linkish"
+              hx-get="/run/{{ run['id'] }}/log/{{ side.id }}/inline"
+              hx-target="#log-dialog-body"
+              hx-swap="innerHTML"
+              onclick="document.getElementById('log-dialog').showModal()">log</button>
+    {%- endif %}
+  {%- endif %}
+{%- endmacro %}
+
+{% if name in ("newly_broken", "still_broken") %}
+  <table>
+    <colgroup><col style="width: 24%"><col></colgroup>
+    <thead><tr><th>attr</th><th>error (head)</th></tr></thead>
+    <tbody>
+    {% for e in shown %}
+      <tr>
+        <td class="attr">{{ e.attr }}</td>
+        <td class="err">{{ ((e.head.error if e.head else "") or "") | first_lines(6) }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+{% elif name == "newly_fixed" %}
+  <table>
+    <colgroup><col style="width: 24%"><col><col style="width: 30%"><col style="width: 8em"></colgroup>
+    <thead><tr><th>attr</th><th>base error</th><th>head drv</th><th>build</th></tr></thead>
+    <tbody>
+    {% for e in shown %}
+      <tr>
+        <td class="attr">{{ e.attr }}</td>
+        <td class="err">{{ ((e.base.error if e.base else "") or "") | first_lines(2) }}</td>
+        <td class="drv">{{ drv_link(e.head) }}</td>
+        <td class="build">{{ build_pill(e.head) }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+{% elif name == "added" %}
+  <table>
+    <colgroup><col style="width: 28%"><col><col style="width: 8em"></colgroup>
+    <thead><tr><th>attr</th><th>head drv</th><th>build</th></tr></thead>
+    <tbody>
+    {% for e in shown %}
+      <tr>
+        <td class="attr">{{ e.attr }}</td>
+        <td class="drv">{{ drv_link(e.head) }}</td>
+        <td class="build">{{ build_pill(e.head) }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+{% elif name == "removed" %}
+  <table>
+    <colgroup><col style="width: 28%"><col></colgroup>
+    <thead><tr><th>attr</th><th>base drv</th></tr></thead>
+    <tbody>
+    {% for e in shown %}
+      <tr>
+        <td class="attr">{{ e.attr }}</td>
+        <td class="drv">{{ drv_link(e.base) }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+{% elif name == "changed" %}
+  <table>
+    <colgroup><col style="width: 24%"><col><col><col style="width: 8em"></colgroup>
+    <thead>
+      <tr>
+        <th>attr</th>
+        <th><span class="diff-old">was</span></th>
+        <th><span class="diff-new">now</span></th>
+        <th>build</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for e in shown %}
+      <tr>
+        <td class="attr">{{ e.attr }}</td>
+        <td class="drv diff-old">{{ drv_link(e.base) }}</td>
+        <td class="drv diff-new">{{ drv_link(e.head) }}</td>
+        <td class="build">{{ build_pill(e.head) }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+{% else %} {# unchanged #}
+  <table>
+    <colgroup><col style="width: 28%"><col></colgroup>
+    <thead><tr><th>attr</th><th>drv</th></tr></thead>
+    <tbody>
+    {% for e in shown %}
+      <tr>
+        <td class="attr">{{ e.attr }}</td>
+        <td class="drv">{{ drv_link(e.head) }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% endif %}
+
+{% if total > limit %}
+  {# Replace the whole section body with a fresh render at the larger limit.
+     Cumulative pagination keeps the URL state simple. #}
+  <button class="load-more"
+          hx-get="/run/{{ run['id'] }}/section/{{ name }}?limit={{ limit + DEFAULT_LIMIT }}{% if q %}&q={{ q | urlencode }}{% endif %}"
+          hx-target="#sect-{{ name }}-body"
+          hx-swap="innerHTML">
+    show {{ DEFAULT_LIMIT }} more · {{ limit }} of {{ total }}
+  </button>
+{% elif total > DEFAULT_LIMIT %}
+  <div class="section-foot">all {{ total }} shown</div>
+{% endif %}

--- a/pkgs/minihydra/src/minihydra/templates/base.html
+++ b/pkgs/minihydra/src/minihydra/templates/base.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% block title %}minihydra{% endblock %}</title>
+<script src="https://unpkg.com/htmx.org@2.0.4"></script>
+<style>
+  :root {
+    color-scheme: light dark;
+    --fg: #1c1c1e;
+    --bg: #fafafa;
+    --bg-alt: #f0f0f2;
+    --border: #d8d8dc;
+    --muted: #6e6e72;
+    --accent: #2e7d5b;
+    --accent-soft: #2e7d5b22;
+    --bad: #b53a3a;
+    --bad-soft: #b53a3a22;
+    --warn: #b58308;
+    --warn-soft: #b5830822;
+    --neutral-soft: #8884;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --fg: #e8e8ea;
+      --bg: #18181b;
+      --bg-alt: #232327;
+      --border: #2f2f34;
+      --muted: #98989d;
+    }
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+    color: var(--fg); background: var(--bg);
+    margin: 0; padding: 0;
+  }
+  main { max-width: 1280px; margin: 0 auto; padding: 1rem 1.5rem 4rem; }
+
+  nav.topbar {
+    position: sticky; top: 0; z-index: 10;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    padding: 0.6rem 1.5rem;
+    display: flex; gap: 1rem; align-items: center;
+  }
+  nav.topbar a { color: var(--accent); text-decoration: none; font-weight: 600; }
+  nav.topbar .grow { flex: 1; }
+  nav.topbar input[type=search] {
+    flex: 0 1 28rem;
+    font: inherit;
+    padding: 0.35rem 0.6rem;
+    border: 1px solid var(--border); border-radius: 6px;
+    background: var(--bg-alt); color: var(--fg);
+  }
+
+  h1, h2, h3 { margin-top: 1.2rem; }
+  h1 { display: flex; gap: 0.6rem; align-items: baseline; }
+
+  .meta { color: var(--muted); font-size: 0.9em; line-height: 1.5; }
+  code, .mono, td.drv, td.attr, td.err { font-family: ui-monospace, SFMono-Regular, "Menlo", monospace; }
+  .tabnum { font-variant-numeric: tabular-nums; }
+
+  table { border-collapse: collapse; width: 100%; font-size: 0.88rem; table-layout: fixed; }
+  th, td { text-align: left; padding: 0.35rem 0.55rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { background: var(--bg-alt); font-weight: 600; color: var(--muted); font-size: 0.8em; text-transform: uppercase; letter-spacing: 0.04em; }
+  tr:hover td { background: var(--bg-alt); }
+  td.attr { width: 24%; font-weight: 600; word-break: break-all; }
+  td.drv  { width: 30%; font-size: 0.82em; word-break: break-all; }
+  td.err  { font-size: 0.82em; white-space: pre-wrap; word-break: break-word; }
+  td.build { width: 8em; text-align: right; white-space: nowrap; }
+
+  .pill {
+    display: inline-block; padding: 0.05em 0.55em; border-radius: 999px;
+    background: var(--neutral-soft); font-size: 0.78em; font-weight: 600;
+    text-transform: lowercase; letter-spacing: 0.02em;
+  }
+  .pill.added, .pill.newly_fixed, .pill.ok, .pill.done { background: var(--accent-soft); color: var(--accent); }
+  .pill.removed, .pill.newly_broken, .pill.failed     { background: var(--bad-soft);    color: var(--bad); }
+  .pill.changed, .pill.queued, .pill.running          { background: var(--warn-soft);   color: var(--warn); }
+
+  .summary { display: flex; gap: 0.4rem; flex-wrap: wrap; margin: 0.5rem 0 1rem; }
+  .summary .pill { font-size: 0.85em; padding: 0.2em 0.7em; }
+
+  details.section {
+    border: 1px solid var(--border); border-radius: 8px;
+    margin: 0.6rem 0; background: var(--bg);
+    overflow: hidden;
+  }
+  details.section > summary {
+    cursor: pointer; padding: 0.7rem 0.9rem;
+    font-weight: 600; user-select: none;
+    display: flex; gap: 0.6rem; align-items: center;
+    list-style: none;
+  }
+  details.section > summary::-webkit-details-marker { display: none; }
+  details.section > summary::before {
+    content: "▸"; color: var(--muted); width: 1ch;
+    transition: transform 0.15s;
+  }
+  details.section[open] > summary::before { transform: rotate(90deg); }
+  details.section > summary:hover { background: var(--bg-alt); }
+  details.section > .section-body { padding: 0; }
+
+  .progress-row { margin: 0.5rem 0; }
+  .bar { background: var(--bg-alt); height: 0.55rem; border-radius: 999px; overflow: hidden; border: 1px solid var(--border); }
+  .bar > span { display: block; height: 100%; background: var(--accent); transition: width .3s; }
+
+  .diff-old { color: var(--bad); }
+  .diff-new { color: var(--accent); }
+
+  .load-more {
+    display: block; width: 100%; padding: 0.6rem;
+    border: none; border-top: 1px solid var(--border);
+    background: var(--bg-alt); color: var(--accent);
+    font: inherit; font-weight: 600; cursor: pointer;
+  }
+  .load-more:hover { background: var(--border); }
+  .section-foot { padding: 0.5rem 0.9rem; color: var(--muted); font-size: 0.85em; text-align: center; }
+
+  button.linkish {
+    background: none; border: none; padding: 0;
+    color: var(--accent); cursor: pointer; font: inherit;
+    font-size: 0.85em; text-decoration: underline;
+  }
+
+  dialog.log-dialog {
+    width: min(80rem, 90vw);
+    max-height: 80vh;
+    border: 1px solid var(--border); border-radius: 8px;
+    padding: 0; background: var(--bg); color: var(--fg);
+    box-shadow: 0 8px 32px rgba(0,0,0,0.25);
+  }
+  dialog.log-dialog::backdrop { background: rgba(0,0,0,0.4); }
+  dialog.log-dialog .log-dialog-close {
+    position: sticky; top: 0; padding: 0.4rem 0.6rem;
+    background: var(--bg-alt); border-bottom: 1px solid var(--border);
+    text-align: right;
+  }
+  dialog.log-dialog .log-dialog-close button {
+    background: none; border: none; cursor: pointer;
+    font-size: 1.1em; color: var(--muted);
+  }
+  dialog.log-dialog #log-dialog-body { padding: 0.6rem 0.9rem 1rem; }
+  dialog.log-dialog pre {
+    margin: 0; padding: 0.6rem 0.8rem;
+    background: var(--bg-alt); border-radius: 4px;
+    white-space: pre-wrap; word-break: break-word;
+    font-size: 0.82em; line-height: 1.45;
+    max-height: 60vh; overflow: auto;
+  }
+
+  .empty { color: var(--muted); font-style: italic; padding: 1rem 0.9rem; }
+</style>
+</head>
+<body>
+<nav class="topbar">
+  <a href="/">minihydra</a>
+  {% block topbar_extra %}{% endblock %}
+  <span class="grow"></span>
+</nav>
+<main>
+{% block body %}{% endblock %}
+</main>
+</body>
+</html>

--- a/pkgs/minihydra/src/minihydra/templates/index.html
+++ b/pkgs/minihydra/src/minihydra/templates/index.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}minihydra runs{% endblock %}
+{% block body %}
+<h1>runs</h1>
+{% if not runs %}
+<p class="meta">no runs yet. run <code>minihydra run --attr ...</code></p>
+{% else %}
+<table>
+  <colgroup>
+    <col style="width: 4em"><col><col style="width: 8em"><col style="width: 8em">
+    <col style="width: 6em"><col style="width: 14em">
+  </colgroup>
+  <thead>
+    <tr><th>id</th><th>attr</th><th>base</th><th>head</th><th>status</th><th>created</th></tr>
+  </thead>
+  <tbody>
+  {% for r in runs %}
+    <tr>
+      <td><a href="/run/{{ r['id'] }}">#{{ r['id'] }}</a></td>
+      <td class="mono">{{ r['attr'] }}</td>
+      <td class="mono tabnum" title="{{ r['base_resolved'] }}">{{ r['base_resolved'][:12] }}</td>
+      <td class="mono tabnum" title="{{ r['head_resolved'] }}">{{ r['head_resolved'][:12] }}</td>
+      <td><span class="pill {{ r['status'].split(':')[0] }}">{{ r['status'] }}</span></td>
+      <td class="mono tabnum">{{ r['created_at'] | datetime }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/pkgs/minihydra/src/minihydra/templates/job.html
+++ b/pkgs/minihydra/src/minihydra/templates/job.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %} {% block title %}job {{ row['id'] }}{% endblock %} {%
+block body %}
+<h1>job {{ row['id'] }} <span class="pill">{{ row['side'] }}</span></h1>
+<p class="mono">
+  attr: <b>{{ row['attr'] }}</b><br>
+  system: {{ row['system'] }}<br>
+  drv: {{ row['drv_path'] }}<br>
+  build: {{ row['build_status'] or "—" }} {% if row['build_log_path'] %}
+  <a href="/run/{{ run_id }}/log/{{ row['id'] }}">log</a>
+  {% endif %}
+</p>
+{% if row['error'] %}
+<h2>eval error</h2>
+<pre>{{ row['error'] }}</pre>
+{% endif %}
+<h2>raw</h2>
+<pre class="mono">{{ raw }}</pre>
+<p><a href="/run/{{ run_id }}">← back to run</a></p>
+{% endblock %}

--- a/pkgs/minihydra/src/minihydra/templates/run.html
+++ b/pkgs/minihydra/src/minihydra/templates/run.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block title %}run #{{ run['id'] }}{% endblock %}
+
+{% block topbar_extra %}
+{# Search box lives in the sticky topbar so it stays reachable when scrolling
+   through long sections. HTMX swaps the diff-area body in place. #}
+<input type="search" name="q" value="{{ q }}"
+       placeholder="filter attrs (e.g. python3, gnome.)"
+       autocomplete="off" autofocus
+       hx-get="/run/{{ run['id'] }}/search"
+       hx-target="#diff-area"
+       hx-swap="innerHTML"
+       hx-trigger="input changed delay:300ms, search, keyup[key=='Enter']"
+       hx-include="this"
+       hx-push-url="false">
+{% endblock %}
+
+{% block body %}
+<h1>
+  run #{{ run['id'] }}
+  <span class="pill {{ run['status'].split(':')[0] }}">{{ run['status'] }}</span>
+</h1>
+<div class="meta mono">
+  <div><b>{{ run['attr'] }}</b></div>
+  <div>base: {{ run['base_rev'] }} (<span title="{{ run['base_resolved'] }}">{{ run['base_resolved'][:12] }}</span>)</div>
+  <div>head: {{ run['head_rev'] }} (<span title="{{ run['head_resolved'] }}">{{ run['head_resolved'][:12] }}</span>)</div>
+  <div>flake: {{ run['flake_ref'] }} · created {{ run['created_at'] | datetime }}</div>
+</div>
+
+<h2>progress</h2>
+{# Stop polling once the run is no longer running, otherwise the page hammers
+   the server forever. #}
+<div hx-get="/run/{{ run['id'] }}/progress"
+     {% if run['status'] == 'running' %}hx-trigger="load, every 2s"
+     {% else %}hx-trigger="load"{% endif %}
+     hx-swap="innerHTML">
+  {% include "_progress.html" %}
+</div>
+
+<h2>diff</h2>
+<div id="diff-area">
+  {% include "_diff_area.html" %}
+</div>
+
+{# Page-level log popover. A single dialog is reused for every "log" button;
+   HTMX swaps in the lazy-loaded fragment on click. Using <dialog> avoids the
+   table-row-layout issues we'd hit if the log were rendered inline. #}
+<dialog id="log-dialog" class="log-dialog">
+  <form method="dialog" class="log-dialog-close">
+    <button type="submit" aria-label="close">✕</button>
+  </form>
+  <div id="log-dialog-body"></div>
+</dialog>
+{% endblock %}

--- a/pkgs/minihydra/src/minihydra/web.py
+++ b/pkgs/minihydra/src/minihydra/web.py
@@ -1,0 +1,449 @@
+"""FastAPI + HTMX web UI.
+
+The DB path is read from the MINIHYDRA_DB env var (set by the CLI) so the
+ASGI app object stays trivially constructable for tests.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import sqlite3
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
+from fastapi.templating import Jinja2Templates
+
+from minihydra import db, diff
+
+TEMPLATES_DIR = Path(__file__).parent / "templates"
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+
+
+_DRV_HASH_RE = re.compile(r"^/nix/store/[a-z0-9]{32}-")
+
+#: Bucket names in the order the UI presents them: regressions and fixes
+#: first, then identity changes, then chronic / unchanged.
+SECTIONS = (
+    "newly_broken",
+    "newly_fixed",
+    "changed",
+    "added",
+    "removed",
+    "still_broken",
+    "unchanged",
+)
+
+#: Sections that are open by default in the run view.
+SECTIONS_OPEN_BY_DEFAULT = frozenset(
+    {"newly_broken", "newly_fixed", "changed", "added", "removed"}
+)
+
+#: How many rows to render per section before requiring the user to click
+#: "load more". 100 is plenty to skim a regression set without blowing up
+#: page weight on a real nixpkgs eval (~80k unchanged attrs).
+DEFAULT_LIMIT = 100
+
+
+def _drv_short(path: str | None) -> str:
+    """Strip /nix/store/<hash>- prefix and trailing .drv for display.
+
+    Keeps the human-meaningful name+version while dropping the hash that
+    differs on every rebuild.
+    """
+    if not path:
+        return ""
+    return _DRV_HASH_RE.sub("", path).removesuffix(".drv")
+
+
+def _first_lines(text: str | None, n: int = 4) -> str:
+    if not text:
+        return ""
+    lines = text.splitlines()
+    out = "\n".join(lines[:n])
+    if len(lines) > n:
+        out += f"\n… ({len(lines) - n} more lines)"
+    return out
+
+
+def _datetime(ts: float | None) -> str:
+    if ts is None:
+        return ""
+    return dt.datetime.fromtimestamp(float(ts), tz=dt.UTC).strftime(
+        "%Y-%m-%d %H:%M:%S UTC"
+    )
+
+
+templates.env.filters["drv_short"] = _drv_short
+templates.env.filters["first_lines"] = _first_lines
+templates.env.filters["datetime"] = _datetime
+templates.env.globals["SECTIONS"] = SECTIONS
+templates.env.globals["SECTIONS_OPEN_BY_DEFAULT"] = SECTIONS_OPEN_BY_DEFAULT
+templates.env.globals["DEFAULT_LIMIT"] = DEFAULT_LIMIT
+
+app = FastAPI(title="minihydra")
+
+
+def _conn() -> sqlite3.Connection:
+    path = os.environ.get("MINIHYDRA_DB")
+    if not path:
+        raise HTTPException(500, "MINIHYDRA_DB not set")
+    return db.connect(Path(path))
+
+
+# ---------------------------------------------------------------------------
+# Diff cache
+#
+# Computing the diff over an 80k-attribute nixpkgs eval takes ~1s. Without a
+# cache, every keystroke in the search box and every "load more" click would
+# re-run that work. We key on the run id plus the largest progress.updated_at
+# timestamp, so a still-running eval invalidates automatically as new attrs
+# stream in, but a finished run hits the cache forever (until the process
+# restarts). This trades a small amount of memory for a much snappier UI.
+# ---------------------------------------------------------------------------
+
+_DIFF_CACHE: dict[int, tuple[float, diff.Diff]] = {}
+
+
+def _diff_freshness(conn: sqlite3.Connection, run_id: int) -> float:
+    row = conn.execute(
+        "SELECT COALESCE(MAX(updated_at), 0) FROM progress WHERE run_id = ?",
+        (run_id,),
+    ).fetchone()
+    return float(row[0] or 0.0)
+
+
+def _get_diff(conn: sqlite3.Connection, run_id: int) -> diff.Diff:
+    stamp = _diff_freshness(conn, run_id)
+    cached = _DIFF_CACHE.get(run_id)
+    if cached and cached[0] == stamp:
+        return cached[1]
+    base_rows = db.jobs_for(conn, run_id, side="base")
+    head_rows = db.jobs_for(conn, run_id, side="head")
+    d = diff.compute(base_rows, head_rows)
+    _DIFF_CACHE[run_id] = (stamp, d)
+    return d
+
+
+def _filter_diff(d: diff.Diff, q: str) -> diff.Diff:
+    """Return a new Diff with each section narrowed to attrs containing *q*.
+
+    Case-insensitive substring match on the attribute path. We rebuild a
+    fresh :class:`diff.Diff` rather than mutate so the cache stays clean.
+    """
+    if not q:
+        return d
+    needle = q.lower()
+    out = diff.Diff()
+    for name in SECTIONS:
+        setattr(
+            out,
+            name,
+            [e for e in getattr(d, name) if needle in e.attr.lower()],
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# HTML routes
+# ---------------------------------------------------------------------------
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request) -> HTMLResponse:
+    conn = _conn()
+    return templates.TemplateResponse(request, "index.html", {"runs": db.runs(conn)})
+
+
+def _diff_context(
+    request: Request,
+    run: sqlite3.Row,
+    d: diff.Diff,
+    q: str,
+    limit: int,
+) -> dict[str, Any]:
+    """Shared template variables for the run page and the search fragment."""
+    return {
+        "request": request,
+        "run": run,
+        "diff": d,
+        "summary": d.summary(),
+        "q": q,
+        "limit": limit,
+    }
+
+
+@app.get("/run/{run_id}", response_class=HTMLResponse)
+def run_view(
+    request: Request,
+    run_id: int,
+    q: str = "",
+    limit: int = DEFAULT_LIMIT,
+) -> HTMLResponse:
+    conn = _conn()
+    run = db.get_run(conn, run_id)
+    if not run:
+        raise HTTPException(404)
+    d = _filter_diff(_get_diff(conn, run_id), q)
+    ctx = _diff_context(request, run, d, q, limit)
+    ctx["progress"] = db.progress_for(conn, run_id)
+    return templates.TemplateResponse(request, "run.html", ctx)
+
+
+@app.get("/run/{run_id}/search", response_class=HTMLResponse)
+def run_search(
+    request: Request,
+    run_id: int,
+    q: str = "",
+    limit: int = DEFAULT_LIMIT,
+) -> HTMLResponse:
+    """HTMX target for the search box: re-renders just the diff area."""
+    conn = _conn()
+    run = db.get_run(conn, run_id)
+    if not run:
+        raise HTTPException(404)
+    d = _filter_diff(_get_diff(conn, run_id), q)
+    return templates.TemplateResponse(
+        request, "_diff_area.html", _diff_context(request, run, d, q, limit)
+    )
+
+
+@app.get("/run/{run_id}/section/{name}", response_class=HTMLResponse)
+def run_section(
+    request: Request,
+    run_id: int,
+    name: str,
+    q: str = "",
+    limit: int = DEFAULT_LIMIT,
+) -> HTMLResponse:
+    """HTMX target for the per-section "load more" button."""
+    if name not in SECTIONS:
+        raise HTTPException(404, f"unknown section {name}")
+    conn = _conn()
+    run = db.get_run(conn, run_id)
+    if not run:
+        raise HTTPException(404)
+    d = _filter_diff(_get_diff(conn, run_id), q)
+    return templates.TemplateResponse(
+        request,
+        "_section.html",
+        {
+            "request": request,
+            "run": run,
+            "name": name,
+            "entries": getattr(d, name),
+            "limit": limit,
+            "q": q,
+        },
+    )
+
+
+@app.get("/run/{run_id}/progress", response_class=HTMLResponse)
+def run_progress(request: Request, run_id: int) -> HTMLResponse:
+    """HTMX polling endpoint for live progress bars."""
+    conn = _conn()
+    run = db.get_run(conn, run_id)
+    if not run:
+        raise HTTPException(404)
+    return templates.TemplateResponse(
+        request,
+        "_progress.html",
+        {"run": run, "progress": db.progress_for(conn, run_id)},
+    )
+
+
+@app.get("/run/{run_id}/job/{job_id}", response_class=HTMLResponse)
+def job_view(request: Request, run_id: int, job_id: int) -> HTMLResponse:
+    conn = _conn()
+    row = conn.execute(
+        "SELECT * FROM jobs WHERE id = ? AND run_id = ?", (job_id, run_id)
+    ).fetchone()
+    if not row:
+        raise HTTPException(404)
+    raw = json.dumps(json.loads(row["raw"]), indent=2) if row["raw"] else ""
+    return templates.TemplateResponse(
+        request, "job.html", {"row": row, "raw": raw, "run_id": run_id}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Logs: served plain-text for direct access, and as an HTML <pre> fragment
+# for inline HTMX expansion in the diff tables.
+# ---------------------------------------------------------------------------
+
+
+def _log_root() -> Path | None:
+    """Directory under which build logs are allowed to live.
+
+    `minihydra serve` sets MINIHYDRA_LOG_ROOT to a known location. Without
+    it, log access is disabled so a tampered or copied-around DB cannot be
+    used to read arbitrary files.
+    """
+    raw = os.environ.get("MINIHYDRA_LOG_ROOT")
+    if not raw:
+        return None
+    return Path(raw).resolve()
+
+
+def _resolve_log(conn: sqlite3.Connection, run_id: int, job_id: int) -> Path:
+    row = conn.execute(
+        "SELECT build_log_path FROM jobs WHERE id = ? AND run_id = ?",
+        (job_id, run_id),
+    ).fetchone()
+    if not row or not row["build_log_path"]:
+        raise HTTPException(404, "no log")
+    root = _log_root()
+    if root is None:
+        raise HTTPException(403, "log access disabled (MINIHYDRA_LOG_ROOT unset)")
+    candidate = Path(row["build_log_path"]).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as e:
+        # Refuse anything outside the configured root; this is the
+        # path-traversal guardrail.
+        raise HTTPException(403, "log path outside allowed root") from e
+    if not candidate.exists():
+        raise HTTPException(404, "log file missing")
+    return candidate
+
+
+@app.get("/run/{run_id}/log/{job_id}", response_class=PlainTextResponse)
+def job_log(run_id: int, job_id: int) -> PlainTextResponse:
+    return PlainTextResponse(
+        _resolve_log(_conn(), run_id, job_id).read_text(errors="replace")
+    )
+
+
+@app.get("/run/{run_id}/log/{job_id}/inline", response_class=HTMLResponse)
+def job_log_inline(request: Request, run_id: int, job_id: int) -> HTMLResponse:
+    """Lazy-loaded log fragment for inline HTMX expansion.
+
+    Tail the log to a sane number of lines so a runaway build doesn't dump
+    megabytes of output into the diff page.
+    """
+    text = _resolve_log(_conn(), run_id, job_id).read_text(errors="replace")
+    tail_max = 400
+    lines = text.splitlines()
+    truncated = len(lines) > tail_max
+    body = "\n".join(lines[-tail_max:])
+    return templates.TemplateResponse(
+        request,
+        "_log.html",
+        {
+            "body": body,
+            "truncated": truncated,
+            "shown": min(tail_max, len(lines)),
+            "total": len(lines),
+            "run_id": run_id,
+            "job_id": job_id,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON API. The CLI consumes these via ASGI in-process; external agents/LLMs
+# can hit the same endpoints over HTTP. All shapes are stable contracts.
+# ---------------------------------------------------------------------------
+
+
+def _row(row: Any) -> dict[str, Any]:
+    return {k: row[k] for k in row.keys()}  # noqa: SIM118
+
+
+@app.get("/api/runs")
+def api_runs() -> JSONResponse:
+    conn = _conn()
+    return JSONResponse([_row(r) for r in db.runs(conn)])
+
+
+@app.get("/api/run/{run_id}")
+def api_run(run_id: int) -> JSONResponse:
+    conn = _conn()
+    run = db.get_run(conn, run_id)
+    if not run:
+        raise HTTPException(404)
+    d = _get_diff(conn, run_id)
+    base_count = sum(
+        len(getattr(d, n))
+        for n in ("removed", "newly_fixed", "changed", "unchanged", "still_broken")
+    )
+    head_count = sum(
+        len(getattr(d, n))
+        for n in ("added", "newly_broken", "changed", "unchanged", "still_broken")
+    )
+    return JSONResponse(
+        {
+            "run": _row(run),
+            "summary": d.summary(),
+            "counts": {"base": base_count, "head": head_count},
+            "progress": [_row(p) for p in db.progress_for(conn, run_id)],
+        }
+    )
+
+
+@app.get("/api/run/{run_id}/diff")
+def api_diff(run_id: int, q: str = "") -> JSONResponse:
+    conn = _conn()
+    if not db.get_run(conn, run_id):
+        raise HTTPException(404)
+    d = _filter_diff(_get_diff(conn, run_id), q)
+    return JSONResponse({"summary": d.summary(), **_serialize_diff(d)})
+
+
+@app.get("/api/run/{run_id}/section/{name}")
+def api_section(
+    run_id: int,
+    name: str,
+    q: str = "",
+    offset: int = 0,
+    limit: int | None = None,
+) -> JSONResponse:
+    if name not in SECTIONS:
+        raise HTTPException(404, f"unknown section {name}")
+    conn = _conn()
+    if not db.get_run(conn, run_id):
+        raise HTTPException(404)
+    d = _filter_diff(_get_diff(conn, run_id), q)
+    entries = getattr(d, name)
+    total = len(entries)
+    sliced = entries[offset : (offset + limit) if limit is not None else None]
+    return JSONResponse(
+        {
+            "section": name,
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+            "entries": [asdict(e) for e in sliced],
+        }
+    )
+
+
+@app.get("/api/run/{run_id}/job/{job_id}")
+def api_job(run_id: int, job_id: int) -> JSONResponse:
+    conn = _conn()
+    row = conn.execute(
+        "SELECT * FROM jobs WHERE id = ? AND run_id = ?", (job_id, run_id)
+    ).fetchone()
+    if not row:
+        raise HTTPException(404)
+    out = _row(row)
+    if out.get("raw"):
+        out["raw_parsed"] = json.loads(out["raw"])
+    return JSONResponse(out)
+
+
+@app.get("/api/run/{run_id}/progress")
+def api_progress(run_id: int) -> JSONResponse:
+    conn = _conn()
+    if not db.get_run(conn, run_id):
+        raise HTTPException(404)
+    return JSONResponse([_row(p) for p in db.progress_for(conn, run_id)])
+
+
+def _serialize_diff(d: diff.Diff) -> dict[str, list[dict[str, Any]]]:
+    return {name: [asdict(e) for e in getattr(d, name)] for name in SECTIONS}

--- a/pkgs/minihydra/tests/test_diff.py
+++ b/pkgs/minihydra/tests/test_diff.py
@@ -122,14 +122,16 @@ def test_copy_side_jobs_preserves_build_columns() -> None:
     conn, rid = _setup()
     _ins(conn, rid, "head", "foo", drv="/nix/store/foo.drv")
     foo_id = conn.execute("SELECT id FROM jobs WHERE attr='foo'").fetchone()[0]
-    db.update_build_status(
-        conn, [foo_id], "failed", log_path="/var/log/foo.log"
-    )
+    db.update_build_status(conn, [foo_id], "failed", log_path="/var/log/foo.log")
 
     rid2 = db.create_run(
-        conn, flake_ref="x", attr="a",
-        base_rev="b", head_rev="h",
-        base_resolved="a" * 40, head_resolved="b" * 40,
+        conn,
+        flake_ref="x",
+        attr="a",
+        base_rev="b",
+        head_rev="h",
+        base_resolved="a" * 40,
+        head_resolved="b" * 40,
     )
     db.copy_side_jobs(conn, rid, rid2, "head")
     row = db.jobs_for(conn, rid2, side="head")[0]

--- a/pkgs/minihydra/tests/test_diff.py
+++ b/pkgs/minihydra/tests/test_diff.py
@@ -1,0 +1,153 @@
+"""Diff classification: stable input -> deterministic bucket placement."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from minihydra import db, diff
+
+
+def _setup() -> tuple[sqlite3.Connection, int]:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(db.SCHEMA)
+    rid = db.create_run(
+        conn,
+        flake_ref="x",
+        attr="legacyPackages.x86_64-linux",
+        base_rev="HEAD~1",
+        head_rev="HEAD",
+        base_resolved="a" * 40,
+        head_resolved="b" * 40,
+    )
+    return conn, rid
+
+
+def _ins(conn, rid, side, attr, *, drv=None, error=None):
+    db.insert_job(
+        conn,
+        run_id=rid,
+        side=side,
+        record={"attr": attr, "drvPath": drv, "error": error, "system": "x86_64-linux"},
+    )
+
+
+def test_diff_buckets() -> None:
+    conn, rid = _setup()
+    # unchanged: same drv on both sides
+    _ins(conn, rid, "base", "hello", drv="/nix/store/aaa-hello.drv")
+    _ins(conn, rid, "head", "hello", drv="/nix/store/aaa-hello.drv")
+    # changed: drv differs
+    _ins(conn, rid, "base", "git", drv="/nix/store/bbb-git.drv")
+    _ins(conn, rid, "head", "git", drv="/nix/store/ccc-git.drv")
+    # added
+    _ins(conn, rid, "head", "newpkg", drv="/nix/store/ddd-new.drv")
+    # removed
+    _ins(conn, rid, "base", "oldpkg", drv="/nix/store/eee-old.drv")
+    # newly_broken
+    _ins(conn, rid, "base", "broke", drv="/nix/store/fff.drv")
+    _ins(conn, rid, "head", "broke", error="boom")
+    # newly_fixed
+    _ins(conn, rid, "base", "fixed", error="boom")
+    _ins(conn, rid, "head", "fixed", drv="/nix/store/ggg.drv")
+    # still_broken
+    _ins(conn, rid, "base", "stuck", error="x")
+    _ins(conn, rid, "head", "stuck", error="x")
+
+    base = db.jobs_for(conn, rid, side="base")
+    head = db.jobs_for(conn, rid, side="head")
+    d = diff.compute(base, head)
+    s = d.summary()
+    assert s == {
+        "added": 1,
+        "removed": 1,
+        "changed": 1,
+        "unchanged": 1,
+        "newly_broken": 1,
+        "newly_fixed": 1,
+        "still_broken": 1,
+    }
+    assert d.added[0].attr == "newpkg"
+    assert d.removed[0].attr == "oldpkg"
+    assert d.newly_broken[0].attr == "broke"
+
+
+def test_progress_upsert() -> None:
+    conn, rid = _setup()
+    db.update_progress(conn, rid, "eval-base", current=1, total=10, message="a")
+    db.update_progress(conn, rid, "eval-base", current=5, total=10, message="b")
+    rows = db.progress_for(conn, rid)
+    assert len(rows) == 1
+    assert rows[0]["current"] == 5
+    assert rows[0]["message"] == "b"
+
+
+def test_copy_side_jobs_round_trip() -> None:
+    """`minihydra rerun` reuses a prior run's base side; verify the copy
+    helper preserves attrs, drv paths, and errors so the diff is identical
+    against the new head."""
+    conn, rid = _setup()
+    _ins(conn, rid, "base", "hello", drv="/nix/store/aaa.drv")
+    _ins(conn, rid, "base", "git", drv="/nix/store/bbb.drv")
+    _ins(conn, rid, "base", "broken", error="boom")
+    # Different side and a head row should not bleed across.
+    _ins(conn, rid, "head", "hello", drv="/nix/store/aaa.drv")
+
+    rid2 = db.create_run(
+        conn,
+        flake_ref="x",
+        attr="legacyPackages.x86_64-linux",
+        base_rev="HEAD~1",
+        head_rev="HEAD",
+        base_resolved="a" * 40,
+        head_resolved="c" * 40,
+    )
+    n = db.copy_side_jobs(conn, rid, rid2, "base")
+    assert n == 3
+
+    copied = db.jobs_for(conn, rid2, side="base")
+    assert {(r["attr"], r["drv_path"], r["error"]) for r in copied} == {
+        ("hello", "/nix/store/aaa.drv", None),
+        ("git", "/nix/store/bbb.drv", None),
+        ("broken", None, "boom"),
+    }
+    # Head-side rows of run 1 are untouched.
+    assert db.jobs_for(conn, rid2, side="head") == []
+
+
+def test_copy_side_jobs_preserves_build_columns() -> None:
+    """Even though `rerun` only copies the base side today, the helper must
+    keep build_status/build_log_path so future callers that copy head don't
+    silently lose build results."""
+    conn, rid = _setup()
+    _ins(conn, rid, "head", "foo", drv="/nix/store/foo.drv")
+    foo_id = conn.execute("SELECT id FROM jobs WHERE attr='foo'").fetchone()[0]
+    db.update_build_status(
+        conn, [foo_id], "failed", log_path="/var/log/foo.log"
+    )
+
+    rid2 = db.create_run(
+        conn, flake_ref="x", attr="a",
+        base_rev="b", head_rev="h",
+        base_resolved="a" * 40, head_resolved="b" * 40,
+    )
+    db.copy_side_jobs(conn, rid, rid2, "head")
+    row = db.jobs_for(conn, rid2, side="head")[0]
+    assert row["build_status"] == "failed"
+    assert row["build_log_path"] == "/var/log/foo.log"
+
+
+def test_latest_run_orders_by_created_at() -> None:
+    conn, _ = _setup()
+    rid2 = db.create_run(
+        conn,
+        flake_ref="x",
+        attr="a",
+        base_rev="b",
+        head_rev="h",
+        base_resolved="b" * 40,
+        head_resolved="h" * 40,
+    )
+    latest = db.latest_run(conn)
+    assert latest is not None
+    assert latest["id"] == rid2

--- a/pkgs/minihydra/tests/test_web.py
+++ b/pkgs/minihydra/tests/test_web.py
@@ -1,0 +1,312 @@
+"""Web layer: smoke-test the FastAPI app against an in-process sqlite db."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from minihydra import db
+
+
+def _seed(tmp_path: Path) -> Path:
+    p = tmp_path / "m.db"
+    conn = db.connect(p)
+    rid = db.create_run(
+        conn,
+        flake_ref="repo",
+        attr="legacyPackages.x86_64-linux",
+        base_rev="HEAD~1",
+        head_rev="HEAD",
+        base_resolved="a" * 40,
+        head_resolved="b" * 40,
+    )
+    db.insert_job(
+        conn,
+        run_id=rid,
+        side="base",
+        record={
+            "attr": "hello",
+            "drvPath": "/nix/store/x.drv",
+            "system": "x86_64-linux",
+        },
+    )
+    db.insert_job(
+        conn,
+        run_id=rid,
+        side="head",
+        record={
+            "attr": "hello",
+            "drvPath": "/nix/store/y.drv",
+            "system": "x86_64-linux",
+        },
+    )
+    db.update_progress(conn, rid, "eval-head", current=1, total=1, message="done")
+    db.set_run_status(conn, rid, "done")
+    conn.close()
+    return p
+
+
+def test_routes(tmp_path: Path) -> None:
+    db_path = _seed(tmp_path)
+    os.environ["MINIHYDRA_DB"] = str(db_path)
+    # import after env var so the app picks it up if it ever caches
+    from minihydra.web import app
+
+    client = TestClient(app)
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "runs" in r.text
+
+    r = client.get("/run/1")
+    assert r.status_code == 200
+    assert "changed" in r.text or "diff" in r.text
+
+    r = client.get("/run/1/progress")
+    assert r.status_code == 200
+    assert "eval-head" in r.text
+
+    r = client.get("/run/1/section/changed")
+    assert r.status_code == 200
+    assert "hello" in r.text
+
+    r = client.get("/run/999")
+    assert r.status_code == 404
+
+    # JSON API parity with the human routes.
+    r = client.get("/api/runs")
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+    assert r.json()[0]["id"] == 1
+
+    r = client.get("/api/run/1")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["summary"]["changed"] == 1
+    assert body["counts"] == {"base": 1, "head": 1}
+
+    r = client.get("/api/run/1/diff")
+    assert r.status_code == 200
+    assert r.json()["changed"][0]["attr"] == "hello"
+
+    r = client.get("/api/run/1/section/changed")
+    assert r.status_code == 200
+    assert len(r.json()["entries"]) == 1
+
+    r = client.get("/api/run/1/section/bogus")
+    assert r.status_code == 404
+
+
+def test_log_endpoint_path_traversal(tmp_path: Path) -> None:
+    """A poisoned build_log_path must not exfiltrate files outside the root."""
+    db_path = _seed(tmp_path)
+    log_root = tmp_path / "logs"
+    log_root.mkdir()
+    legit = log_root / "1.log"
+    legit.write_text("hello-log")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOPSECRET")
+
+    from minihydra import db as dbmod
+
+    conn = dbmod.connect(db_path)
+    # job id 1 = base side hello, id 2 = head side hello
+    dbmod.update_build_status(conn, [2], "ok", log_path=str(legit))
+    dbmod.update_build_status(conn, [1], "ok", log_path=str(secret))
+    conn.close()
+
+    os.environ["MINIHYDRA_DB"] = str(db_path)
+    os.environ["MINIHYDRA_LOG_ROOT"] = str(log_root)
+    from minihydra.web import app
+
+    client = TestClient(app)
+
+    # Legit path inside the root: 200 + content.
+    r = client.get("/run/1/log/2")
+    assert r.status_code == 200
+    assert r.text == "hello-log"
+
+    # Path outside the root: 403, never the file contents.
+    r = client.get("/run/1/log/1")
+    assert r.status_code == 403
+    assert "TOPSECRET" not in r.text
+
+    # With no MINIHYDRA_LOG_ROOT, the endpoint refuses unconditionally.
+    del os.environ["MINIHYDRA_LOG_ROOT"]
+    r = client.get("/run/1/log/2")
+    assert r.status_code == 403
+
+
+def test_template_filters() -> None:
+    """The drv-shortening + first-lines filters underpin the readable UI."""
+    from minihydra.web import _datetime, _drv_short, _first_lines
+
+    # Real-shaped 32-char hash gets stripped and .drv suffix removed.
+    assert (
+        _drv_short("/nix/store/abcdefghijklmnopqrstuvwxyz012345-hello-1.0.drv")
+        == "hello-1.0"
+    )
+    # Non-conforming hash is left alone (defensive: better to show too much
+    # than to silently mangle a path).
+    assert _drv_short("/nix/store/short-fake.drv") == "/nix/store/short-fake"
+    assert _drv_short(None) == ""
+    assert _drv_short("") == ""
+
+    # first_lines truncates and indicates how many lines were dropped.
+    long = "\n".join(f"line {i}" for i in range(10))
+    assert _first_lines(long, 3).startswith("line 0\nline 1\nline 2")
+    assert "7 more lines" in _first_lines(long, 3)
+    assert _first_lines(None) == ""
+
+    # datetime: no exception on edge values.
+    assert _datetime(0).startswith("1970-01-01")
+    assert _datetime(None) == ""
+
+
+def _seed_many(tmp_path: Path, n_unchanged: int = 250, n_changed: int = 5) -> Path:
+    """Larger fixture so the pagination/search/cache tests have room to work."""
+    p = tmp_path / "big.db"
+    conn = db.connect(p)
+    rid = db.create_run(
+        conn,
+        flake_ref="repo",
+        attr="legacyPackages.x86_64-linux",
+        base_rev="HEAD~1",
+        head_rev="HEAD",
+        base_resolved="a" * 40,
+        head_resolved="b" * 40,
+    )
+    h = "abcdefghijklmnopqrstuvwxyz012345"
+    for i in range(n_unchanged):
+        d = f"/nix/store/{h}-pkg{i:04d}-1.0.drv"
+        for side in ("base", "head"):
+            db.insert_job(
+                conn,
+                run_id=rid,
+                side=side,
+                record={
+                    "attr": f"unchanged.pkg{i:04d}",
+                    "drvPath": d,
+                    "system": "x86_64-linux",
+                },
+            )
+    for i in range(n_changed):
+        db.insert_job(
+            conn,
+            run_id=rid,
+            side="base",
+            record={"attr": f"python.pkg{i}", "drvPath": f"/nix/store/{h}-old{i}.drv"},
+        )
+        db.insert_job(
+            conn,
+            run_id=rid,
+            side="head",
+            record={"attr": f"python.pkg{i}", "drvPath": f"/nix/store/{h}-new{i}.drv"},
+        )
+    db.update_progress(
+        conn, rid, "eval-head", current=n_unchanged, total=n_unchanged, message="done"
+    )
+    db.set_run_status(conn, rid, "done")
+    conn.close()
+    return p
+
+
+def test_pagination_limits_section_body(tmp_path: Path) -> None:
+    """Sections must paginate so a 30k-row unchanged bucket doesn't blow up
+    the page. The load-more button is the contract; verify it shows up."""
+    db_path = _seed_many(tmp_path, n_unchanged=250)
+    os.environ["MINIHYDRA_DB"] = str(db_path)
+    from minihydra import web
+    from minihydra.web import app
+
+    web._DIFF_CACHE.clear()  # noqa: SLF001
+    client = TestClient(app)
+
+    # Default limit is 100; with 250 unchanged rows we expect a load-more.
+    r = client.get("/run/1/section/unchanged")
+    assert r.status_code == 200
+    assert "load-more" in r.text
+    assert "100 of 250" in r.text
+    # Bumping limit shrinks the remaining count.
+    r = client.get("/run/1/section/unchanged?limit=200")
+    assert "200 of 250" in r.text
+    # Limit beyond total: no button, all-shown footer.
+    r = client.get("/run/1/section/unchanged?limit=1000")
+    assert "load-more" not in r.text
+    assert "all 250 shown" in r.text
+
+
+def test_search_filters_attrs(tmp_path: Path) -> None:
+    """The search endpoint must narrow each section to attrs containing q,
+    case-insensitively, and reuse the diff-area template."""
+    db_path = _seed_many(tmp_path)
+    os.environ["MINIHYDRA_DB"] = str(db_path)
+    from minihydra import web
+    from minihydra.web import app
+
+    web._DIFF_CACHE.clear()  # noqa: SLF001
+    client = TestClient(app)
+
+    r = client.get("/run/1/search?q=python")
+    assert r.status_code == 200
+    # The 5 changed.python.* match; no unchanged should leak through.
+    assert "python.pkg0" in r.text
+    assert "unchanged.pkg0000" not in r.text
+    # Empty match still renders the area with a friendly message.
+    r = client.get("/run/1/search?q=zzzzzzzznope")
+    assert "no attributes match" in r.text
+
+    # Case-insensitive.
+    r = client.get("/run/1/search?q=PYTHON")
+    assert "python.pkg0" in r.text
+
+
+def test_diff_cache_invalidates_on_progress_update(tmp_path: Path) -> None:
+    """Cache key uses the latest progress.updated_at so a still-running
+    eval picks up new rows. Stale cache would mean the UI shows old data."""
+    db_path = _seed_many(tmp_path, n_unchanged=10)
+    os.environ["MINIHYDRA_DB"] = str(db_path)
+    from minihydra import web
+
+    web._DIFF_CACHE.clear()  # noqa: SLF001
+    conn = db.connect(db_path)
+    d1 = web._get_diff(conn, 1)  # noqa: SLF001
+    assert len(d1.unchanged) == 10
+    assert 1 in web._DIFF_CACHE  # noqa: SLF001
+
+    # Insert a new attr and bump progress; cache should re-compute.
+    db.insert_job(
+        conn,
+        run_id=1,
+        side="head",
+        record={"attr": "brandnew", "drvPath": "/nix/store/x-new.drv"},
+    )
+    db.update_progress(conn, 1, "eval-head", current=11, total=11, message="more")
+    d2 = web._get_diff(conn, 1)  # noqa: SLF001
+    assert any(e.attr == "brandnew" for e in d2.added)
+
+
+def test_inline_log_endpoint_tails(tmp_path: Path) -> None:
+    """Inline log fragment must tail to keep diff pages small."""
+    db_path = _seed(tmp_path)
+    log_root = tmp_path / "logs"
+    log_root.mkdir()
+    log = log_root / "big.log"
+    log.write_text("\n".join(f"line {i}" for i in range(1000)))
+
+    conn = db.connect(db_path)
+    db.update_build_status(conn, [2], "ok", log_path=str(log))
+    conn.close()
+
+    os.environ["MINIHYDRA_DB"] = str(db_path)
+    os.environ["MINIHYDRA_LOG_ROOT"] = str(log_root)
+    from minihydra.web import app
+
+    client = TestClient(app)
+    r = client.get("/run/1/log/2/inline")
+    assert r.status_code == 200
+    # Tail caps at 400 lines; a 1000-line log triggers the truncation hint.
+    assert "line 999" in r.text
+    assert "line 0\n" not in r.text
+    assert "showing last 400 of 1000" in r.text
+    del os.environ["MINIHYDRA_LOG_ROOT"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ exclude = ["zsh/*", "gdb/*"]
 "machines/eve/modules/paperless-perms/paperless_perms/apps.py" = ["PLC0415"]
 # Standalone script, not a package
 "nixosModules/niri/kwallet-tpm/kwallet-tpm-unlock.py" = ["INP001"]
+# minihydra: keyword-arg-rich helpers + lazy uvicorn import
+"pkgs/minihydra/src/minihydra/*.py" = ["PLR0913", "PLR0915", "PLC0415", "TC003"]
+"pkgs/minihydra/tests/*.py" = ["PLC0415", "S101", "PLR0913", "TC003", "ANN"]
 
 [tool.mypy]
 python_version = "3.13"


### PR DESCRIPTION
Adds `minihydra`: a tiny tool that answers "what does this commit
actually change in nixpkgs?" by running nix-eval-jobs at base + head,
diffing the results, and serving them via a search/paginate-friendly web
UI.

## Workflow

```sh
# initial: full eval against origin/main
minihydra run --attr legacyPackages.x86_64-linux --base origin/main
# → run #1, newly_broken: pkgFoo

# fix something, commit
minihydra rerun                       # reuses run #1's base, ~minutes → seconds
minihydra serve                       # web UI
minihydra summary 2                   # compact text for LLM context
```

## Surface

- CLI: `run`, `rerun`, `serve`, `list`, `show`, `diff`, `summary`, `job`
- HTTP API: `/api/runs`, `/api/run/{id}`, `/api/run/{id}/diff`,
  `/api/run/{id}/section/{name}`, `/api/run/{id}/job/{jid}`
- The CLI's read-only commands wrap the same FastAPI app in-process via
  `httpx.ASGITransport`, so JSON shapes match server-side rendering.
- Single-file SQLite DB at `\$XDG_DATA_HOME/minihydra/minihydra.db`.

## Web UI

HTMX-driven, server-rendered. Designed to scale to a real nixpkgs eval
(~80k attrs):

- Sticky search box, server-side substring filter across all sections
- Per-section pagination ("show 100 more · 100 of 4000")
- Lazy build logs in a single shared `<dialog>` popover, tail-truncated
- Per-bucket table layouts (newly_broken: full-width error column;
  changed: was → now with red/green; etc.)
- Drv hash prefix stripped for display (`hello-1.0` instead of
  `/nix/store/abc…-hello-1.0.drv`)
- Diff cache keyed on the latest progress timestamp, so still-running
  evals see fresh data and finished runs hit cache instantly
- Page weight on a 68k-row fixture: 8.2 MB → 95 KB

## Security

- `serve` binds 127.0.0.1 by default; non-loopback requires
  `--allow-public`
- Build-log endpoint resolves and validates paths against
  `MINIHYDRA_LOG_ROOT`, so a poisoned `build_log_path` in a
  copied-around DB cannot exfiltrate arbitrary files
- `git worktree add` uses a `--` sentinel against hostile rev names
- README documents that evaluating an untrusted ref runs untrusted Nix
  code (same risk class as `nix flake show` on a hostile flake)

## Tests

12 tests covering: diff classification, copy-side-jobs round trip
(including build columns), log path-traversal guard, search /
pagination / cache invalidation, and the template filters. All run
in-build via `pytestCheckHook`.