### PR TITLE
firefox-extensions: add app-windows extension

### DIFF
--- a/darwinModules/nix-casks.nix
+++ b/darwinModules/nix-casks.nix
@@ -10,7 +10,6 @@ in
 
   environment.casks = [
     cask.alt-tab
-    cask.ferdium
     cask.ungoogled-chromium
     cask.signal
     cask.ghostty

--- a/darwinModules/nix-casks.nix
+++ b/darwinModules/nix-casks.nix
@@ -23,7 +23,7 @@ in
       policies = import ../pkgs/librewolf-policies.nix {
         inherit (pkgs) lib stdenv;
         inherit (micsSkills) browser-cli-extension;
-        inherit (firefoxExtensions) chrome-tab-gc-extension;
+        inherit (firefoxExtensions) chrome-tab-gc-extension app-windows-extension;
       };
     })
     myPkgs.radicle-desktop

--- a/home-manager/modules/librewolf.nix
+++ b/home-manager/modules/librewolf.nix
@@ -25,7 +25,7 @@ in
       extraPolicies = import ../../pkgs/librewolf-policies.nix {
         inherit (pkgs) lib stdenv;
         inherit (micsSkillsPkgs) browser-cli-extension;
-        inherit (firefoxExtensions) chrome-tab-gc-extension;
+        inherit (firefoxExtensions) chrome-tab-gc-extension app-windows-extension;
       };
     })
   ];

--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -63,7 +63,10 @@ comments use normal English.
 ## Git
 
 - Commit messages: Linux-kernel style, explain WHY the change is needed.
-- Always test/lint/format before committing.
+- Before committing:
+  1. Check for bugs
+  2. Try to simplify your code
+  3. Always test/lint/format
 - Use `gh` for GitHub (CI logs, issues, PRs), e.g.
   `gh run view 18256703410 --log`
 - Use `tea` for Gitea, e.g. `tea pr 5519 --comments`

--- a/machines/evo/configuration.nix
+++ b/machines/evo/configuration.nix
@@ -40,6 +40,10 @@
     # per /nix/store entry (~700k objects, ~1GB RSS) when it enumerates the dir
     test -e /nix/.metadata_never_index || touch /nix/.metadata_never_index
     chflags hidden /nix
+
+    # Disable AirPlay Receiver to prevent FUSkyBridge from holding locks
+    # in WindowServer, which can cause watchdog timeout crashes.
+    sudo -u joerg defaults -currentHost write com.apple.controlcenter AirplayReceiverEnabled -bool false
   '';
 
   fonts.packages = [ pkgs.nerd-fonts.fira-code ];

