### PR TITLE
eve/authelia: extend refresh-token lifetime for herdr-eternal

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785136454,
-        "narHash": "sha256-6bOdXsaD0QJ5npc9Ggy6oZN1CYyj3dlkYskXcXfzt2k=",
+        "lastModified": 1785144443,
+        "narHash": "sha256-0FsEzaN3QWj8hKu40TOf7D4hRi/LRc+VvNVRPfKv2CA=",
         "owner": "Mic92",
         "repo": "herdr-eternal",
-        "rev": "8836062564cc78e1120ebefc815201920f826d03",
+        "rev": "a46eb6b8d16ebb8ffd3ef86d5642fafd5ac36627",
         "type": "github"
       },
       "original": {

--- a/machines/eve/modules/authelia.nix
+++ b/machines/eve/modules/authelia.nix
@@ -70,6 +70,16 @@
         ];
       };
 
+      # Authelia's default refresh-token lifetime (~90 minutes) logs
+      # herdr-eternal-ssh out as soon as a laptop sleeps for a while; keep the
+      # refresh token valid for months so long-running herdr sessions can keep
+      # re-minting access tokens.
+      identity_providers.oidc.lifespans.custom.herdr-eternal = {
+        access_token = "1 hour";
+        id_token = "1 hour";
+        refresh_token = "3 months";
+      };
+
       identity_providers.oidc.clients = [
         {
           # Public client for `step ca certificate --provisioner authelia`
@@ -128,6 +138,7 @@
           # them offline against the JWKS.
           access_token_signed_response_alg = "RS256";
           authorization_policy = "herdr-eternal";
+          lifespan = "herdr-eternal";
         }
         {
           client_id = "punchcard";


### PR DESCRIPTION
Authelia's default ~90 minute refresh token logged herdr-eternal-ssh out whenever the client stayed idle for a bit; long-running herdr sessions then could not re-mint access tokens.

Give the client a custom lifespan (access 1h, refresh 3 months) and pull in the client fix (Mic92/herdr-eternal@a46eb6b) that refreshes the access token on every reconnect.