### PR TITLE
punchcard: switch to fork with punch CLI and install it

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -858,15 +858,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1784375220,
-        "narHash": "sha256-3g/v0Mw/U5B5p8kFbHozsYzLzhtX2QpulrLPmvicf6s=",
-        "owner": "pinpox",
+        "lastModified": 1784442768,
+        "narHash": "sha256-pLRbRLdMa0WJb1KvA2AFQW+rVOTv3ijh1NRn5Ap572k=",
+        "owner": "Mic92",
         "repo": "punchcard",
-        "rev": "3de209947691fb71ff378ea42c9b343bb73a10ac",
+        "rev": "0f3e51418d1c0298cd1044c081555d2806692e76",
         "type": "github"
       },
       "original": {
-        "owner": "pinpox",
+        "owner": "Mic92",
+        "ref": "punch-cli",
         "repo": "punchcard",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,9 @@
     forge-triage.url = "github:Mic92/forge-triage";
     forge-triage.inputs.nixpkgs.follows = "nixpkgs";
 
-    punchcard.url = "github:pinpox/punchcard";
+    # Fork with API keys, JSON API, and punch CLI until the PRs land upstream:
+    # https://github.com/pinpox/punchcard/pull/6 /pull/7 /pull/8
+    punchcard.url = "github:Mic92/punchcard/punch-cli";
     punchcard.inputs.nixpkgs.follows = "nixpkgs";
 
     gitea-mq.url = "github:Mic92/gitea-mq";

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -88,6 +88,8 @@
       self.inputs.flake-fmt.packages.${pkgs.stdenv.hostPlatform.system}.default
       self.inputs.nix-diff-rs.packages.${pkgs.stdenv.hostPlatform.system}.default
       self.inputs.nix-tree-rs.packages.${pkgs.stdenv.hostPlatform.system}.default
+      # punch: CLI for punchcard.thalheim.io (start/stop timers, export timesheets)
+      self.inputs.punchcard.packages.${pkgs.stdenv.hostPlatform.system}.punch
     ]
     ++ lib.optionals pkgs.stdenv.isLinux [
       strace


### PR DESCRIPTION

Point the punchcard input at Mic92/punchcard branch punch-cli (API keys,
JSON API, punch CLI; upstream PRs pinpox/punchcard#6-#8) and add the new
punch package to the common home-manager packages so timers can be
started/stopped and timesheets exported from the terminal.
