### PR TITLE
pi: add persistent python tool

### DIFF
--- a/home-manager/modules/ai.nix
+++ b/home-manager/modules/ai.nix
@@ -11,6 +11,15 @@ let
   micsSkillsPkgs = inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system};
   nixbot-cli = inputs.nixbot.packages.${pkgs.stdenv.hostPlatform.system}.nixbot-cli;
 
+  # Interpreter for the pi-agent-extensions python tool. Separate name so it
+  # never shadows a project's python3; override per project with $PI_PYTHON.
+  piPython = pkgs.python3.withPackages (ps: [
+    ps.matplotlib
+    ps.polars
+    ps.pyelftools
+    ps.requests
+  ]);
+
   # On Darwin llm-agents ships the prebuilt release binary, so the source
   # patch can only be applied on Linux.
   herdrPackage =
@@ -113,6 +122,7 @@ in
     pkgs.pueue
     # interpreter for the pi-agent-extensions nushell tool
     pkgs.nushell
+    (pkgs.writeShellScriptBin "pi-python" ''exec ${piPython}/bin/python3 "$@"'')
   ]
   ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
     selfPkgs.macprof

--- a/home/.pi/agent/extensions/python/driver.py
+++ b/home/.pi/agent/extensions/python/driver.py
@@ -1,0 +1,94 @@
+"""Persistent Python evaluator speaking JSON lines on stdin/stdout.
+
+Request:  {"code": str}
+Response: {"stdout": str, "stderr": str, "result": str|null,
+           "error": str|null, "images": [base64 png, ...]}
+
+fd 1 is reserved for the protocol; stray writes from child processes or C
+extensions are diverted to stderr so they cannot corrupt the stream.
+"""
+# ruff: noqa: INP001, S102, S307 - standalone script whose job is exec/eval
+
+import ast
+import base64
+import contextlib
+import io
+import json
+import os
+import signal
+import sys
+import traceback
+from typing import Any
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+proto = os.fdopen(os.dup(1), "w", buffering=1)
+os.dup2(2, 1)
+
+ns: dict[str, Any] = {"__name__": "__main__"}
+
+
+def collect_figures() -> list[str]:
+    plt = sys.modules.get("matplotlib.pyplot")
+    if plt is None:
+        return []
+    images = []
+    for num in plt.get_fignums():
+        fig = plt.figure(num)
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=100, bbox_inches="tight")
+        images.append(base64.b64encode(buf.getvalue()).decode())
+    plt.close("all")
+    return images
+
+
+def run(code: str) -> dict[str, Any]:
+    out, err = io.StringIO(), io.StringIO()
+    result: str | None = None
+    error: str | None = None
+    try:
+        tree = ast.parse(code, "<cell>", "exec")
+        last = None
+        # REPL semantics: echo the value of a trailing bare expression.
+        if tree.body and isinstance(tree.body[-1], ast.Expr):
+            last = ast.Expression(tree.body.pop().value)  # type: ignore[attr-defined]
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            if tree.body:
+                exec(compile(tree, "<cell>", "exec"), ns)
+            if last is not None:
+                value = eval(compile(last, "<cell>", "eval"), ns)
+                if value is not None:
+                    ns["_"] = value
+                    result = repr(value)
+    except KeyboardInterrupt:
+        error = "KeyboardInterrupt: execution interrupted"
+    except BaseException as e:  # noqa: BLE001 - a REPL must survive SystemExit too
+        tb = e.__traceback__
+        # Hide this driver's frame so tracebacks start at <cell>.
+        while tb is not None and tb.tb_frame.f_code.co_filename == __file__:
+            tb = tb.tb_next
+        error = "".join(traceback.format_exception(type(e), e, tb))
+    return {
+        "stdout": out.getvalue(),
+        "stderr": err.getvalue(),
+        "result": result,
+        "error": error,
+        "images": collect_figures(),
+    }
+
+
+def main() -> None:
+    while True:
+        # SIGINT is only meaningful while user code runs; ignore it when idle
+        # so a late interrupt does not kill the session.
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        line = sys.stdin.readline()
+        if not line:
+            return
+        req = json.loads(line)
+        signal.signal(signal.SIGINT, signal.default_int_handler)
+        proto.write(json.dumps(run(req["code"])) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/home/.pi/agent/extensions/python/index.ts
+++ b/home/.pi/agent/extensions/python/index.ts
@@ -7,75 +7,104 @@
 
 import { execFileSync } from "node:child_process";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateTail } from "@mariozechner/pi-coding-agent";