--- a/pkgs/firefox-extensions/app-windows/background.js
+++ b/pkgs/firefox-extensions/app-windows/background.js
@@ -1,0 +1,220 @@
+// @ts-check
+/// <reference path="webext.d.ts" />
+/// <reference path="defaults.js" />
+"use strict";
+
+const SESSION_KEY = "appWindowsRole";
+const TAB_KEY = "appWindowsApp";
+
+/** @type {number | null} */
+let appWindowId = null;
+/** Most recently focused non-app window (for routing external links).
+ * @type {number | null} */
+let lastMainWindowId = null;
+
+/** @returns {Promise<App[]>} */
+async function getApps() {
+  const { apps } = await browser.storage.sync.get({ apps: DEFAULT_APPS });
+  return apps;
+}
+
+/** @param {string} url */
+function hostnameOf(url) {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "";
+  }
+}
+
+/** @param {App[]} apps @param {string} url */
+function inScope(apps, url) {
+  const host = hostnameOf(url);
+  return apps.some((app) =>
+    host === app.scope || host.endsWith("." + app.scope)
+  );
+}
+
+/** Get or create a container for an app. Returns its cookieStoreId or undefined.
+ * @param {App} app */
+async function containerFor(app) {
+  if (!app.color) return undefined;
+  const name = `App: ${app.name}`;
+  const existing = await browser.contextualIdentities.query({ name });
+  if (existing.length > 0) return existing[0].cookieStoreId;
+  const created = await browser.contextualIdentities.create({
+    name,
+    color: app.color,
+    icon: app.icon ?? "circle",
+  });
+  return created.cookieStoreId;
+}
+
+/** @type {Promise<void> | null} */
+let ensuring = null;
+
+function ensureAppWindow() {
+  if (!ensuring) {
+    ensuring = ensureAppWindowImpl().finally(() => {
+      ensuring = null;
+    });
+  }
+  return ensuring;
+}
+
+async function ensureAppWindowImpl() {
+  const apps = await getApps();
+  if (apps.length === 0) return;
+
+  if (appWindowId !== null) {
+    try {
+      await browser.windows.get(appWindowId);
+    } catch {
+      appWindowId = null;
+    }
+  }
+
+  if (appWindowId === null) {
+    const win = await browser.windows.create({ type: "normal" });
+    if (win.id === undefined) return;
+    appWindowId = win.id;
+    await browser.sessions.setWindowValue(win.id, SESSION_KEY, "app");
+    await addAppTabs(win.id, apps, new Set());
+    // Close the blank tab the new window started with
+    const [blank] = await browser.tabs.query({ windowId: win.id, index: 0 });
+    if (blank?.id !== undefined && blank.url === "about:blank") {
+      await browser.tabs.remove(blank.id).catch(() => {});
+    }
+    return;
+  }
+
+  // Window exists: add tabs for any apps that don't have one yet
+  const tabs = await browser.tabs.query({ windowId: appWindowId });
+  const present = new Set();
+  for (const t of tabs) {
+    if (t.id === undefined) continue;
+    const name = await browser.sessions.getTabValue(t.id, TAB_KEY);
+    if (typeof name === "string") present.add(name);
+  }
+  await addAppTabs(appWindowId, apps, present);
+}
+
+/** @param {number} windowId @param {App[]} apps @param {Set<string>} skip */
+async function addAppTabs(windowId, apps, skip) {
+  for (const app of apps) {
+    if (skip.has(app.name)) continue;
+    try {
+      const cookieStoreId = await containerFor(app);
+      const tab = await browser.tabs.create({ windowId, url: app.url, cookieStoreId });
+      if (tab.id !== undefined) await browser.sessions.setTabValue(tab.id, TAB_KEY, app.name);
+    } catch (e) {
+      console.error("app-windows: failed to open", app.name, e);
+    }
+  }
+}
+
+async function focusAppWindow() {
+  await ensureAppWindow();
+  if (appWindowId !== null) {
+    await browser.windows.update(appWindowId, { focused: true });
+  }
+}
+
+async function findMainWindow() {
+  if (lastMainWindowId !== null && lastMainWindowId !== appWindowId) {
+    try {
+      return await browser.windows.get(lastMainWindowId);
+    } catch {
+      lastMainWindowId = null;
+    }
+  }
+  const windows = await browser.windows.getAll({
+    populate: false,
+    windowTypes: ["normal"],
+  });
+  return windows.find((w) => w.id !== appWindowId) ?? null;
+}
+
+/** @param {number} tabId @param {string} url */
+async function moveTabToMain(tabId, url) {
+  const main = await findMainWindow();
+  if (main?.id !== undefined) {
+    await browser.tabs.move(tabId, { windowId: main.id, index: -1 });
+    await browser.tabs.update(tabId, { active: true });
+    await browser.windows.update(main.id, { focused: true });
+  } else {
+    const win = await browser.windows.create({ url });
+    lastMainWindowId = win.id ?? null;
+    await browser.tabs.remove(tabId);
+  }
+}
+
+async function restoreState() {
+  const windows = await browser.windows.getAll({ populate: false });
+  for (const win of windows) {
+    if (win.id === undefined) continue;
+    const role = await browser.sessions.getWindowValue(win.id, SESSION_KEY);
+    if (role === "app") {
+      appWindowId = win.id;
+    } else if (win.focused) {
+      lastMainWindowId = win.id;
+    }
+  }
+  await ensureAppWindow();
+}
+
+// Move out-of-scope tabs created in the app window to the main window.
+browser.tabs.onCreated.addListener(async (tab) => {
+  if (tab.windowId !== appWindowId || tab.id === undefined) return;
+  const apps = await getApps();
+  const tabId = tab.id;
+
+  if (tab.url && tab.url !== "about:blank" && tab.url !== "about:newtab") {
+    if (!inScope(apps, tab.url)) {
+      moveTabToMain(tabId, tab.url).catch(console.error);
+    }
+    return;
+  }
+
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let timer;
+  const cleanup = () => {
+    browser.tabs.onUpdated.removeListener(onUpdated);
+    browser.tabs.onRemoved.removeListener(onRemoved);
+    clearTimeout(timer);
+  };
+  /** @type {(tabId: number, changeInfo: TabChangeInfo, tab: BrowserTab) => void} */
+  const onUpdated = (updatedTabId, changeInfo) => {
+    if (updatedTabId !== tabId || !changeInfo.url) return;
+    if (changeInfo.url === "about:blank" || changeInfo.url === "about:newtab") {
+      return;
+    }
+    cleanup();
+    if (!inScope(apps, changeInfo.url)) {
+      moveTabToMain(tabId, changeInfo.url).catch(console.error);
+    }
+  };
+  /** @type {(removedTabId: number) => void} */
+  const onRemoved = (removedTabId) => {
+    if (removedTabId === tabId) cleanup();
+  };
+  browser.tabs.onUpdated.addListener(onUpdated);
+  browser.tabs.onRemoved.addListener(onRemoved);
+  timer = setTimeout(cleanup, 10000);
+});
+
+browser.windows.onFocusChanged.addListener((windowId) => {
+  if (windowId === browser.windows.WINDOW_ID_NONE) return;
+  if (windowId !== appWindowId) lastMainWindowId = windowId;
+});
+
+browser.windows.onRemoved.addListener((windowId) => {
+  if (appWindowId === windowId) appWindowId = null;
+  if (lastMainWindowId === windowId) lastMainWindowId = null;
+});
+
+browser.browserAction.onClicked.addListener(() => {
+  focusAppWindow().catch(console.error);
+});
+
+restoreState().catch(console.error);

