### PR TITLE
herdr: trim defaults, fix key conflicts, enable experiments

### DIFF
--- a/home/.config/herdr/config.toml
+++ b/home/.config/herdr/config.toml
@@ -3,9 +3,9 @@
 
 onboarding = false
 
-[terminal]
-# tmux: bind '"'/%/c with -c "#{pane_current_path}" -> keep cwd of current pane
-new_cwd = "follow"
+[update]
+# installed via Nix
+version_check = false
 
 [keys]
 # tmux: set -g prefix C-Space
@@ -15,32 +15,22 @@ prefix = "ctrl+space"
 split_horizontal = ["prefix+double_quote", "prefix+minus"]
 split_vertical = ["prefix+percent", "prefix+v"]
 
-# tmux: bind c new-window
-new_tab = "prefix+c"
-next_tab = "prefix+n"
-previous_tab = "prefix+p"
-switch_tab = "prefix+1..9"
-
-close_tab = "prefix+shift+x"
-
 last_pane = "prefix+semicolon"
 cycle_pane_next = "prefix+o"
-zoom = "prefix+z"
 
 # tmux: bind x kill-pane, bind k confirm kill-pane (confirm_close covers both)
 close_pane = ["prefix+x", "prefix+k"]
 
-# tmux: copy-mode on prefix+[ (vi keys)
-copy_mode = "prefix+["
-
 # tmux: detach on prefix+d
 detach = "prefix+d"
 
-workspace_picker = "prefix+w"
 new_workspace = "prefix+shift+c"
 
-help = "prefix+?"
 reload_config = "prefix+r"
+# moved off prefix+s/prefix+r/prefix+o (sesh picker, reload_config, cycle_pane_next)
+settings = "prefix+comma"
+resize_mode = "prefix+m"
+open_notification_target = "prefix+u"
 
 # tmux: bind s -> sesh session picker; herdr-plugin-sesh picker
 [[keys.command]]
@@ -89,11 +79,6 @@ dark_name = "tokyo-night"
 light_name = "tokyo-night-day"
 
 [ui]
-# tmux: mouse on, set-clipboard on
-mouse_capture = true
-copy_on_select = true
-# tmux: bind-key k confirm kill-pane -> keep confirmation on close
-confirm_close = true
 # tabs are auto-named by the herdr-autoname plugin
 prompt_new_tab_name = false
 
@@ -104,8 +89,9 @@ delivery = "herdr"
 # tmux: history-limit 50000 lines; roughly equivalent generous byte budget
 scrollback_limit_bytes = 20000000
 
-[worktrees]
-directory = "~/.herdr/worktrees"
+[experimental]
+kitty_graphics = true
+pane_history = true
 
 [remote]
 # Use herdr-eternal instead of OpenSSH for herdr --remote (survives netsplits).

--- a/nixosModules/rustdesk-client.nix
+++ b/nixosModules/rustdesk-client.nix
@@ -61,10 +61,24 @@ in
       KERNEL=="uinput", MODE="0660", GROUP="input"
     '';
 
-    systemd.tmpfiles.rules = lib.flatten (
+    systemd.tmpfiles.rules = [
+      # The background service runs as root; without this it falls back to
+      # the public rendezvous servers and keeps syncing that back to user
+      # configs via IPC.
+      "d /root/.config/rustdesk 0700 root root -"
+      "C+ /root/.config/rustdesk/RustDesk2.toml 0600 root root - ${configFile}"
+    ]
+    ++ lib.flatten (
       map (user: [
         "d /home/${user}/.config/rustdesk 0755 ${user} users -"
         "C+ /home/${user}/.config/rustdesk/RustDesk2.toml 0644 ${user} users - ${configFile}"
+        # Desktop shortcut following the current system closure (never stale).
+        # Both English and German desktop dir names; ensure they are
+        # user-owned so L+ does not create them as root.
+        "d /home/${user}/Desktop 0755 ${user} users -"
+        "d /home/${user}/Schreibtisch 0755 ${user} users -"
+        "L+ /home/${user}/Desktop/rustdesk.desktop - - - - /run/current-system/sw/share/applications/rustdesk.desktop"
+        "L+ /home/${user}/Schreibtisch/rustdesk.desktop - - - - /run/current-system/sw/share/applications/rustdesk.desktop"
       ]) cfg.users
     );
   };


### PR DESCRIPTION

Drop settings that restate 0.8.0 defaults and disable the version
check (Nix-managed). Default settings/resize_mode bindings collided
with the sesh picker and reload_config; move them to prefix+comma
and prefix+m. Enable kitty_graphics and pane_history.
