### PR TITLE
home-manager/coder: add yensid remote builders

### DIFF
--- a/home-manager/coder.nix
+++ b/home-manager/coder.nix
@@ -136,6 +136,22 @@
       /usr/bin/sudo tee /etc/nix/machines > /dev/null <<'NIXEOF'
     ssh-ng://nix2-builder?max-connections=8 x86_64-linux - 192 1 big-parallel,kvm,nixos-test - -
     NIXEOF
+    else
+      # yensid: load-balanced x86/arm builder pools. Auth via the persistent
+      # key in ~/src/keys (must be in yensid's allow-list). ssh-ng ignores
+      # ssh_config Port, so the arm pool's :2222 lives in the URI.
+      /usr/bin/sudo tee /etc/nix/machines > /dev/null <<'NIXEOF'
+    ssh-ng://builder-ssh@x86-64-linux.yensid.rio-build.com?max-connections=4 x86_64-linux /root/src/keys/id_ed25519 64 2 benchmark,big-parallel,kvm,nixos-test - -
+    ssh-ng://builder-ssh@aarch64-linux.yensid.rio-build.com:2222?max-connections=4 aarch64-linux /root/src/keys/id_ed25519 64 2 benchmark,big-parallel,kvm,nixos-test - -
+    NIXEOF
+
+      # yensid load-balances across builders with different host keys;
+      # trust the CA that signs them instead of pinning each one.
+      if ! /usr/bin/sudo grep -qs 'yensid.rio-build.com' /etc/ssh/ssh_known_hosts 2>/dev/null; then
+        /usr/bin/sudo tee -a /etc/ssh/ssh_known_hosts > /dev/null <<'KHEOF'
+    @cert-authority yensid.rio-build.com,*.yensid.rio-build.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO3TEgIFuRf18rB9tWDfNCZfprjC0hjMgSj2MTGu5jQY
+    KHEOF
+      fi
     fi
   '';
 }


### PR DESCRIPTION
Coder pods are small; offload to the yensid bare-metal x86/arm pools. Auth uses ~/src/keys/id_ed25519 (persists across restarts, in yensid's allow-list). Trust the host-key signing CA via @cert-authority since the proxy load-balances across builders. nix1-devspace keeps its existing nix2 builder.