--- a/pkgs/firefox-extensions/app-windows/background.js
+++ b/pkgs/firefox-extensions/app-windows/background.js
@@ -85,18 +85,41 @@ async function ensureAppWindowImpl() {
     if (blank?.id !== undefined && blank.url === "about:blank") {
       await browser.tabs.remove(blank.id).catch(() => {});
     }
+    await sortAppTabs(win.id, apps);
     return;
   }
 
   // Window exists: add tabs for any apps that don't have one yet
   const tabs = await browser.tabs.query({ windowId: appWindowId });
-  const present = new Set();
+  /** @type {Map<string, number>} */
+  const tabByApp = new Map();
   for (const t of tabs) {
     if (t.id === undefined) continue;
     const name = await browser.sessions.getTabValue(t.id, TAB_KEY);
-    if (typeof name === "string") present.add(name);
+    if (typeof name === "string") tabByApp.set(name, t.id);
   }
-  await addAppTabs(appWindowId, apps, present);
+  await addAppTabs(appWindowId, apps, new Set(tabByApp.keys()));
+  await sortAppTabs(appWindowId, apps);
+}
+
+/** Reorder app tabs to match the configured order.
+ * @param {number} windowId @param {App[]} apps */
+async function sortAppTabs(windowId, apps) {
+  const tabs = await browser.tabs.query({ windowId });
+  /** @type {Map<string, number>} */
+  const tabByApp = new Map();
+  for (const t of tabs) {
+    if (t.id === undefined) continue;
+    const name = await browser.sessions.getTabValue(t.id, TAB_KEY);
+    if (typeof name === "string") tabByApp.set(name, t.id);
+  }
+  let index = 0;
+  for (const app of apps) {
+    const tabId = tabByApp.get(app.name);
+    if (tabId === undefined) continue;
+    await browser.tabs.move(tabId, { index }).catch(console.error);
+    index++;
+  }
 }
 
 /** @param {number} windowId @param {App[]} apps @param {Set<string>} skip */

