### PR TITLE
eve/step-ca: wait for authelia OIDC endpoint before start

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -705,11 +705,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784634158,
-        "narHash": "sha256-/cqZHZ5AnLiRwMPMkQa6u+9s9WF2xK0FZa/BjYuDmjY=",
+        "lastModified": 1785224815,
+        "narHash": "sha256-I4scKn4n2dvHDRbvjZd9FgYk0DNhcEqmrSCwbDZf2xM=",
         "owner": "Mic92",
         "repo": "nix-grpc-store",
-        "rev": "4ab5f6b8ed96f094830f7600545d62e74c47dc90",
+        "rev": "30aa06ca2f1cec1145ea8d99397641e9bcfe8c6c",
         "type": "github"
       },
       "original": {

--- a/machines/eve/configuration.nix
+++ b/machines/eve/configuration.nix
@@ -56,7 +56,7 @@
     ./modules/nextcloud.nix
     ./modules/nginx/default.nix
     ./modules/opencrow
-    ./modules/hermes
+    # ./modules/hermes
     #./modules/nixos-wiki
     ./modules/packages.nix
     ./modules/paperless.nix

--- a/machines/eve/modules/step-ca/default.nix
+++ b/machines/eve/modules/step-ca/default.nix
@@ -111,6 +111,21 @@ in
     '';
   };
 
+  # step-ca fetches the Authelia OIDC discovery document once at startup and
+  # permanently disables the provisioner if that fails, so wait until it is
+  # actually served before starting.
+  systemd.services.step-ca = {
+    after = [
+      "authelia-main.service"
+      "nginx.service"
+    ];
+    preStart = ''
+      ${pkgs.curl}/bin/curl -fsS --retry 60 --retry-all-errors --retry-delay 1 -o /dev/null \
+        https://auth.thalheim.io/.well-known/openid-configuration \
+        || echo "authelia OIDC discovery endpoint not ready" >&2
+    '';
+  };
+
   services.step-ca = {
     enable = true;
     intermediatePasswordFile = "/dev/null";


### PR DESCRIPTION

step-ca fetches the Authelia OIDC discovery document only once at
startup and permanently disables the provisioner if that fails, which
broke nix-grpc-cert after a boot where authelia was not yet serving.
Order step-ca after authelia/nginx and wait for the discovery endpoint
in preStart.

Also bump the nix-grpc-store flake input.
