### PR TITLE
permission-gate: block sleep before queue wait

### DIFF
--- a/home/.config/pi-agent-extensions/permission-gate/rules.ts
+++ b/home/.config/pi-agent-extensions/permission-gate/rules.ts
@@ -47,6 +47,16 @@ export default (helpers: any) => ({
         "nix --refresh is blocked: cache invalidation is not needed in nix — " +
         "to trigger a rebuild, alter the derivation instead.",
     },
+    {
+      // A regex, not an argv test: `sleep` and `queue wait` land in
+      // separate pipelines of an `&&`/`;` list, and rule tests only ever
+      // see one pipeline at a time.
+      label: "sleep before queue wait",
+      action: "block",
+      pattern: /\bsleep\s+\S+\s*(&&|;)\s*queue\s+wait\b/,
+      reason:
+        "Do not sleep before `queue wait` — use `queue wait --timeout SECS` instead.",
+    },
     { label: "ssh", test: (p) => is(p, "ssh") },
     { label: "send email", test: (p) => is(p, "msmtp") },
 


### PR DESCRIPTION
Steer agents to `queue wait --timeout SECS` instead of idling in sleep. A regex rule: the two halves of an &&/; list land in separate pipelines that argv tests see one at a time.