--- a/pkgs/firefox-extensions/app-windows/background.js
+++ b/pkgs/firefox-extensions/app-windows/background.js
@@ -105,8 +105,15 @@ async function addAppTabs(windowId, apps, skip) {
     if (skip.has(app.name)) continue;
     try {
       const cookieStoreId = await containerFor(app);
-      const tab = await browser.tabs.create({ windowId, url: app.url, cookieStoreId });
-      if (tab.id !== undefined) await browser.sessions.setTabValue(tab.id, TAB_KEY, app.name);
+      const tab = await browser.tabs.create({
+        windowId,
+        url: app.url,
+        cookieStoreId,
+        pinned: true,
+      });
+      if (tab.id !== undefined) {
+        await browser.sessions.setTabValue(tab.id, TAB_KEY, app.name);
+      }
     } catch (e) {
       console.error("app-windows: failed to open", app.name, e);
     }

--- a/pkgs/firefox-extensions/app-windows/defaults.js
+++ b/pkgs/firefox-extensions/app-windows/defaults.js
@@ -36,13 +36,6 @@ const DEFAULT_APPS = [
     icon: "briefcase",
   },
   {
-    name: "Slack Numtide Labs",
-    url: "https://numtide-labs.slack.com/",
-    scope: "slack.com",
-    color: "yellow",
-    icon: "briefcase",
-  },
-  {
     name: "Slack TUM",
     url: "https://ls1-tum.slack.com/",
     scope: "slack.com",

--- a/pkgs/firefox-extensions/app-windows/defaults.js
+++ b/pkgs/firefox-extensions/app-windows/defaults.js
@@ -1,0 +1,59 @@
+"use strict";
+
+/** @typedef {{ name: string, url: string, scope: string, color?: string, icon?: string }} App */
+
+// Valid Firefox container colors: blue, turquoise, green, yellow, orange, red, pink, purple
+// Valid icons: fingerprint, briefcase, dollar, cart, circle, gift, vacation, food, fruit, pet, tree, chill, fence
+
+/** @type {App[]} */
+const DEFAULT_APPS = [
+  {
+    name: "WhatsApp",
+    url: "https://web.whatsapp.com/",
+    scope: "web.whatsapp.com",
+    color: "green",
+    icon: "circle",
+  },
+  {
+    name: "Discord",
+    url: "https://discord.com/app",
+    scope: "discord.com",
+    color: "purple",
+    icon: "circle",
+  },
+  {
+    name: "Element",
+    url: "https://matrix.thalheim.io/",
+    scope: "matrix.thalheim.io",
+    color: "turquoise",
+    icon: "circle",
+  },
+  {
+    name: "Slack Numtide",
+    url: "https://numtide.slack.com/",
+    scope: "slack.com",
+    color: "blue",
+    icon: "briefcase",
+  },
+  {
+    name: "Slack Numtide Labs",
+    url: "https://numtide-labs.slack.com/",
+    scope: "slack.com",
+    color: "yellow",
+    icon: "briefcase",
+  },
+  {
+    name: "Slack TUM",
+    url: "https://ls1-tum.slack.com/",
+    scope: "slack.com",
+    color: "orange",
+    icon: "briefcase",
+  },
+  {
+    name: "Slack TII",
+    url: "https://securesystem-71s3304.slack.com/",
+    scope: "slack.com",
+    color: "red",
+    icon: "briefcase",
+  },
+];

--- a/pkgs/firefox-extensions/app-windows/jsconfig.json
+++ b/pkgs/firefox-extensions/app-windows/jsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "target": "es2022",
+    "module": "none",
+    "lib": ["es2022", "dom", "dom.iterable"]
+  },
+  "include": ["*.js", "*.d.ts"]
+}

