### PR TITLE
eve/nixbot: drop test-* branch builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -737,16 +737,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1780924088,
-        "narHash": "sha256-cZYWN0eQoDp3ykovhD3os7eSYdh5TDtAFPWmEEpTDUo=",
-        "ref": "eval-warnings",
-        "rev": "8545d7cdf7173170c3f8c1f711c634c75332fdf4",
+        "lastModified": 1781007244,
+        "narHash": "sha256-4hl0+4eKjnhiiNtfvBzIH1orW/3wkTi5eyFR18sIzHM=",
+        "ref": "test-refactorings",
+        "rev": "e47a27aec8ed370445dd92da4c3ca43b6e50cec2",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/Mic92/nixbot"
       },
       "original": {
-        "ref": "eval-warnings",
+        "ref": "test-refactorings",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/Mic92/nixbot"

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
     data-mesher.inputs.treefmt-nix.follows = "treefmt-nix";
     data-mesher.inputs.flake-parts.follows = "flake-parts";
 
-    nixbot.url = "git+https://github.com/Mic92/nixbot?shallow=1&ref=eval-warnings";
+    nixbot.url = "git+https://github.com/Mic92/nixbot?shallow=1&ref=test-refactorings";
     nixbot.inputs.nixpkgs.follows = "nixpkgs";
     nixbot.inputs.treefmt-nix.follows = "treefmt-nix";
 

--- a/machines/eve/modules/nixbot.nix
+++ b/machines/eve/modules/nixbot.nix
@@ -117,7 +117,6 @@ in
       "aarch64-linux"
       "aarch64-darwin"
     ];
-    branches.releaseBranches.matchGlob = "test-*";
     branches.mergeQueue.matchGlob = "gitea-mq/*";
     evalWorkerCount = 6;
     github = {


### PR DESCRIPTION

Push builds for test-* branches double the work of their PRs and,
because builds dedupe on the post-merge tree, the shared build shows
up as a branch build instead of the PR.