+import {
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  truncateTail,
+} from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import { Kernel } from "./kernel.ts";
 
 function findPython(): string | undefined {
-	for (const cand of [process.env.PI_PYTHON, "pi-python", "python3"]) {
-		if (!cand) continue;
-		try {
-			execFileSync(cand, ["-c", ""], { stdio: "ignore" });
-			return cand;
-		} catch {}
-	}
-	return undefined;
+  for (const cand of [process.env.PI_PYTHON, "pi-python", "python3"]) {
+    if (!cand) continue;
+    try {
+      execFileSync(cand, ["-c", ""], { stdio: "ignore" });
+      return cand;
+    } catch {}
+  }
+  return undefined;
 }
 
 export default function (pi: ExtensionAPI) {
-	const python = findPython();
-	if (!python) return;
-	let kernel: Kernel | undefined;
+  const python = findPython();
+  if (!python) return;
+  let kernel: Kernel | undefined;
 
-	pi.on("session_shutdown", async () => {
-		kernel?.stop();
-		kernel = undefined;
-	});
+  pi.on("session_shutdown", async () => {
+    kernel?.stop();
+    kernel = undefined;
+  });
 
-	pi.registerCommand("python-restart", {
-		description: "Restart the persistent Python interpreter (drops all state)",
-		handler: async (_args, ctx) => {
-			kernel?.stop();
-			kernel = undefined;
-			ctx.ui.notify("Python interpreter reset.", "info");
-		},
-	});
+  pi.registerCommand("python-restart", {
+    description: "Restart the persistent Python interpreter (drops all state)",
+    handler: async (_args, ctx) => {
+      kernel?.stop();
+      kernel = undefined;
+      ctx.ui.notify("Python interpreter reset.", "info");
+    },
+  });
 
-	pi.registerTool({
-		name: "python",
-		label: "python",
-		description:
-			"Execute Python code in a persistent interpreter: variables, imports and open files survive between calls for the whole session. " +
-			"The value of a trailing expression is echoed like in a REPL; use print() for anything else. " +
-			"matplotlib figures are returned as images. Available: polars, matplotlib, requests, pyelftools + stdlib. " +
-			`Output is truncated to the last ${DEFAULT_MAX_LINES} lines / ${formatSize(DEFAULT_MAX_BYTES)}.`,
-		promptSnippet: "Run Python in a persistent interpreter (state kept across calls; polars, matplotlib, requests, pyelftools)",
-		promptGuidelines: [
-			"Use python instead of bash for multi-step data work (JSON/CSV/logs/ELF), calculations, and anything where re-parsing input on every call would be wasteful; state persists, so load once and iterate.",
-		],
-		parameters: Type.Object({
-			code: Type.String({ description: "Python source to execute" }),
-			timeout: Type.Optional(Type.Number({ description: "Timeout in seconds (interrupts the cell, keeps state)" })),
-		}),
+  pi.registerTool({
+    name: "python",
+    label: "python",
+    description:
+      "Execute Python code in a persistent interpreter: variables, imports and open files survive between calls for the whole session. " +
+      "The value of a trailing expression is echoed like in a REPL; use print() for anything else. " +
+      "matplotlib figures are returned as images. Available: polars, matplotlib, requests, pyelftools + stdlib. " +
+      `Output is truncated to the last ${DEFAULT_MAX_LINES} lines / ${
+        formatSize(DEFAULT_MAX_BYTES)
+      }.`,
+    promptSnippet:
+      "Run Python in a persistent interpreter (state kept across calls; polars, matplotlib, requests, pyelftools)",
+    promptGuidelines: [
+      "Use python instead of bash for multi-step data work (JSON/CSV/logs/ELF), calculations, and anything where re-parsing input on every call would be wasteful; state persists, so load once and iterate.",
+    ],
+    parameters: Type.Object({
+      code: Type.String({ description: "Python source to execute" }),
+      timeout: Type.Optional(
+        Type.Number({
+          description: "Timeout in seconds (interrupts the cell, keeps state)",
+        }),
+      ),
+    }),
 
-		async execute(_id, params, signal, _onUpdate, ctx) {
-			kernel ??= new Kernel(python, ctx.cwd);
-			const ac = new AbortController();
-			signal?.addEventListener("abort", () => ac.abort(), { once: true });
-			const timer = params.timeout ? setTimeout(() => ac.abort(), params.timeout * 1000) : undefined;
-			const r = await kernel.exec(params.code, ac.signal).finally(() => clearTimeout(timer));
+    async execute(_id, params, signal, _onUpdate, ctx) {
+      kernel ??= new Kernel(python, ctx.cwd);
+      const ac = new AbortController();
+      signal?.addEventListener("abort", () => ac.abort(), { once: true });
+      const timer = params.timeout
+        ? setTimeout(() => ac.abort(), params.timeout * 1000)
+        : undefined;
+      const r = await kernel.exec(params.code, ac.signal).finally(() =>
+        clearTimeout(timer)
+      );
 
-			let text = r.stdout;
-			if (r.stderr) text += (text && !text.endsWith("\n") ? "\n" : "") + r.stderr;
-			if (r.result !== null) text += (text && !text.endsWith("\n") ? "\n" : "") + r.result;
-			if (r.error) text += (text && !text.endsWith("\n") ? "\n" : "") + r.error;
-			const t = truncateTail(text || (r.images.length ? "" : "(no output)"));
-			if (t.truncated) t.content = `[output truncated: showing last ${t.outputLines} of ${t.totalLines} lines]\n${t.content}`;
+      let text = r.stdout;
+      if (r.stderr) {
+        text += (text && !text.endsWith("\n") ? "\n" : "") + r.stderr;
+      }
+      if (r.result !== null) {
+        text += (text && !text.endsWith("\n") ? "\n" : "") + r.result;
+      }
+      if (r.error) text += (text && !text.endsWith("\n") ? "\n" : "") + r.error;
+      const t = truncateTail(text || (r.images.length ? "" : "(no output)"));
+      if (t.truncated) {
+        t.content =
+          `[output truncated: showing last ${t.outputLines} of ${t.totalLines} lines]\n${t.content}`;
+      }
 
-			const content: ({ type: "text"; text: string } | { type: "image"; data: string; mimeType: string })[] = [];
-			if (t.content) content.push({ type: "text", text: t.content });
-			for (const data of r.images) content.push({ type: "image", data, mimeType: "image/png" });
-			return { content, details: undefined, isError: r.error !== null };
-		},
-	});
+      const content: ({ type: "text"; text: string } | {
+        type: "image";
+        data: string;
+        mimeType: string;
+      })[] = [];
+      if (t.content) content.push({ type: "text", text: t.content });
+      for (const data of r.images) {
+        content.push({ type: "image", data, mimeType: "image/png" });
+      }
+      return { content, details: undefined, isError: r.error !== null };
+    },
+  });
 }