--- a/pkgs/firefox-extensions/app-windows/manifest.json
+++ b/pkgs/firefox-extensions/app-windows/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "App Windows",
-  "version": "1.14",
+  "version": "1.15",
   "description": "Run web apps (WhatsApp, Discord, Element) in dedicated windows. External links open in your normal window.",
   "permissions": [
     "tabs",

--- a/pkgs/firefox-extensions/app-windows/manifest.json
+++ b/pkgs/firefox-extensions/app-windows/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "App Windows",
-  "version": "1.13",
+  "version": "1.14",
   "description": "Run web apps (WhatsApp, Discord, Element) in dedicated windows. External links open in your normal window.",
   "permissions": [
     "tabs",

--- a/pkgs/firefox-extensions/app-windows/manifest.json
+++ b/pkgs/firefox-extensions/app-windows/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 2,
+  "name": "App Windows",
+  "version": "1.13",
+  "description": "Run web apps (WhatsApp, Discord, Element) in dedicated windows. External links open in your normal window.",
+  "permissions": [
+    "tabs",
+    "storage",
+    "sessions",
+    "contextualIdentities",
+    "cookies"
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "app-windows@thalheim.io"
+    }
+  },
+  "background": {
+    "scripts": ["defaults.js", "background.js"]
+  },
+  "browser_action": {
+    "default_title": "Open Messengers"
+  },
+  "options_ui": {
+    "page": "options.html"
+  }
+}

