### PR TITLE
eve/postfix: accept handi-work.co.uk mail, forward hello@ to shannan

### DIFF
--- a/machines/eve/modules/knot/handi-work.co.uk.zone
+++ b/machines/eve/modules/knot/handi-work.co.uk.zone
@@ -1,4 +1,4 @@
-@ 3600 IN SOA handi-work.co.uk. ns1.thalheim.io. 2025010101 7200 3600 86400 3600
+@ 3600 IN SOA handi-work.co.uk. ns1.thalheim.io. 2025010102 7200 3600 86400 3600
 
 $TTL 600
 
@@ -8,8 +8,16 @@ $TTL 600
 @ 3600 IN NS ns4.he.net.
 @ 3600 IN NS ns5.he.net.
 
-@ IN A 135.181.61.171
-@ IN AAAA 2a01:4f9:4b:4084::1
+; GitHub Pages (Mic92/Handi-work.co.uk)
+@ IN A 185.199.108.153
+@ IN A 185.199.109.153
+@ IN A 185.199.110.153
+@ IN A 185.199.111.153
+@ IN AAAA 2606:50c0:8000::153
+@ IN AAAA 2606:50c0:8001::153
+@ IN AAAA 2606:50c0:8002::153
+@ IN AAAA 2606:50c0:8003::153
+www IN CNAME mic92.github.io.
 @ IN MX 10 mail.thalheim.io.
 @ IN CAA 0 issue "letsencrypt.org"
 @ IN CAA 0 iodef "mailto:joerg.caa@thalheim.io"

--- a/machines/eve/modules/knot/handi-work.co.uk.zone
+++ b/machines/eve/modules/knot/handi-work.co.uk.zone
@@ -8,8 +8,8 @@ $TTL 600
 @ 3600 IN NS ns4.he.net.
 @ 3600 IN NS ns5.he.net.
 
-@ IN A 95.216.112.61
-@ IN AAAA 2a01:4f9:2b:1605::1
+@ IN A 135.181.61.171
+@ IN AAAA 2a01:4f9:4b:4084::1
 @ IN MX 10 mail.thalheim.io.
 @ IN CAA 0 issue "letsencrypt.org"
 @ IN CAA 0 iodef "mailto:joerg.caa@thalheim.io"

--- a/machines/eve/modules/knot/lekwati.com.zone
+++ b/machines/eve/modules/knot/lekwati.com.zone
@@ -8,8 +8,8 @@ $TTL 600
 @ 3600 IN NS ns4.he.net.
 @ 3600 IN NS ns5.he.net.
 
-@ IN A 95.216.112.61
-@ IN AAAA 2a01:4f9:2b:1605::1
+@ IN A 135.181.61.171
+@ IN AAAA 2a01:4f9:4b:4084::1
 @ IN MX 10 mail.thalheim.io.
 @ IN CAA 0 issue "letsencrypt.org"
 @ IN CAA 0 iodef "mailto:joerg.caa@thalheim.io"

--- a/machines/eve/modules/postfix.nix
+++ b/machines/eve/modules/postfix.nix
@@ -8,6 +8,7 @@ let
   virtualRegex = pkgs.writeText "virtual-regex" ''
     /^joerg(\.|\+)[^@.]+@thalheim\.io$/ joerg@thalheim.io
     /^shannan(\.|\+)[^@.]+@lekwati\.com/ shannan@lekwati.com
+    /^hello@handi-work\.co\.uk$/ shannan@lekwati.com
     /^devkid-[^@.]+@devkid\.net$/ devkid@devkid.net
     /^ls1-logins-[^@.]+@thalheim.io$/ ls1-logins@lists.lrz.de
     /^info\.[^@.]+@davhau\.com$/ info@davhau.com
@@ -17,6 +18,7 @@ let
   mailDomains = [
     "davhau.com"
     "devkid.net"
+    "handi-work.co.uk"
     "lekwati.com"
     "thalheim.io"
     "thaigersprint.org"

--- a/machines/eve/modules/postfix.nix
+++ b/machines/eve/modules/postfix.nix
@@ -67,7 +67,7 @@ in
       myhostname = "mail.thalheim.io";
       mydomain = "thalheim.io";
       smtp_bind_address = config.networking.eve.ipv4.address;
-      smtp_bind_address6 = "2a01:4f9:2b:1605::1";
+      smtp_bind_address6 = config.networking.eve.ipv6.address;
       mailbox_transport = "lmtp:unix:private/dovecot-lmtp";
       masquerade_domains = toString mailDomains;
       virtual_mailbox_domains = toString mailDomains;

--- a/machines/eve/modules/sshd.nix
+++ b/machines/eve/modules/sshd.nix
@@ -1,25 +1,5 @@
 {
   imports = [ ../../../nixosModules/sshd/tor.nix ];
 
-  services.openssh = {
-    listenAddresses = [
-      {
-        addr = "0.0.0.0";
-        port = 22;
-      }
-      {
-        addr = "[::]";
-        port = 22;
-      }
-      {
-        addr = "[2a01:4f9:2b:1605::2]";
-        port = 443;
-      }
-    ];
-  };
-
-  networking.firewall.allowedTCPPorts = [
-    22
-    443
-  ];
+  networking.firewall.allowedTCPPorts = [ 22 ];
 }


### PR DESCRIPTION

The website lists hello@handi-work.co.uk as contact address; MX
already points at mail.thalheim.io but postfix did not treat the
domain as local, so mail would have been rejected as relay attempt.
