### PR TITLE
coder: fix gh token on login

### DIFF
--- a/home-manager/coder.nix
+++ b/home-manager/coder.nix
@@ -154,4 +154,14 @@
       fi
     fi
   '';
+
+  # Refresh the GitHub token in nix.conf's secrets.conf each activation;
+  # $HOME (and the file) is wiped on workspace restart. No gh/token: no-op.
+  home.activation.nix-github-token = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    if token="$(PATH="''${HM_HOST_PATH:-$PATH}" gh auth token 2>/dev/null)" && [ -n "$token" ]; then
+      umask 077
+      mkdir -p "$HOME/.config/nix"
+      printf 'access-tokens = github.com=%s\n' "$token" > "$HOME/.config/nix/secrets.conf"
+    fi
+  '';
 }

--- a/home-manager/flake-module.nix
+++ b/home-manager/flake-module.nix
@@ -31,6 +31,9 @@ in
     type = "app";
     program = "${pkgs.writeShellScriptBin "hm" ''
       set -x
+      # Activation runs with a hermetic PATH; expose the host PATH for hooks
+      # needing host tools (e.g. gh for a nix.conf token).
+      export HM_HOST_PATH="$PATH"
       export PATH=${
         pkgs.lib.makeBinPath [
           pkgs.gitMinimal


### PR DESCRIPTION
## Why

On coder workspaces `$HOME` is wiped on every restart, taking `~/.config/nix/secrets.conf` (the `!include`d GitHub token for nix.conf) with it. Without the token, flake fetches hit the anonymous GitHub API rate limit.

## What

- `coder.nix`: add a `nix-github-token` activation hook that regenerates `secrets.conf` from `gh auth token` on each activation. Best-effort — no gh/token means no-op.
- `flake-module.nix`: home-manager runs activation with a hermetic PATH, so the `hm` wrapper now exports `HM_HOST_PATH` to let hooks reach host tools (here, `gh`).

Generic: no host-specific paths; degrades to a no-op where `gh` is absent.