--- a/pkgs/firefox-extensions/app-windows/manifest.json
+++ b/pkgs/firefox-extensions/app-windows/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "App Windows",
-  "version": "1.15",
+  "version": "1.16",
   "description": "Run web apps (WhatsApp, Discord, Element) in dedicated windows. External links open in your normal window.",
   "permissions": [
     "tabs",

--- a/pkgs/firefox-extensions/app-windows/options.html
+++ b/pkgs/firefox-extensions/app-windows/options.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        font: menu;
+        padding: 1em;
+        max-width: 600px;
+      }
+      textarea {
+        width: 100%;
+        height: 200px;
+        font-family: monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>App Windows</h2>
+    <p>
+      JSON array of apps. Each entry needs <code>name</code>, <code>url</code>
+      (start page), and <code>scope</code> (hostname; subdomains match too).
+    </p>
+    <textarea id="apps" spellcheck="false"></textarea>
+    <p>
+      <button id="save">Save</button>
+      <button id="reset">Reset to defaults</button>
+      <span id="status"></span>
+    </p>
+    <script src="defaults.js"></script>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/pkgs/firefox-extensions/app-windows/options.js
+++ b/pkgs/firefox-extensions/app-windows/options.js
@@ -1,0 +1,31 @@
+// @ts-check
+/// <reference path="webext.d.ts" />
+/// <reference path="defaults.js" />
+"use strict";
+
+const ta = /** @type {HTMLTextAreaElement} */ (document.getElementById("apps"));
+const statusEl = /** @type {HTMLElement} */ (document.getElementById("status"));
+
+async function load() {
+  const { apps } = await browser.storage.sync.get({ apps: DEFAULT_APPS });
+  ta.value = JSON.stringify(apps, null, 2);
+}
+
+document.getElementById("save")?.addEventListener("click", async () => {
+  try {
+    const apps = JSON.parse(ta.value);
+    await browser.storage.sync.set({ apps });
+    statusEl.textContent = "Saved.";
+  } catch (e) {
+    statusEl.textContent = "Invalid JSON: " +
+      (e instanceof Error ? e.message : String(e));
+  }
+});
+
+document.getElementById("reset")?.addEventListener("click", async () => {
+  await browser.storage.sync.set({ apps: DEFAULT_APPS });
+  await load();
+  statusEl.textContent = "Reset.";
+});
+
+load();

--- a/pkgs/firefox-extensions/app-windows/webext.d.ts
+++ b/pkgs/firefox-extensions/app-windows/webext.d.ts
@@ -65,6 +65,7 @@ declare const browser: {
       url?: string;
       active?: boolean;
       cookieStoreId?: string;
+      pinned?: boolean;
     }): Promise<BrowserTab>;
     update(id: number, opts: { active?: boolean }): Promise<BrowserTab>;
     move(

--- a/pkgs/firefox-extensions/app-windows/webext.d.ts
+++ b/pkgs/firefox-extensions/app-windows/webext.d.ts
@@ -70,7 +70,7 @@ declare const browser: {
     update(id: number, opts: { active?: boolean }): Promise<BrowserTab>;
     move(
       id: number,
-      opts: { windowId: number; index: number },
+      opts: { windowId?: number; index: number },
     ): Promise<BrowserTab | BrowserTab[]>;
     remove(id: number): Promise<void>;
     onCreated: Listener<(tab: BrowserTab) => void>;

--- a/pkgs/firefox-extensions/app-windows/webext.d.ts
+++ b/pkgs/firefox-extensions/app-windows/webext.d.ts
@@ -1,0 +1,93 @@
+// Minimal WebExtension API surface used by this extension.
+
+interface BrowserTab {
+  id?: number;
+  windowId?: number;
+  url?: string;
+  index: number;
+}
+
+interface BrowserWindow {
+  id?: number;
+  focused: boolean;
+}
+
+interface TabChangeInfo {
+  url?: string;
+}
+
+type Listener<F> = {
+  addListener(cb: F): void;
+  removeListener(cb: F): void;
+};
+
+declare const browser: {
+  storage: {
+    sync: {
+      get<T>(defaults: T): Promise<T>;
+      set(items: object): Promise<void>;
+    };
+  };
+  sessions: {
+    setWindowValue(
+      windowId: number,
+      key: string,
+      value: unknown,
+    ): Promise<void>;
+    getWindowValue(windowId: number, key: string): Promise<unknown>;
+    setTabValue(tabId: number, key: string, value: unknown): Promise<void>;
+    getTabValue(tabId: number, key: string): Promise<unknown>;
+  };
+  windows: {
+    WINDOW_ID_NONE: number;
+    get(id: number): Promise<BrowserWindow>;
+    getAll(
+      opts?: { populate?: boolean; windowTypes?: string[] },
+    ): Promise<BrowserWindow[]>;
+    create(opts: { url?: string; type?: string }): Promise<BrowserWindow>;
+    update(id: number, opts: { focused?: boolean }): Promise<BrowserWindow>;
+    onFocusChanged: Listener<(windowId: number) => void>;
+    onRemoved: Listener<(windowId: number) => void>;
+  };
+  contextualIdentities: {
+    query(
+      opts: { name?: string },
+    ): Promise<{ cookieStoreId: string; name: string }[]>;
+    create(
+      opts: { name: string; color: string; icon: string },
+    ): Promise<{ cookieStoreId: string }>;
+  };
+  tabs: {
+    get(id: number): Promise<BrowserTab>;
+    query(opts: { windowId?: number; index?: number }): Promise<BrowserTab[]>;
+    create(opts: {
+      windowId?: number;
+      url?: string;
+      active?: boolean;
+      cookieStoreId?: string;
+    }): Promise<BrowserTab>;
+    update(id: number, opts: { active?: boolean }): Promise<BrowserTab>;
+    move(
+      id: number,
+      opts: { windowId: number; index: number },
+    ): Promise<BrowserTab | BrowserTab[]>;
+    remove(id: number): Promise<void>;
+    onCreated: Listener<(tab: BrowserTab) => void>;
+    onUpdated: Listener<
+      (tabId: number, changeInfo: TabChangeInfo, tab: BrowserTab) => void
+    >;
+    onRemoved: Listener<(tabId: number) => void>;
+  };
+  browserAction: {
+    onClicked: Listener<() => void>;
+  };
+  runtime: {
+    onMessage: Listener<
+      (
+        msg: { type: string; [k: string]: unknown },
+        sender: { tab?: BrowserTab },
+      ) => unknown
+    >;
+    sendMessage(msg: object): Promise<unknown>;
+  };
+};

--- a/pkgs/firefox-extensions/default.nix
+++ b/pkgs/firefox-extensions/default.nix
@@ -5,6 +5,7 @@
   unzip,
   zip,
   jq,
+  typescript,
 }:
 
 let
@@ -14,6 +15,7 @@ let
       version,
       src,
       extensionId,
+      typecheck ? false,
       meta ? { },
     }:
     stdenv.mkDerivation {
@@ -23,7 +25,15 @@ let
         unzip
         zip
         jq
-      ];
+      ]
+      ++ lib.optional typecheck typescript;
+
+      doCheck = typecheck;
+      checkPhase = ''
+        runHook preCheck
+        tsc --noEmit -p jsconfig.json
+        runHook postCheck
+      '';
 
       unpackPhase = ''
         mkdir -p source