--- a/home/.pi/agent/extensions/python/index.ts
+++ b/home/.pi/agent/extensions/python/index.ts
@@ -1,0 +1,81 @@
+/**
+ * `python` tool: a persistent interpreter (driver.py) per session, so the
+ * model can keep parsed data, imports and figures between calls instead of
+ * re-running scripts through bash. Uses `pi-python` (nix, with matplotlib/
+ * polars/pyelftools/requests) unless $PI_PYTHON points elsewhere.
+ */
+
+import { execFileSync } from "node:child_process";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateTail } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+import { Kernel } from "./kernel.ts";
+
+function findPython(): string | undefined {
+	for (const cand of [process.env.PI_PYTHON, "pi-python", "python3"]) {
+		if (!cand) continue;
+		try {
+			execFileSync(cand, ["-c", ""], { stdio: "ignore" });
+			return cand;
+		} catch {}
+	}
+	return undefined;
+}
+
+export default function (pi: ExtensionAPI) {
+	const python = findPython();
+	if (!python) return;
+	let kernel: Kernel | undefined;
+
+	pi.on("session_shutdown", async () => {
+		kernel?.stop();
+		kernel = undefined;
+	});
+
+	pi.registerCommand("python-restart", {
+		description: "Restart the persistent Python interpreter (drops all state)",
+		handler: async (_args, ctx) => {
+			kernel?.stop();
+			kernel = undefined;
+			ctx.ui.notify("Python interpreter reset.", "info");
+		},
+	});
+
+	pi.registerTool({
+		name: "python",
+		label: "python",
+		description:
+			"Execute Python code in a persistent interpreter: variables, imports and open files survive between calls for the whole session. " +
+			"The value of a trailing expression is echoed like in a REPL; use print() for anything else. " +
+			"matplotlib figures are returned as images. Available: polars, matplotlib, requests, pyelftools + stdlib. " +
+			`Output is truncated to the last ${DEFAULT_MAX_LINES} lines / ${formatSize(DEFAULT_MAX_BYTES)}.`,
+		promptSnippet: "Run Python in a persistent interpreter (state kept across calls; polars, matplotlib, requests, pyelftools)",
+		promptGuidelines: [
+			"Use python instead of bash for multi-step data work (JSON/CSV/logs/ELF), calculations, and anything where re-parsing input on every call would be wasteful; state persists, so load once and iterate.",
+		],
+		parameters: Type.Object({
+			code: Type.String({ description: "Python source to execute" }),
+			timeout: Type.Optional(Type.Number({ description: "Timeout in seconds (interrupts the cell, keeps state)" })),
+		}),
+
+		async execute(_id, params, signal, _onUpdate, ctx) {
+			kernel ??= new Kernel(python, ctx.cwd);
+			const ac = new AbortController();
+			signal?.addEventListener("abort", () => ac.abort(), { once: true });
+			const timer = params.timeout ? setTimeout(() => ac.abort(), params.timeout * 1000) : undefined;
+			const r = await kernel.exec(params.code, ac.signal).finally(() => clearTimeout(timer));
+
+			let text = r.stdout;
+			if (r.stderr) text += (text && !text.endsWith("\n") ? "\n" : "") + r.stderr;
+			if (r.result !== null) text += (text && !text.endsWith("\n") ? "\n" : "") + r.result;
+			if (r.error) text += (text && !text.endsWith("\n") ? "\n" : "") + r.error;
+			const t = truncateTail(text || (r.images.length ? "" : "(no output)"));
+			if (t.truncated) t.content = `[output truncated: showing last ${t.outputLines} of ${t.totalLines} lines]\n${t.content}`;
+
+			const content: ({ type: "text"; text: string } | { type: "image"; data: string; mimeType: string })[] = [];
+			if (t.content) content.push({ type: "text", text: t.content });
+			for (const data of r.images) content.push({ type: "image", data, mimeType: "image/png" });
+			return { content, details: undefined, isError: r.error !== null };
+		},
+	});
+}

