### PR TITLE
knot/handi-work.co.uk: point www at slekwati.github.io

### DIFF
--- a/machines/eve/modules/knot/handi-work.co.uk.zone
+++ b/machines/eve/modules/knot/handi-work.co.uk.zone
@@ -1,4 +1,4 @@
-@ 3600 IN SOA handi-work.co.uk. ns1.thalheim.io. 2025010102 7200 3600 86400 3600
+@ 3600 IN SOA handi-work.co.uk. ns1.thalheim.io. 2025010103 7200 3600 86400 3600
 
 $TTL 600
 
@@ -8,7 +8,7 @@ $TTL 600
 @ 3600 IN NS ns4.he.net.
 @ 3600 IN NS ns5.he.net.
 
-; GitHub Pages (Mic92/Handi-work.co.uk)
+; GitHub Pages (slekwati/Handi-work.co.uk)
 @ IN A 185.199.108.153
 @ IN A 185.199.109.153
 @ IN A 185.199.110.153
@@ -17,7 +17,7 @@ $TTL 600
 @ IN AAAA 2606:50c0:8001::153
 @ IN AAAA 2606:50c0:8002::153
 @ IN AAAA 2606:50c0:8003::153
-www IN CNAME mic92.github.io.
+www IN CNAME slekwati.github.io.
 @ IN MX 10 mail.thalheim.io.
 @ IN CAA 0 issue "letsencrypt.org"
 @ IN CAA 0 iodef "mailto:joerg.caa@thalheim.io"


### PR DESCRIPTION

The site is moving from the Mic92 fork to slekwati/Handi-work.co.uk so
Shannan can maintain it directly.
