### PR TITLE
queue: agent-friendly pueue frontend + atuin daemon fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -558,11 +558,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785332299,
-        "narHash": "sha256-ag8HVYGtful2WGYbmU+BgqcPUTxzI8+L8Vyo0ha1Nfo=",
+        "lastModified": 1786173088,
+        "narHash": "sha256-N3S3u75T3ihXiOKyUWdyRlkSmJ+bZrwgqL3cjScMomc=",
         "owner": "Mic92",
         "repo": "mics-skills",
-        "rev": "4ea15fdb5190eed4c6ec2554e23b41f4ad6be3ec",
+        "rev": "5a7817fb42840f0faad7de756a3e38c0621ccc02",
         "type": "github"
       },
       "original": {

--- a/home-manager/coder.nix
+++ b/home-manager/coder.nix
@@ -36,7 +36,7 @@ in
   # Background sync daemon; shell client reaches it via socket.
   services.supervisor.programs.atuin-daemon.settings = {
     command = "${pkgs.atuin}/bin/atuin daemon start";
-    user = "root";
+    user = "argocd";
     environment = ''ATUIN_CONFIG_DIR="${atuinConfigDir}"'';
   };
 

--- a/home-manager/modules/ai.nix
+++ b/home-manager/modules/ai.nix
@@ -85,6 +85,7 @@ in
       "kagi-search"
       "n8n-cli"
       "pexpect-cli"
+      "queue"
       "screenshot-cli"
     ];
   };
@@ -125,8 +126,6 @@ in
     aiTools.git-surgeon
     aiTools.jscpd
     pkgs.pueue
-    # agent-friendly frontend for pueue
-    micsSkillsPkgs.queue
   ]
   ++ lib.optionals pkgs.stdenv.isDarwin [
     selfPkgs.macprof

--- a/home-manager/modules/ai.nix
+++ b/home-manager/modules/ai.nix
@@ -125,6 +125,8 @@ in
     aiTools.git-surgeon
     aiTools.jscpd
     pkgs.pueue
+    # agent-friendly frontend for pueue
+    micsSkillsPkgs.queue
   ]
   ++ lib.optionals pkgs.stdenv.isDarwin [
     selfPkgs.macprof

--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -62,33 +62,9 @@
 
 ## Running programs
 
-- CRITICAL: ALWAYS use `queue` for ANY command that might take longer than 10
-  seconds to avoid timeouts. This includes but is not limited to:
-  - `nix build` commands
-  - `merge-when-green`
-  - Any test runs that might be slow
-  - Any build operations (make, ninja, cargo)
-
-  The command is read from stdin (heredoc), so quoting inside it never needs
-  escaping. Output is streamed and the exit code is the command's exit code.
-  ```bash
-  queue run <<'EOF'
-  command arg1 "arg with spaces"
-  EOF
-  ```
-  Exit code 75 means still running; resume with `queue wait <id>` (id was
-  printed as `task=<id>`). Useful subcommands:
-  ```bash
-  queue status        # one line per task; --json for scripts
-  queue log <id>      # full output so far + status, works while running
-  queue ps <id>       # pid, RSS, CPU of the task's process tree
-  queue restart <id>  # rerun a failed task without retyping the command
-  queue kill <id>
-  queue run --after <id> ... # start only after <id> succeeded
-  queue run --tail-ok 20 ... # on success only show last 20 lines
-  queue wait          # barrier: wait for all my tasks
-  ```
-  Never pipe queued commands through head/tail; use `queue log` instead.
+- CRITICAL: ALWAYS use the `queue` skill for ANY command that might take
+  longer than 10 seconds (nix build, merge-when-green, test runs, make,
+  ninja, cargo) to avoid tool timeouts.
 
 ## Search
 

--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -62,20 +62,33 @@
 
 ## Running programs
 
-- CRITICAL: ALWAYS use pueue for ANY command that might take longer than 10
+- CRITICAL: ALWAYS use `queue` for ANY command that might take longer than 10
   seconds to avoid timeouts. This includes but is not limited to:
   - `nix build` commands
   - `merge-when-green`
   - Any test runs that might be slow
   - Any build operations (make, ninja, cargo)
 
-  To run and wait (quote the entire command to preserve argument quoting):
+  The command is read from stdin (heredoc), so quoting inside it never needs
+  escaping. Output is streamed and the exit code is the command's exit code.
   ```bash
-  # use --lines in log command instead of tail in `pueue add` to retain full log
-  id=$(pueue add --print-task-id -- 'command arg1 "arg with spaces"')
-  pueue follow "$id" # stream output, blocks until task finishes
-  pueue log --lines 50 "$id" # Get exit status and logs
+  queue run <<'EOF'
+  command arg1 "arg with spaces"
+  EOF
   ```
+  Exit code 75 means still running; resume with `queue wait <id>` (id was
+  printed as `task=<id>`). Useful subcommands:
+  ```bash
+  queue status        # one line per task; --json for scripts
+  queue log <id>      # full output so far + status, works while running
+  queue ps <id>       # pid, RSS, CPU of the task's process tree
+  queue restart <id>  # rerun a failed task without retyping the command
+  queue kill <id>
+  queue run --after <id> ... # start only after <id> succeeded
+  queue run --tail-ok 20 ... # on success only show last 20 lines
+  queue wait          # barrier: wait for all my tasks
+  ```
+  Never pipe queued commands through head/tail; use `queue log` instead.
 
 ## Search
 


### PR DESCRIPTION
- run atuin daemon as argocd instead of root (fixes 'Permission denied' in every atuin client call on coder workspaces)
- replace the raw pueue workflow with the new queue tool from mics-skills: stdin commands, truthful exit codes, timeout-detach (exit 75), per-agent session sandboxing, auto-started pueued
- ship queue's usage docs as a skill; CLAUDE.md keeps only the policy line