### PR TITLE
pi/python: render code and output in the tool row

### DIFF
--- a/checks/flake-module.nix
+++ b/checks/flake-module.nix
@@ -56,7 +56,7 @@ let
 in
 {
   # Warning for testing eval warning reporting in CI
-  checks = lib.warn "test eval warning from checks/flake-module.nix" (
+  checks = (
     nixosMachines // darwinMachines // packages // packageTests // devShells // homeConfigurations
   );
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1101,11 +1101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783174389,
-        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "lastModified": 1786629091,
+        "narHash": "sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -919,10 +919,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787516733,
-        "narHash": "sha256-CFKyaeXVp5OFDWamGcDPNtxPCH32LFwB4LiJtiO5O10=",
+        "lastModified": 1788295810,
+        "narHash": "sha256-Ui+ShOObCKNwtS83FkOSvC7pPUQPInzPk0e8YzMI/lE=",
         "ref": "main",
-        "rev": "1bf0cdc0477e621b046356226b3df44140b3c8ac",
+        "rev": "869276c56c2b4675adc8767a767153410d0458fc",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/Mic92/nixpkgs"

--- a/flake.lock
+++ b/flake.lock
@@ -686,10 +686,10 @@
         "nixpkgs-regression": []
       },
       "locked": {
-        "lastModified": 1787989251,
-        "narHash": "sha256-L8/AUynue63dBMN0zfpo9b416UBHu4PH0EEebK5Iav0=",
+        "lastModified": 1788296695,
+        "narHash": "sha256-g00EbL2OU56czimIbaL5xzFjGgJ8xDWlFtiuREMpkxY=",
         "ref": "refs/heads/main",
-        "rev": "7405040112c4f06128154e83bdef1cfc5ff09403",
+        "rev": "66560545bc69484d7fcfdded9736f43f29682e5c",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/Mic92/nix-1"

--- a/home-manager/modules/ai.nix
+++ b/home-manager/modules/ai.nix
@@ -15,6 +15,7 @@ let
   # never shadows a project's python3; override per project with $PI_PYTHON.
   piPython = pkgs.python3.withPackages (ps: [
     ps.matplotlib
+    ps.pexpect
     ps.polars
     ps.pyelftools
     ps.requests
@@ -78,7 +79,6 @@ in
       "gmaps-cli"
       "kagi-search"
       "n8n-cli"
-      "pexpect-cli"
       "queue"
       "screenshot-cli"
     ];

--- a/home/.pi/agent/extensions/python/index.ts
+++ b/home/.pi/agent/extensions/python/index.ts
@@ -11,8 +11,11 @@ import {
   DEFAULT_MAX_BYTES,
   DEFAULT_MAX_LINES,
   formatSize,
+  highlightCode,
+  keyHint,
   truncateTail,
 } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
 import { Type } from "typebox";
 import { Kernel } from "./kernel.ts";
 
@@ -69,6 +72,46 @@ export default function (pi: ExtensionAPI) {
         }),
       ),
     }),
+
+    // Without this pi's fallback renders only the tool name, hiding the code.
+    renderCall(args, theme, context) {
+      const text = (context.lastComponent as Text | undefined) ??
+        new Text("", 0, 0);
+      let out = theme.fg("toolTitle", theme.bold("python"));
+      if (args.timeout) out += theme.fg("muted", ` (timeout ${args.timeout}s)`);
+      const code = (args.code ?? "").trimEnd();
+      if (code) out += "\n" + highlightCode(code, "python").join("\n");
+      text.setText(out);
+      return text;
+    },
+
+    renderResult(result, options, theme, context) {
+      const text = (context.lastComponent as Text | undefined) ??
+        new Text("", 0, 0);
+      const output = result.content
+        .filter((c) => c.type === "text")
+        .map((c) => (c as { text: string }).text)
+        .join("\n")
+        .trimEnd();
+      const images = result.content.filter((c) => c.type === "image").length;
+      const lines = output ? output.split("\n") : [];
+      // Tail, not head: tracebacks and REPL results come last.
+      const shown = options.expanded ? lines : lines.slice(-10);
+      const color = context.isError ? "error" : "toolOutput";
+      let out = theme.fg("muted", "─── output ───");
+      if (lines.length > shown.length) {
+        out += theme.fg(
+          "muted",
+          `\n... (${lines.length - shown.length} earlier lines, `,
+        ) + keyHint("app.tools.expand", "to expand") + theme.fg("muted", ")");
+      }
+      if (shown.length) {
+        out += "\n" + shown.map((l) => theme.fg(color, l)).join("\n");
+      }
+      if (images) out += theme.fg("muted", `\n[${images} image(s)]`);
+      text.setText(out);
+      return text;
+    },
 
     async execute(_id, params, signal, _onUpdate, ctx) {
       kernel ??= new Kernel(python, ctx.cwd);

--- a/home/.pi/agent/extensions/python/index.ts
+++ b/home/.pi/agent/extensions/python/index.ts
@@ -2,7 +2,7 @@
  * `python` tool: a persistent interpreter (driver.py) per session, so the
  * model can keep parsed data, imports and figures between calls instead of
  * re-running scripts through bash. Uses `pi-python` (nix, with matplotlib/
- * polars/pyelftools/requests) unless $PI_PYTHON points elsewhere.
+ * pexpect/polars/pyelftools/requests) unless $PI_PYTHON points elsewhere.
  */
 
 import { execFileSync } from "node:child_process";