@@ -50,6 +60,7 @@ let
         mkdir -p "$out"
 
         # Create XPI (Firefox 62+ requires packed extensions for sideloading)
+        rm -f jsconfig.json webext.d.ts
         zip -r "$out/${pname}.xpi" .
 
         runHook postInstall
@@ -63,6 +74,18 @@ let
 in
 {
   inherit buildFirefoxExtension;
+
+  app-windows-extension = buildFirefoxExtension {
+    pname = "app-windows";
+    version = (lib.importJSON ./app-windows/manifest.json).version;
+    src = ./app-windows;
+    extensionId = "app-windows@thalheim.io";
+    typecheck = true;
+    meta = {
+      description = "Run web apps in dedicated windows; external links open in main window";
+      license = lib.licenses.mit;
+    };
+  };
 
   chrome-tab-gc-extension = buildFirefoxExtension {
     pname = "chrome-tab-gc-extension";

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -29,6 +29,7 @@ in
     crabfit-cli = pkgs.python3.pkgs.callPackage ./crabfit-cli { };
     inherit (pkgs.callPackages ./firefox-extensions { })
       chrome-tab-gc-extension
+      app-windows-extension
       ;
     gh-radicle = pkgs.callPackage ./gh-radicle { };
     iroh-ssh = pkgs.callPackage ./iroh-ssh { };

--- a/pkgs/librewolf-policies.nix
+++ b/pkgs/librewolf-policies.nix
@@ -3,6 +3,7 @@
   stdenv,
   browser-cli-extension,
   chrome-tab-gc-extension,
+  app-windows-extension,
 }:
 {
   ExtensionSettings = {
@@ -13,6 +14,10 @@
     "tab-garbage-collector@thalheim.io" = {
       installation_mode = "force_installed";
       install_url = "file://${chrome-tab-gc-extension}/chrome-tab-gc-extension.xpi";
+    };
+    "app-windows@thalheim.io" = {
+      installation_mode = "force_installed";
+      install_url = "file://${app-windows-extension}/app-windows.xpi";
     };
   }
   // lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {


### PR DESCRIPTION

Replaces Ferdium for messaging apps. Runs WhatsApp, Discord, Element
and Slack workspaces as tabs in a dedicated LibreWolf window, sharing
the browser's process tree instead of spawning a separate Electron
runtime, which is significantly lighter on memory.

Each app tab is opened in its own Firefox container so multiple Slack
workspaces get distinct colored tab indicators without overriding
favicons (which would lose unread badges). External links clicked in
the messengers window are automatically moved to the last-focused
normal browsing window.

The window is created on browser startup and can be re-opened via the
toolbar action. App list is configurable in the extension options page.

Type-checked with TypeScript --checkJs against a vendored minimal
webext.d.ts; the check runs in the nix derivation's checkPhase.
