### PR TITLE
pi-agent-extensions: track my fork, run pi's bash tool through nushell

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 	url = https://github.com/jorgebucaran/autopair.fish
 [submodule "pi-agent-extensions"]
 	path = pi-agent-extensions
-	url = https://github.com/rytswd/pi-agent-extensions
+	url = https://github.com/Mic92/pi-agent-extensions
 [submodule "home/.config/noctalia/shared-plugins"]
 	path = home/.config/noctalia/shared-plugins
 	url = https://github.com/Mic92/noctalia-plugins

--- a/flake.lock
+++ b/flake.lock
@@ -1243,11 +1243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787651078,
-        "narHash": "sha256-V3mcLKQ+56EL2q/MNbAuF3VxDHpqIukvO1+r/mHOq2Y=",
+        "lastModified": 1787858127,
+        "narHash": "sha256-UtSTRLO5zR+YMED4zx+XVbe2SHbsuWJ7CKup5AJCFuY=",
         "owner": "Mic92",
         "repo": "tribuchet",
-        "rev": "50727bbd88a5d58f6cd0794ae1863545812f9cb5",
+        "rev": "261d795b8d18bfdb1f398d8faa90434da5970be6",
         "type": "github"
       },
       "original": {

--- a/home-manager/modules/ai.nix
+++ b/home-manager/modules/ai.nix
@@ -111,6 +111,8 @@ in
     aiTools.git-surgeon
     aiTools.jscpd
     pkgs.pueue
+    # interpreter for the pi-agent-extensions nushell tool
+    pkgs.nushell
   ]
   ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
     selfPkgs.macprof

--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -46,7 +46,7 @@
 - Tests use realistic inputs/outputs that exercise actual code, not mocks.
 - Linter reports dead code: remove it.
 - Linter errors: fix root cause, do not suppress warnings.
-- Code comments: explain WHY, not WHAT. Describe current state, not what was
+- Code comments: Keep them minimal, Explain WHY, not WHAT. Describe current state, not what was
   removed.
 
 ## Git

--- a/home/.pi/agent/settings.json
+++ b/home/.pi/agent/settings.json
@@ -13,7 +13,7 @@
       "source": "~/.homesick/repos/dotfiles/pi-agent-extensions",
       "extensions": [
         "!*",
-        "+permission-gate/index.ts"
+        "+nushell/index.ts"
       ]
     }
   ],

--- a/machines/eve/modules/radicle-httpd-archive-404.patch
+++ b/machines/eve/modules/radicle-httpd-archive-404.patch
@@ -1,0 +1,82 @@
+From 1b20c2f1b2f7bfcccdfd624e6305fe6222d4d39b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Tue, 25 Aug 2026 22:45:42 +0200
+Subject: [PATCH] httpd: Return 404 for unknown archive refs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+/raw/<rid>/archive/<ref> passed the git2 error from
+resolve_reference_from_short_name straight through, so a typo in the
+branch name or a commit SHA in place of a ref yielded a 500. Map
+ErrorCode::NotFound to 404 like we already do for the object lookup.
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ crates/radicle-httpd/src/raw.rs | 34 +++++++++++++++++++++++++--------
+ 1 file changed, 26 insertions(+), 8 deletions(-)
+
+diff --git a/crates/radicle-httpd/src/raw.rs b/crates/radicle-httpd/src/raw.rs
+index 71d3b43d..92178f09 100644
+--- a/crates/radicle-httpd/src/raw.rs
++++ b/crates/radicle-httpd/src/raw.rs
+@@ -208,23 +208,28 @@ async fn archive_by_committish(
+     let project = doc.project()?;
+     let repo_name = project.name();
+ 
++    let not_found = |e: radicle::git::raw::Error| {
++        if e.code() == ErrorCode::NotFound {
++            Error::NotFound
++        } else {
++            Error::Git(e)
++        }
++    };
++
+     let oid = match committish {
+         Committish::Oid(oid) => oid,
+         Committish::Ref(refname) => repo
+             .backend
+             .resolve_reference_from_short_name(refname)
+-            .map(|reference| reference.target())?
++            .map_err(not_found)?
++            .target()
+             .ok_or(Error::NotFound)?
+             .into(),
+     };
+ 
+-    if let Err(e) = repo.backend.find_object(oid.into(), None) {
+-        return Err(if e.code() == ErrorCode::NotFound {
+-            Error::NotFound
+-        } else {
+-            Error::Git(e)
+-        });
+-    }
++    repo.backend
++        .find_object(oid.into(), None)
++        .map_err(not_found)?;
+ 
+     // Build a prefix for the archive, which includes the
+     // refname (if one was given):
+@@ -392,6 +397,19 @@ mod routes {
+         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+     }
+ 
++    #[tokio::test]
++    async fn test_archive_unknown_ref() {
++        let tmp = tempfile::tempdir().unwrap();
++        let ctx = test::seed(tmp.path());
++        let app = super::router(ctx.profile().to_owned(), Arc::new(HashMap::new()));
++
++        let response = get(&app, format!("/{RID}/archive/master.tar.gz")).await;
++        assert_eq!(response.status(), StatusCode::OK);
++
++        let response = get(&app, format!("/{RID}/archive/does-not-exist.tar.gz")).await;
++        assert_eq!(response.status(), StatusCode::NOT_FOUND);
++    }
++
+     #[tokio::test]
+     async fn test_alias_resolution() {
+         let tmp = tempfile::tempdir().unwrap();
+-- 
+2.55.0
+

--- a/machines/eve/modules/radicle.nix
+++ b/machines/eve/modules/radicle.nix
@@ -12,6 +12,8 @@ let
       ./radicle-search-debounce.patch
       # https://radicle.network/nodes/iris.radicle.network/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/patches/33cde5aa6807e87ffe4e6880fe6b664895ee6230
       ./radicle-httpd-zstd-archive.patch
+      # https://radicle.network/nodes/iris.radicle.network/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/patches/5a2b74b8ea48c13e0a3cfcb6c488d3643481e046
+      ./radicle-httpd-archive-404.patch
     ];
     # tar.zst archives shell out to zstd; also needed in checkPhase.
     nativeCheckInputs = (old.nativeCheckInputs or [ ]) ++ [ pkgs.zstd ];


### PR DESCRIPTION

nushell is added to home.packages as the interpreter; without it the
extension degrades to plain permission-gate over bash.