@@ -55,14 +55,15 @@ export default function (pi: ExtensionAPI) {
     description:
       "Execute Python code in a persistent interpreter: variables, imports and open files survive between calls for the whole session. " +
       "The value of a trailing expression is echoed like in a REPL; use print() for anything else. " +
-      "matplotlib figures are returned as images. Available: polars, matplotlib, requests, pyelftools + stdlib. " +
+      "matplotlib figures are returned as images. Available: polars, matplotlib, requests, pexpect, pyelftools + stdlib. " +
       `Output is truncated to the last ${DEFAULT_MAX_LINES} lines / ${
         formatSize(DEFAULT_MAX_BYTES)
       }.`,
     promptSnippet:
-      "Run Python in a persistent interpreter (state kept across calls; polars, matplotlib, requests, pyelftools)",
+      "Run Python in a persistent interpreter (state kept across calls; polars, matplotlib, requests, pexpect, pyelftools)",
     promptGuidelines: [
       "Use python instead of bash for multi-step data work (JSON/CSV/logs/ELF), calculations, and anything where re-parsing input on every call would be wasteful; state persists, so load once and iterate.",
+      "Drive interactive programs (ssh, REPLs, debuggers, installers) with pexpect inside the python tool: `child = pexpect.spawn(cmd, encoding='utf-8')` persists across calls; always pass `timeout=` to expect().",
     ],
     parameters: Type.Object({
       code: Type.String({ description: "Python source to execute" }),

--- a/home/.pi/agent/extensions/python/kernel.test.ts
+++ b/home/.pi/agent/extensions/python/kernel.test.ts
@@ -76,6 +76,17 @@ describe.skipIf(!hasPython)("python kernel", () => {
     k2.stop();
   });
 
+  test("stop kills spawned children too", async () => {
+    const k2 = new Kernel(python, tmpdir());
+    const r = await k2.exec(
+      "import subprocess; p = subprocess.Popen(['sleep', '30']); p.pid",
+    );
+    const pid = Number(r.result);
+    k2.stop();
+    await new Promise((r) => setTimeout(r, 100));
+    expect(() => process.kill(pid, 0)).toThrow();
+  });
+
   test("concurrent calls are serialised", async () => {
     const [a, b] = await Promise.all([
       k.exec("import time; time.sleep(0.1); y = 1"),

--- a/home/.pi/agent/extensions/python/kernel.ts
+++ b/home/.pi/agent/extensions/python/kernel.ts
@@ -28,14 +28,12 @@ export class Kernel {
     readonly killAfterMs = 3000,
   ) {}
 
-  get running(): boolean {
-    return this.proc !== undefined && this.proc.exitCode === null;
-  }
-
   private start(): ChildProcess {
+    // Own process group so kill() also reaches pexpect/subprocess children.
     const proc = spawn(this.python, ["-u", DRIVER], {
       cwd: this.cwd,
       stdio: ["pipe", "pipe", "pipe"],
+      detached: true,
     });
     proc.stderr!.on("data", (d) => {
       this.stderr += d.toString();
@@ -75,7 +73,7 @@ export class Kernel {
       let killTimer: ReturnType<typeof setTimeout> | undefined;
       const onAbort = () => {
         proc.kill("SIGINT");
-        killTimer = setTimeout(() => proc.kill("SIGKILL"), this.killAfterMs);
+        killTimer = setTimeout(() => killGroup(proc), this.killAfterMs);
       };
       signal?.addEventListener("abort", onAbort, { once: true });
       this.pending = (r) => {
@@ -89,7 +87,15 @@ export class Kernel {
   }
 
   stop(): void {
-    this.proc?.kill("SIGKILL");
+    if (this.proc) killGroup(this.proc);
     this.proc = undefined;
+  }
+}
+
+function killGroup(proc: ChildProcess): void {
+  try {
+    if (proc.pid) process.kill(-proc.pid, "SIGKILL");
+  } catch {
+    proc.kill("SIGKILL");
   }
 }

--- a/home/.pi/agent/models.json
+++ b/home/.pi/agent/models.json
@@ -6,12 +6,15 @@
       "apiKey": "dummy",
       "models": [
         {
-          "id": "qwen3-30b-a3b-instruct",
-          "name": "Qwen3 30B A3B Instruct (jack)",
-          "contextWindow": 32768,
+          "id": "qwen3.8-27b",
+          "name": "Qwen 3.8 (27B, jack)",
+          "contextWindow": 262144,
           "input": ["text"],
+          "reasoning": true,
           "compat": {
-            "supportsDeveloperRole": false
+            "supportsDeveloperRole": false,
+            "thinkingFormat": "qwen-chat-template",
+            "reasoningEffortMap": { "minimal": "low", "xhigh": "high" }
           }
         }
       ]

--- a/home/.pi/agent/settings.json
+++ b/home/.pi/agent/settings.json
@@ -29,5 +29,6 @@
   "warnings": {
     "anthropicExtraUsage": false
   },
-  "hideThinkingBlock": true
+  "hideThinkingBlock": false,
+  "quietStartup": true
 }


### PR DESCRIPTION

pi's fallback renderer only prints the tool name when an extension
defines no renderCall, so the executed code was invisible in the TUI.
Add renderCall with syntax highlighting and a renderResult that
separates output, shows the tail (tracebacks/REPL results come last)
and colors errors.

Change-Id: I6affba1348b67d8bff97ec9ca4679f44328fe34f