--- a/home/.pi/agent/extensions/python/kernel.test.ts
+++ b/home/.pi/agent/extensions/python/kernel.test.ts
@@ -6,87 +6,108 @@ import { Kernel } from "./kernel.ts";
 
 const python = process.env.PI_PYTHON ?? "python3";
 const hasPython = (() => {
-	try {
-		execFileSync(python, ["--version"]);
-		return true;
-	} catch {
-		return false;
-	}
+  try {
+    execFileSync(python, ["--version"]);
+    return true;
+  } catch {
+    return false;
+  }
 })();
 
 describe.skipIf(!hasPython)("python kernel", () => {
-	const k = new Kernel(python, tmpdir());
-	afterAll(() => k.stop());
+  const k = new Kernel(python, tmpdir());
+  afterAll(() => k.stop());
 
-	test("state persists and trailing expression is echoed", async () => {
-		await k.exec("import json\nx = 20");
-		const r = await k.exec("print('hi')\nx + 22");
-		expect(r).toEqual({ stdout: "hi\n", stderr: "", result: "42", error: null, images: [] });
-		expect((await k.exec("_ * 2")).result).toBe("84");
-	});
+  test("state persists and trailing expression is echoed", async () => {
+    await k.exec("import json\nx = 20");
+    const r = await k.exec("print('hi')\nx + 22");
+    expect(r).toEqual({
+      stdout: "hi\n",
+      stderr: "",
+      result: "42",
+      error: null,
+      images: [],
+    });
+    expect((await k.exec("_ * 2")).result).toBe("84");
+  });
 
-	test("exceptions come back as tracebacks starting at the cell", async () => {
-		const r = await k.exec("def f():\n  raise ValueError('boom')\nf()");
-		expect(r.error).toContain("ValueError: boom");
-		expect(r.error).toContain('File "<cell>", line 2, in f');
-		expect(r.error).not.toContain("driver.py");
-		expect((await k.exec("x")).result).toBe("20");
-	});
+  test("exceptions come back as tracebacks starting at the cell", async () => {
+    const r = await k.exec("def f():\n  raise ValueError('boom')\nf()");
+    expect(r.error).toContain("ValueError: boom");
+    expect(r.error).toContain('File "<cell>", line 2, in f');
+    expect(r.error).not.toContain("driver.py");
+    expect((await k.exec("x")).result).toBe("20");
+  });
 
-	test("syntax errors do not kill the session", async () => {
-		expect((await k.exec("def")).error).toContain("SyntaxError");
-		expect((await k.exec("x")).result).toBe("20");
-	});
+  test("syntax errors do not kill the session", async () => {
+    expect((await k.exec("def")).error).toContain("SyntaxError");
+    expect((await k.exec("x")).result).toBe("20");
+  });
 
-	test("subprocess output cannot corrupt the protocol stream", async () => {
-		const r = await k.exec("import subprocess; subprocess.run(['echo', 'raw'], check=True).returncode");
-		expect(r.result).toBe("0");
-		expect(r.stderr).toContain("raw");
-	});
+  test("subprocess output cannot corrupt the protocol stream", async () => {
+    const r = await k.exec(
+      "import subprocess; subprocess.run(['echo', 'raw'], check=True).returncode",
+    );
+    expect(r.result).toBe("0");
+    expect(r.stderr).toContain("raw");
+  });
 
-	test("abort interrupts running code but keeps state", async () => {
-		const ac = new AbortController();
-		const p = k.exec("import time\nfor i in range(100): time.sleep(0.05)", ac.signal);
-		setTimeout(() => ac.abort(), 100);
-		expect((await p).error).toContain("KeyboardInterrupt");
-		expect((await k.exec("x")).result).toBe("20");
-	});
+  test("abort interrupts running code but keeps state", async () => {
+    const ac = new AbortController();
+    const p = k.exec(
+      "import time\nfor i in range(100): time.sleep(0.05)",
+      ac.signal,
+    );
+    setTimeout(() => ac.abort(), 100);
+    expect((await p).error).toContain("KeyboardInterrupt");
+    expect((await k.exec("x")).result).toBe("20");
+  });
 
-	test("abort escalates to kill when SIGINT is swallowed", async () => {
-		const k2 = new Kernel(python, tmpdir(), 200);
-		const ac = new AbortController();
-		const p = k2.exec("import time\nwhile True:\n  try: time.sleep(1)\n  except KeyboardInterrupt: pass", ac.signal);
-		setTimeout(() => ac.abort(), 100);
-		expect((await p).error).toContain("state was lost");
-		expect((await k2.exec("1")).result).toBe("1");
-		k2.stop();
-	});
+  test("abort escalates to kill when SIGINT is swallowed", async () => {
+    const k2 = new Kernel(python, tmpdir(), 200);
+    const ac = new AbortController();
+    const p = k2.exec(
+      "import time\nwhile True:\n  try: time.sleep(1)\n  except KeyboardInterrupt: pass",
+      ac.signal,
+    );
+    setTimeout(() => ac.abort(), 100);
+    expect((await p).error).toContain("state was lost");
+    expect((await k2.exec("1")).result).toBe("1");
+    k2.stop();
+  });
 
-	test("concurrent calls are serialised", async () => {
-		const [a, b] = await Promise.all([k.exec("import time; time.sleep(0.1); y = 1"), k.exec("y")]);
-		expect(a.error).toBeNull();
-		expect(b.result).toBe("1");
-	});
+  test("concurrent calls are serialised", async () => {
+    const [a, b] = await Promise.all([
+      k.exec("import time; time.sleep(0.1); y = 1"),
+      k.exec("y"),
+    ]);
+    expect(a.error).toBeNull();
+    expect(b.result).toBe("1");
+  });
 
-	test("crash is reported and next call starts a fresh interpreter", async () => {
-		const r = await k.exec("import os; os._exit(3)");
-		expect(r.error).toContain("exited (3)");
-		expect((await k.exec("'x' in globals()")).result).toBe("False");
-	});
+  test("crash is reported and next call starts a fresh interpreter", async () => {
+    const r = await k.exec("import os; os._exit(3)");
+    expect(r.error).toContain("exited (3)");
+    expect((await k.exec("'x' in globals()")).result).toBe("False");
+  });
 
-	const hasMpl = hasPython && (() => {
-		try {
-			execFileSync(python, ["-c", "import matplotlib"]);
-			return true;
-		} catch {
-			return false;
-		}
-	})();
-	test.skipIf(!hasMpl)("matplotlib figures are returned as png", async () => {
-		const r = await k.exec("import matplotlib.pyplot as plt\nplt.plot([1,2,3])\nplt.title('t')");
-		expect(r.error).toBeNull();
-		expect(r.images).toHaveLength(1);
-		expect(Buffer.from(r.images[0], "base64").subarray(1, 4).toString()).toBe("PNG");
-		expect((await k.exec("len(plt.get_fignums())")).result).toBe("0");
-	});
+  const hasMpl = hasPython && (() => {
+    try {
+      execFileSync(python, ["-c", "import matplotlib"]);
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+  test.skipIf(!hasMpl)("matplotlib figures are returned as png", async () => {
+    const r = await k.exec(
+      "import matplotlib.pyplot as plt\nplt.plot([1,2,3])\nplt.title('t')",
+    );
+    expect(r.error).toBeNull();
+    expect(r.images).toHaveLength(1);
+    expect(Buffer.from(r.images[0], "base64").subarray(1, 4).toString()).toBe(
+      "PNG",
+    );
+    expect((await k.exec("len(plt.get_fignums())")).result).toBe("0");
+  });
 });

--- a/home/.pi/agent/extensions/python/kernel.test.ts
+++ b/home/.pi/agent/extensions/python/kernel.test.ts
@@ -1,0 +1,92 @@
+/** Run with: bun test python (needs python3) */
+import { afterAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { Kernel } from "./kernel.ts";
+
+const python = process.env.PI_PYTHON ?? "python3";
+const hasPython = (() => {
+	try {
+		execFileSync(python, ["--version"]);
+		return true;
+	} catch {
+		return false;
+	}
+})();
+
+describe.skipIf(!hasPython)("python kernel", () => {
+	const k = new Kernel(python, tmpdir());
+	afterAll(() => k.stop());
+
+	test("state persists and trailing expression is echoed", async () => {
+		await k.exec("import json\nx = 20");
+		const r = await k.exec("print('hi')\nx + 22");
+		expect(r).toEqual({ stdout: "hi\n", stderr: "", result: "42", error: null, images: [] });
+		expect((await k.exec("_ * 2")).result).toBe("84");
+	});
+
+	test("exceptions come back as tracebacks starting at the cell", async () => {
+		const r = await k.exec("def f():\n  raise ValueError('boom')\nf()");
+		expect(r.error).toContain("ValueError: boom");
+		expect(r.error).toContain('File "<cell>", line 2, in f');
+		expect(r.error).not.toContain("driver.py");
+		expect((await k.exec("x")).result).toBe("20");
+	});
+
+	test("syntax errors do not kill the session", async () => {
+		expect((await k.exec("def")).error).toContain("SyntaxError");
+		expect((await k.exec("x")).result).toBe("20");
+	});
+
+	test("subprocess output cannot corrupt the protocol stream", async () => {
+		const r = await k.exec("import subprocess; subprocess.run(['echo', 'raw'], check=True).returncode");
+		expect(r.result).toBe("0");
+		expect(r.stderr).toContain("raw");
+	});
+
+	test("abort interrupts running code but keeps state", async () => {
+		const ac = new AbortController();
+		const p = k.exec("import time\nfor i in range(100): time.sleep(0.05)", ac.signal);
+		setTimeout(() => ac.abort(), 100);
+		expect((await p).error).toContain("KeyboardInterrupt");
+		expect((await k.exec("x")).result).toBe("20");
+	});
+
+	test("abort escalates to kill when SIGINT is swallowed", async () => {
+		const k2 = new Kernel(python, tmpdir(), 200);
+		const ac = new AbortController();
+		const p = k2.exec("import time\nwhile True:\n  try: time.sleep(1)\n  except KeyboardInterrupt: pass", ac.signal);
+		setTimeout(() => ac.abort(), 100);
+		expect((await p).error).toContain("state was lost");
+		expect((await k2.exec("1")).result).toBe("1");
+		k2.stop();
+	});
+
+	test("concurrent calls are serialised", async () => {
+		const [a, b] = await Promise.all([k.exec("import time; time.sleep(0.1); y = 1"), k.exec("y")]);
+		expect(a.error).toBeNull();
+		expect(b.result).toBe("1");
+	});
+
+	test("crash is reported and next call starts a fresh interpreter", async () => {
+		const r = await k.exec("import os; os._exit(3)");
+		expect(r.error).toContain("exited (3)");
+		expect((await k.exec("'x' in globals()")).result).toBe("False");
+	});
+
+	const hasMpl = hasPython && (() => {
+		try {
+			execFileSync(python, ["-c", "import matplotlib"]);
+			return true;
+		} catch {
+			return false;
+		}
+	})();
+	test.skipIf(!hasMpl)("matplotlib figures are returned as png", async () => {
+		const r = await k.exec("import matplotlib.pyplot as plt\nplt.plot([1,2,3])\nplt.title('t')");
+		expect(r.error).toBeNull();
+		expect(r.images).toHaveLength(1);
+		expect(Buffer.from(r.images[0], "base64").subarray(1, 4).toString()).toBe("PNG");
+		expect((await k.exec("len(plt.get_fignums())")).result).toBe("0");
+	});
+});

--- a/home/.pi/agent/extensions/python/kernel.ts
+++ b/home/.pi/agent/extensions/python/kernel.ts
@@ -8,85 +8,88 @@ import { fileURLToPath } from "node:url";
 const DRIVER = join(dirname(fileURLToPath(import.meta.url)), "driver.py");
 
 export interface ExecResult {
-	stdout: string;
-	stderr: string;
-	result: string | null;
-	error: string | null;
-	images: string[];
+  stdout: string;
+  stderr: string;
+  result: string | null;
+  error: string | null;
+  images: string[];
 }
 
 export class Kernel {
-	private proc: ChildProcess | undefined;
-	private pending: ((r: ExecResult) => void) | undefined;
-	private stderr = "";
-	private queue: Promise<unknown> = Promise.resolve();
+  private proc: ChildProcess | undefined;
+  private pending: ((r: ExecResult) => void) | undefined;
+  private stderr = "";
+  private queue: Promise<unknown> = Promise.resolve();
 
-	constructor(
-		readonly python: string,
-		readonly cwd: string,
-		/** C extensions or `except KeyboardInterrupt` can swallow SIGINT; kill after this. */
-		readonly killAfterMs = 3000,
-	) {}
+  constructor(
+    readonly python: string,
+    readonly cwd: string,
+    /** C extensions or `except KeyboardInterrupt` can swallow SIGINT; kill after this. */
+    readonly killAfterMs = 3000,
+  ) {}
 
-	get running(): boolean {
-		return this.proc !== undefined && this.proc.exitCode === null;
-	}
+  get running(): boolean {
+    return this.proc !== undefined && this.proc.exitCode === null;
+  }
 
-	private start(): ChildProcess {
-		const proc = spawn(this.python, ["-u", DRIVER], { cwd: this.cwd, stdio: ["pipe", "pipe", "pipe"] });
-		proc.stderr!.on("data", (d) => {
-			this.stderr += d.toString();
-		});
-		createInterface({ input: proc.stdout! }).on("line", (line) => {
-			const done = this.pending;
-			this.pending = undefined;
-			done?.(JSON.parse(line));
-		});
-		proc.on("exit", (code, sig) => {
-			this.proc = undefined;
-			const done = this.pending;
-			this.pending = undefined;
-			done?.({
-				stdout: "",
-				stderr: this.stderr,
-				result: null,
-				error: `Python process exited (${sig ?? code}); state was lost.`,
-				images: [],
-			});
-			this.stderr = "";
-		});
-		return proc;
-	}
+  private start(): ChildProcess {
+    const proc = spawn(this.python, ["-u", DRIVER], {
+      cwd: this.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    proc.stderr!.on("data", (d) => {
+      this.stderr += d.toString();
+    });
+    createInterface({ input: proc.stdout! }).on("line", (line) => {
+      const done = this.pending;
+      this.pending = undefined;
+      done?.(JSON.parse(line));
+    });
+    proc.on("exit", (code, sig) => {
+      this.proc = undefined;
+      const done = this.pending;
+      this.pending = undefined;
+      done?.({
+        stdout: "",
+        stderr: this.stderr,
+        result: null,
+        error: `Python process exited (${sig ?? code}); state was lost.`,
+        images: [],
+      });
+      this.stderr = "";
+    });
+    return proc;
+  }
 
-	exec(code: string, signal?: AbortSignal): Promise<ExecResult> {
-		const job = this.queue.then(() => this.execNow(code, signal));
-		this.queue = job.catch(() => {});
-		return job;
-	}
+  exec(code: string, signal?: AbortSignal): Promise<ExecResult> {
+    const job = this.queue.then(() => this.execNow(code, signal));
+    this.queue = job.catch(() => {});
+    return job;
+  }
 
-	private execNow(code: string, signal?: AbortSignal): Promise<ExecResult> {
-		this.proc ??= this.start();
-		const proc = this.proc;
-		this.stderr = "";
-		return new Promise<ExecResult>((resolve) => {
-			let killTimer: ReturnType<typeof setTimeout> | undefined;
-			const onAbort = () => {
-				proc.kill("SIGINT");
-				killTimer = setTimeout(() => proc.kill("SIGKILL"), this.killAfterMs);
-			};
-			signal?.addEventListener("abort", onAbort, { once: true });
-			this.pending = (r) => {
-				signal?.removeEventListener("abort", onAbort);
-				clearTimeout(killTimer);
-				// fd-level writes (subprocesses, C libs) bypass sys.stderr and land here.
-				resolve({ ...r, stderr: r.stderr + this.stderr });
-			};
-			proc.stdin!.write(`${JSON.stringify({ code })}\n`);
-		});
-	}
+  private execNow(code: string, signal?: AbortSignal): Promise<ExecResult> {
+    this.proc ??= this.start();
+    const proc = this.proc;
+    this.stderr = "";
+    return new Promise<ExecResult>((resolve) => {
+      let killTimer: ReturnType<typeof setTimeout> | undefined;
+      const onAbort = () => {
+        proc.kill("SIGINT");
+        killTimer = setTimeout(() => proc.kill("SIGKILL"), this.killAfterMs);
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      this.pending = (r) => {
+        signal?.removeEventListener("abort", onAbort);
+        clearTimeout(killTimer);
+        // fd-level writes (subprocesses, C libs) bypass sys.stderr and land here.
+        resolve({ ...r, stderr: r.stderr + this.stderr });
+      };
+      proc.stdin!.write(`${JSON.stringify({ code })}\n`);
+    });
+  }
 
-	stop(): void {
-		this.proc?.kill("SIGKILL");
-		this.proc = undefined;
-	}
+  stop(): void {
+    this.proc?.kill("SIGKILL");
+    this.proc = undefined;
+  }
 }

--- a/home/.pi/agent/extensions/python/kernel.ts
+++ b/home/.pi/agent/extensions/python/kernel.ts
@@ -1,0 +1,92 @@
+/** Thin client for driver.py: one long-lived child, JSON lines, serialised requests. */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+
+const DRIVER = join(dirname(fileURLToPath(import.meta.url)), "driver.py");
+
+export interface ExecResult {
+	stdout: string;
+	stderr: string;
+	result: string | null;
+	error: string | null;
+	images: string[];
+}
+
+export class Kernel {
+	private proc: ChildProcess | undefined;
+	private pending: ((r: ExecResult) => void) | undefined;
+	private stderr = "";
+	private queue: Promise<unknown> = Promise.resolve();
+
+	constructor(
+		readonly python: string,
+		readonly cwd: string,
+		/** C extensions or `except KeyboardInterrupt` can swallow SIGINT; kill after this. */
+		readonly killAfterMs = 3000,
+	) {}
+
+	get running(): boolean {
+		return this.proc !== undefined && this.proc.exitCode === null;
+	}
+
+	private start(): ChildProcess {
+		const proc = spawn(this.python, ["-u", DRIVER], { cwd: this.cwd, stdio: ["pipe", "pipe", "pipe"] });
+		proc.stderr!.on("data", (d) => {
+			this.stderr += d.toString();
+		});
+		createInterface({ input: proc.stdout! }).on("line", (line) => {
+			const done = this.pending;
+			this.pending = undefined;
+			done?.(JSON.parse(line));
+		});
+		proc.on("exit", (code, sig) => {
+			this.proc = undefined;
+			const done = this.pending;
+			this.pending = undefined;
+			done?.({
+				stdout: "",
+				stderr: this.stderr,
+				result: null,
+				error: `Python process exited (${sig ?? code}); state was lost.`,
+				images: [],
+			});
+			this.stderr = "";
+		});
+		return proc;
+	}
+
+	exec(code: string, signal?: AbortSignal): Promise<ExecResult> {
+		const job = this.queue.then(() => this.execNow(code, signal));
+		this.queue = job.catch(() => {});
+		return job;
+	}
+
+	private execNow(code: string, signal?: AbortSignal): Promise<ExecResult> {
+		this.proc ??= this.start();
+		const proc = this.proc;
+		this.stderr = "";
+		return new Promise<ExecResult>((resolve) => {
+			let killTimer: ReturnType<typeof setTimeout> | undefined;
+			const onAbort = () => {
+				proc.kill("SIGINT");
+				killTimer = setTimeout(() => proc.kill("SIGKILL"), this.killAfterMs);
+			};
+			signal?.addEventListener("abort", onAbort, { once: true });
+			this.pending = (r) => {
+				signal?.removeEventListener("abort", onAbort);
+				clearTimeout(killTimer);
+				// fd-level writes (subprocesses, C libs) bypass sys.stderr and land here.
+				resolve({ ...r, stderr: r.stderr + this.stderr });
+			};
+			proc.stdin!.write(`${JSON.stringify({ code })}\n`);
+		});
+	}
+
+	stop(): void {
+		this.proc?.kill("SIGKILL");
+		this.proc = undefined;
+	}
+}

--- a/machines/eve/configuration.nix
+++ b/machines/eve/configuration.nix
@@ -23,6 +23,7 @@
     self.inputs.srvos.nixosModules.mixins-nginx
     self.inputs.srvos.nixosModules.hardware-hetzner-online-amd
     self.inputs.flakelet.nixosModules.flakelet
+    ../../nixosModules/flakelet-deploy.nix
     self.inputs.flakelet-nginx.nixosModules.provider
     self.inputs.flakelet-postgres.nixosModules.provider
     self.inputs.disko.nixosModules.disko

--- a/machines/eve/modules/nixbot.nix
+++ b/machines/eve/modules/nixbot.nix
@@ -1,6 +1,5 @@
 {
   config,
-  lib,
   pkgs,
   self,
   ...
@@ -290,51 +289,10 @@ in
   };
   services.flakelet-postgres.enable = true;
 
-  # Push deploys from nixbot CI via step-ca SSH certs. The forced command
-  # only enqueues a detached update so it survives nixbot restarting itself.
-  users.users.nixbot-deploy = {
-    isSystemUser = true;
-    group = "nixbot-deploy";
-    shell = pkgs.bash;
-  };
-  users.groups.nixbot-deploy = { };
-
-  environment.etc."ssh/nixbot-deploy-ca.pub".source =
-    config.clan.core.vars.generators.step-ssh-user-ca.files."ca.pub".path;
-  # sshd StrictModes rejects symlinks into /nix/store
-  environment.etc."ssh/nixbot-deploy-principals" = {
-    text = ''
-      repo:github:Mic92/nixbot:ref:refs/heads/main
-      repo:github:Mic92/nixbot:ref:refs/heads/flakelet
-    '';
-    mode = "0444";
-  };
-
-  services.openssh.extraConfig = ''
-    Match User nixbot-deploy
-      TrustedUserCAKeys /etc/ssh/nixbot-deploy-ca.pub
-      AuthorizedPrincipalsFile /etc/ssh/nixbot-deploy-principals
-      ForceCommand /run/wrappers/bin/sudo /run/current-system/sw/bin/systemctl start --no-block flakelet-update-nixbot.service && echo "eve: flakelet update of nixbot enqueued"
-  '';
-
-  security.sudo.extraRules = [
-    {
-      users = [ "nixbot-deploy" ];
-      commands = [
-        {
-          command = "/run/current-system/sw/bin/systemctl start --no-block flakelet-update-nixbot.service";
-          options = [ "NOPASSWD" ];
-        }
-      ];
-    }
-  ];
-
-  systemd.services.flakelet-update-nixbot = {
-    description = "flakelet update of nixbot triggered by CI";
-    serviceConfig = {
-      Type = "oneshot";
-      ExecStart = "${lib.getExe config.services.flakelets.package} update nixbot";
-    };
+  # Push deploys from nixbot CI, see nixosModules/flakelet-deploy.nix.
+  services.flakeletDeploy = {
+    caPublicKey = config.clan.core.vars.generators.step-ssh-user-ca.files."ca.pub".value;
+    services.nixbot.principals = [ "repo:github:Mic92/nixbot:ref:refs/heads/main" ];
   };
 
   # Legacy domain: permanently redirect to the new nixbot domain so old

--- a/machines/eve/modules/tribuchet.nix
+++ b/machines/eve/modules/tribuchet.nix
@@ -52,6 +52,10 @@ in
     };
   };
 
+  services.flakeletDeploy.services.tribuchet-hub.principals = [
+    "repo:github:Mic92/tribuchet:ref:refs/heads/main"
+  ];
+
   services.tribuchet-hub = {
     openFirewall = true;
     externalBuilders = {

--- a/nixosModules/flakelet-deploy.nix
+++ b/nixosModules/flakelet-deploy.nix
@@ -1,0 +1,93 @@
+# CI-triggered `flakelet update <name>` over ssh. nixbot effects get a
+# short-lived ssh certificate from step-ca (OIDC provisioner "nixbot")
+# whose principal is the token subject, e.g.
+# repo:github:Mic92/nixbot:ref:refs/heads/main. Each principal may only
+# enqueue the update of the services it is listed under.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.flakeletDeploy;
+  unit = name: "flakelet-update@${name}.service";
+  start = name: "/run/current-system/sw/bin/systemctl start --no-block ${unit name}";
+in
+{
+  options.services.flakeletDeploy = {
+    caPublicKey = lib.mkOption {
+      type = lib.types.str;
+      description = "SSH user CA that signs the deploy certificates.";
+    };
+    services = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options.principals = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            description = "Certificate principals allowed to update this flakelet.";
+          };
+        }
+      );
+      default = { };
+    };
+  };
+
+  config = lib.mkIf (cfg.services != { }) {
+    users.users.flakelet-deploy = {
+      isSystemUser = true;
+      group = "flakelet-deploy";
+      shell = pkgs.bash;
+    };
+    users.groups.flakelet-deploy = { };
+
+    # sshd StrictModes rejects symlinks into /nix/store
+    environment.etc."ssh/flakelet-deploy-ca.pub" = {
+      text = cfg.caPublicKey;
+      mode = "0444";
+    };
+    environment.etc."ssh/flakelet-deploy-principals" = {
+      text = lib.concatStrings (
+        lib.concatLists (
+          lib.mapAttrsToList (
+            name: svc:
+            map (p: ''
+              command="${start name} && echo '${config.networking.hostName}: flakelet update of ${name} enqueued'" ${p}
+            '') svc.principals
+          ) cfg.services
+        )
+      );
+      mode = "0444";
+    };
+
+    services.openssh.extraConfig = lib.mkAfter ''
+      Match User flakelet-deploy
+        TrustedUserCAKeys /etc/ssh/flakelet-deploy-ca.pub
+        AuthorizedPrincipalsFile /etc/ssh/flakelet-deploy-principals
+        AuthorizedKeysFile none
+      Match all
+    '';
+
+    # The forced command pins the unit per principal; polkit only has to
+    # let this user start the template at all.
+    security.polkit.enable = true;
+    security.polkit.extraConfig = ''
+      polkit.addRule(function(action, subject) {
+        if (action.id == "org.freedesktop.systemd1.manage-units" &&
+            subject.user == "flakelet-deploy" &&
+            action.lookup("verb") == "start" &&
+            action.lookup("unit").indexOf("flakelet-update@") == 0) {
+          return polkit.Result.YES;
+        }
+      });
+    '';
+
+    systemd.services."flakelet-update@" = {
+      description = "flakelet update of %i triggered by CI";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${lib.getExe config.services.flakelets.package} update %i";
+      };
+    };
+  };
+}


### PR DESCRIPTION

Ad-hoc data work (JSON/CSV/logs/ELF poking, quick calculations, plots)
through the bash tool means re-running and re-parsing on every call and
fighting shell quoting. A long-lived interpreter lets the model load once
and iterate, and matplotlib figures come back as images.

Deliberately not Jupyter: a ~90 line stdlib driver speaking JSON lines
covers what an agent needs (stdout/stderr/result/traceback/images,
SIGINT with SIGKILL escalation) without pyzmq/ipykernel.

pi-python is a separate wrapper so it never shadows a project's python3;
PI_PYTHON overrides it per project.
