### PR TITLE
ssh-tpm-agent: drop fork override, use nixpkgs 0.9.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -774,10 +774,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780556647,
-        "narHash": "sha256-xyX9QC1t49sFJ7ITVp8libOeyKMMWc0xjwe2lSmsRYo=",
+        "lastModified": 1780839504,
+        "narHash": "sha256-vszhEoocEkJUsiZE8jjrdZBLeK6PAjjWHqm09nbNqYs=",
         "ref": "main",
-        "rev": "8c69eeeb3d38b4b53c5b990436fb9ec4574b05c6",
+        "rev": "abe259120e6cb7861cbf5cb666225f53e473ccb3",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/Mic92/nixpkgs"

--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780403740,
-        "narHash": "sha256-7MNPrFiaX+4aA7aBDhItgmz4/YLlWXg8izN6llngDT4=",
+        "lastModified": 1780688659,
+        "narHash": "sha256-yKoFGu4jwWiBSVUXGiQCZFnZeTRXskfKmi+zu6gaIMw=",
         "owner": "Mic92",
         "repo": "fast-nix-gc",
-        "rev": "8769dd0f579a219f790c593cb692407d80627641",
+        "rev": "21fde03e4a19a957c17203bd47ecd099482c0a80",
         "type": "github"
       },
       "original": {

--- a/nixosModules/ssh-tpm-agent.nix
+++ b/nixosModules/ssh-tpm-agent.nix
@@ -5,22 +5,6 @@
   ...
 }:
 let
-  # Track fork until upstream ships the confirm-prompt requestor info
-  # (SO_PEERCRED process chain in askpass) on top of #114.
-  # keyring tests require Linux kernel keyring which isn't available in the Nix sandbox
-  ssh-tpm-agent = pkgs.ssh-tpm-agent.overrideAttrs (_old: {
-    version = "0.8.0-unstable-2026-04-24";
-    src = pkgs.fetchFromGitHub {
-      owner = "Mic92";
-      repo = "ssh-tpm-agent";
-      rev = "c7a0ce9d733e299f2ecc45697ac25df9aacf65e0";
-      hash = "sha256-P7pHYhQJVXwC4QiMogW2nyt1GWz8JQI9NzNsmnlP8yI=";
-    };
-    # nixpkgs carries a backport patch that is already in this tree
-    patches = [ ];
-    vendorHash = "sha256-s899KmXdeUt/SSCL3Vu1T/JTJT8mZP99MDb+Thcfyw4=";
-    doCheck = false;
-  });
   # Prefer the noctalia ssh-askpass plugin when the shell is running: it
   # actually honours SSH_ASKPASS_PROMPT=confirm (lxqt-openssh-askpass does
   # not) so ssh-tpm-add -c confirmations get real Allow/Deny buttons instead
@@ -54,7 +38,7 @@ in
   users.users.joerg.extraGroups = [ "tss" ]; # tss group has access to TPM devices
 
   environment.systemPackages = [
-    ssh-tpm-agent
+    pkgs.ssh-tpm-agent
     pkgs.keyutils
   ];
 
@@ -77,7 +61,7 @@ in
       SSH_ASKPASS = askPasswordWrapper;
     };
     serviceConfig = {
-      ExecStart = "${ssh-tpm-agent}/bin/ssh-tpm-agent";
+      ExecStart = "${pkgs.ssh-tpm-agent}/bin/ssh-tpm-agent";
       PassEnvironment = "SSH_AGENT_PID";
       SuccessExitStatus = 2;
       Type = "simple";


### PR DESCRIPTION

Upstream v0.9.0 includes both PR #114 (SSH_ASKPASS_PROMPT fix) and the
confirm-prompt requestor info (PR #124) that the Mic92 fork pin carried,
so the overrideAttrs is no longer needed.

The nixpkgs fork branch also carried a backport patch for the keyring
ENOENT fix which no longer applies to (and is included in) 0.9.0; that
commit was dropped from the fork and the nixpkgs input updated.

Closes #5177
