### PR TITLE
eve/tribuchet: run the hub as a flakelet

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -425,11 +425,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787829463,
-        "narHash": "sha256-Sg0WI6YNNU16nUTJyD6QRV1dBkfI8p7OnEVwuagxb8Y=",
+        "lastModified": 1788262632,
+        "narHash": "sha256-LEfkLhZVrvfuX5Jm1upibzwc6FVhGx0zP8mzqDplc34=",
         "owner": "Mic92",
         "repo": "gitea-mq",
-        "rev": "bc58310ea79adf59797cf1a7d057ac1f28538cce",
+        "rev": "2565e79811c7fb0feead19d2578065924e0ceb3c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -329,11 +329,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787895384,
-        "narHash": "sha256-gFIbHRznpvaQWnwtGZxA32HHdEYdXaAOJslSV+nflMk=",
+        "lastModified": 1788292392,
+        "narHash": "sha256-f/06YkoGOsJq9msglQKMJyzK3rQYmPVFhyN0y1FsHLU=",
         "owner": "Mic92",
         "repo": "flakelet",
-        "rev": "1959e041c6aa359bd90f421e9b09172953cf99d6",
+        "rev": "5ce75ca90e28cf84b66ea40eacc3b0d1c7f06b3f",
         "type": "github"
       },
       "original": {
@@ -1240,11 +1240,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787858127,
-        "narHash": "sha256-UtSTRLO5zR+YMED4zx+XVbe2SHbsuWJ7CKup5AJCFuY=",
+        "lastModified": 1788290471,
+        "narHash": "sha256-7q/6rcgRfIy/WThpPqtz5KxMrmfiBDIoIGiFtluiiXI=",
         "owner": "Mic92",
         "repo": "tribuchet",
-        "rev": "261d795b8d18bfdb1f398d8faa90434da5970be6",
+        "rev": "3059796b28b2f9ef47deb68c02e24d16d72fdc8f",
         "type": "github"
       },
       "original": {

--- a/machines/eve/modules/tribuchet.nix
+++ b/machines/eve/modules/tribuchet.nix
@@ -42,13 +42,22 @@ in
   environment.etc."tribuchet/ca/hub.crt".source = gen."hub.crt".path;
   environment.etc."tribuchet/ca/hub.key".source = gen."hub.key".path;
 
+  services.flakelets.services.tribuchet-hub = {
+    flake = "github:Mic92/tribuchet";
+    output = "flakelets.hub";
+    autoUpdate.enable = true;
+    settings = {
+      nixConfigPath = toString config.services.tribuchet-hub.externalBuilders.nixConfigPath;
+      hub.metrics-listen = "127.0.0.1:7438";
+    };
+  };
+
   services.tribuchet-hub = {
-    enable = true;
     openFirewall = true;
-    # Prometheus metrics scraped locally by telegraf (see telegraf.nix).
-    settings.metrics-listen = "127.0.0.1:7438";
     externalBuilders = {
       enable = true;
+      # the flakelet's RuntimeDirectory
+      nixConfigPath = "/run/tribuchet-hub/nix.conf";
       # The hub derives external-builders and max-jobs from the workers
       # actually connected (eliza aarch64-linux, jamie x86_64-linux, and
       # whatever else joins), so we do not hard-code a systems list. A


### PR DESCRIPTION

Hub updates then roll out via flakelet auto-update like nixbot instead
of a full eve rebuild. The host keeps what must live in the NixOS
generation: firewall, patched nix, the nix.conf include and the reload
path unit, which the tribuchet module now applies without enabling its
own hub units.

Change-Id: I9a1c99fb5457103df2f3dc9d0b90aa1cbd313b62
