### PR TITLE
eva/telegraf: stop using 6.<host>.r in http-sd generator

### DIFF
--- a/machines/eva/modules/telegraf/http-sd-generate.py
+++ b/machines/eva/modules/telegraf/http-sd-generate.py
@@ -98,7 +98,7 @@ def main() -> None:
             [
                 "[[inputs.ping]]",
                 '  method = "native"',
-                f'  urls = ["6.{host}"]',
+                f'  urls = ["{host}"]',
                 "  ipv6 = true",
                 "  [inputs.ping.tags]",
                 f'    org = "{org}"',


### PR DESCRIPTION

Same reasoning as b05eb647f: kartei no longer emits 6.-prefixed
aliases, so the http-sd ping targets for the TUM hosts were NXDOMAIN.


