### PR TITLE
maiao: init at 1.4.0

### DIFF
--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -48,6 +48,7 @@
       yq-go
       tig
       lazygit
+      self.packages.${pkgs.stdenv.hostPlatform.system}.maiao
       git-absorb
       delta
       scc

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -32,6 +32,8 @@ in
       app-windows-extension
       ;
     gh-radicle = pkgs.callPackage ./gh-radicle { };
+    # Stacked GitHub PRs from the command line
+    maiao = pkgs.callPackage ./maiao { };
     # herdr plugin (fork with OSC 52 clipboard fallback)
     herdr-pluck = pkgs.callPackage ./herdr-pluck { };
     # herdr plugin: sesh-style workspace picker

--- a/pkgs/maiao/default.nix
+++ b/pkgs/maiao/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  stdenv,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "maiao";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "runetes";
+    repo = "maiao";
+    tag = "maiao-v${finalAttrs.version}";
+    hash = "sha256-sMxEtvDYluRBQGGrCbHZcBDTESdgdVd3+HuE7k3ELFM=";
+  };
+
+  vendorHash = "sha256-1q88bEFo1RKOE9k1Ii3ThcahECQVF40yHUVVEk08RXw=";
+
+  subPackages = [ "cmd/maiao" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/adevinta/maiao/pkg/version.Version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # Upstream ships the binary as git-review so it works as `git review`.
+  postInstall = ''
+    mv $out/bin/maiao $out/bin/git-review
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd git-review \
+      --bash <($out/bin/git-review completion bash) \
+      --fish <($out/bin/git-review completion fish) \
+      --zsh <($out/bin/git-review completion zsh)
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/git-review version | grep -q "^${finalAttrs.version}$"
+  '';
+
+  meta = {
+    description = "Seamless GitHub PR management from the command-line (stacked PRs)";
+    homepage = "https://github.com/runetes/maiao";
+    license = lib.licenses.mit;
+    mainProgram = "git-review";
+  };
+})

--- a/pkgs/maiao/nix-update-args
+++ b/pkgs/maiao/nix-update-args
@@ -1,0 +1,1 @@
+--version-regex maiao-v(.*)


### PR DESCRIPTION
Stacked-PR workflow tool for GitHub; install it alongside lazygit in
the common home-manager profile.
<details>
<summary>
Committer details
</summary>
Local-Branch: cert
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
eve: remove calendar-bot (<a href="https://github.com/Mic92/dotfiles/pull/5848">#5848</a>)
</summary>
The Matrix calendar bot is no longer used; drop the package, NixOS
module, devshell entry and its vars.
</details>
</details>
</details>