### PR TITLE
eve/eva: run flakelet-relay as a flakelet, agent on both relay hosts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,15 +53,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1784665499,
-        "narHash": "sha256-9BMxlTxCCDAeoNLtb1a/st7udtTIJep+wpUzquA29VU=",
-        "owner": "nix-community",
+        "lastModified": 1788011267,
+        "narHash": "sha256-mEq2kU+ljompTToZ44Afvm7d/rHJ5iMBl0tjZuyShJs=",
+        "owner": "Mic92",
         "repo": "bun2nix",
-        "rev": "0f2a1f0b6f42cebe3b149bf62d38754c5e0e9729",
+        "rev": "5765b0614591f75ee8ba5596e81ae85c167d1071",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "Mic92",
+        "ref": "fix-structured-attrs-hook",
         "repo": "bun2nix",
         "type": "github"
       }
@@ -616,11 +617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786646823,
-        "narHash": "sha256-+vQKp9DQ7kKVIopa6U+XHtayQ9OrQvfW+N9xcscpGWo=",
+        "lastModified": 1788437273,
+        "narHash": "sha256-dn+N26nSI4WqryWWBUfClz6qSpFHGNGJmc9M46usr70=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "49dcc8bd363ae864306896407fa352df4d48473f",
+        "rev": "c48d91c89868c53dd0b51bf840977cc83f2544fb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -330,11 +330,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788292392,
-        "narHash": "sha256-f/06YkoGOsJq9msglQKMJyzK3rQYmPVFhyN0y1FsHLU=",
+        "lastModified": 1788312293,
+        "narHash": "sha256-khVhEomZZqhp0GL9RiPaOrp+shvbQvhMl2e0rklyreE=",
         "owner": "Mic92",
         "repo": "flakelet",
-        "rev": "5ce75ca90e28cf84b66ea40eacc3b0d1c7f06b3f",
+        "rev": "bb3df2b31287219c575cade0a10087d21fc2a285",
         "type": "github"
       },
       "original": {
@@ -389,11 +389,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788435810,
-        "narHash": "sha256-iMP8MG/0iycvrQ1z43IRvQJc7/HldhcS+sM2NKqmoqs=",
+        "lastModified": 1788543707,
+        "narHash": "sha256-ngG2OeEFaM/OKXF/hDPooi3HB+fW/8qxzUPQsc5/xiY=",
         "owner": "Mic92",
         "repo": "flakelet-relay",
-        "rev": "524322d75971302890969b941b2cbfe165d8aac3",
+        "rev": "9dd07e9cc4350077228515e02e410222da50efb5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -389,11 +389,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788543707,
-        "narHash": "sha256-ngG2OeEFaM/OKXF/hDPooi3HB+fW/8qxzUPQsc5/xiY=",
+        "lastModified": 1788605695,
+        "narHash": "sha256-Tgb4l+/oBwha17kTu6Gy4Cp2PZY+xixUaxNrvNN+xmw=",
         "owner": "Mic92",
         "repo": "flakelet-relay",
-        "rev": "9dd07e9cc4350077228515e02e410222da50efb5",
+        "rev": "ac37b38606e842672f3f6c133489a31d4c6a1452",
         "type": "github"
       },
       "original": {

--- a/home-manager/modules/ai.nix
+++ b/home-manager/modules/ai.nix
@@ -49,6 +49,7 @@ in
       selfPkgs.herdr-pluck
       selfPkgs.herdr-sesh
       selfPkgs.herdr-autoname
+      selfPkgs.herdr-autospace
     ];
   };
 

--- a/home-manager/modules/ai.nix
+++ b/home-manager/modules/ai.nix
@@ -16,6 +16,7 @@ let
   piPython = pkgs.python3.withPackages (ps: [
     ps.matplotlib
     ps.pexpect
+    ps.plumbum
     ps.polars
     ps.pyelftools
     ps.requests

--- a/home-manager/modules/herdr/0001-remote-make-ssh-transport-program-configurable.patch
+++ b/home-manager/modules/herdr/0001-remote-make-ssh-transport-program-configurable.patch
@@ -1,6 +1,6 @@
-From 7f65636f020511fe6f1781f58bb8feab11e7e63f Mon Sep 17 00:00:00 2001
+From dba963b9a5b3e9179a57908083a98c68feb16ce2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
-Date: Sun, 26 Jul 2026 10:43:42 +0200
+Date: Thu, 3 Sep 2026 22:47:27 +0200
 Subject: [PATCH] remote: make ssh transport program configurable
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -22,16 +22,16 @@ accept OpenSSH-compatible arguments (-T <target> <command>).
 
 Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
 ---
- src/config/model.rs |  4 ++++
- src/main.rs         |  3 +++
- src/remote/unix.rs  | 41 +++++++++++++++++++++++++++++++++--------
- 3 files changed, 40 insertions(+), 8 deletions(-)
+ src/config/model.rs  |  4 ++++
+ src/main.rs          |  3 +++
+ src/remote/attach.rs | 46 +++++++++++++++++++++++++++++++++++---------
+ 3 files changed, 44 insertions(+), 9 deletions(-)
 
 diff --git a/src/config/model.rs b/src/config/model.rs
-index e56ac08..1d471f3 100644
+index c10cd73..0756841 100644
 --- a/src/config/model.rs
 +++ b/src/config/model.rs
-@@ -878,12 +878,16 @@ pub struct RemoteConfig {
+@@ -966,12 +966,16 @@ pub struct RemoteConfig {
      /// Add keepalive fallbacks and private connection reuse for `herdr --remote`.
      /// Set false to run plain ssh unchanged. Default: true.
      pub manage_ssh_config: bool,
@@ -49,10 +49,10 @@ index e56ac08..1d471f3 100644
      }
  }
 diff --git a/src/main.rs b/src/main.rs
-index 27c1d92..0227cd2 100644
+index 56dbb8d..cc903f7 100644
 --- a/src/main.rs
 +++ b/src/main.rs
-@@ -395,6 +395,9 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
+@@ -433,6 +433,9 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
  # Set false to run plain ssh against your ssh config unchanged — this does not
  # force keepalive or multiplexing off, it only stops herdr from adding its own.
  # manage_ssh_config = true
@@ -62,11 +62,11 @@ index 27c1d92..0227cd2 100644
  
  [experimental]
  # Allow launching herdr from inside a herdr-managed pane.
-diff --git a/src/remote/unix.rs b/src/remote/unix.rs
-index 6fe927c..55a0764 100644
---- a/src/remote/unix.rs
-+++ b/src/remote/unix.rs
-@@ -166,11 +166,12 @@ pub(crate) fn run_remote(remote: RemoteLaunch) -> io::Result<()> {
+diff --git a/src/remote/attach.rs b/src/remote/attach.rs
+index 33e191f..c6a0929 100644
+--- a/src/remote/attach.rs
++++ b/src/remote/attach.rs
+@@ -173,11 +173,12 @@ pub(crate) fn run_remote(remote: RemoteLaunch) -> io::Result<()> {
          remote.keybindings,
          remote.live_handoff,
      );
@@ -84,7 +84,7 @@ index 6fe927c..55a0764 100644
      let prepared_remote = prepare_remote_herdr(&remote_ssh, remote.live_handoff)?;
      ensure_remote_server_ready(
          &remote_ssh,
-@@ -186,6 +187,7 @@ pub(crate) fn run_remote(remote: RemoteLaunch) -> io::Result<()> {
+@@ -193,6 +194,7 @@ pub(crate) fn run_remote(remote: RemoteLaunch) -> io::Result<()> {
          local_socket.clone(),
          session_name,
          remote_ssh.options(),
@@ -92,7 +92,7 @@ index 6fe927c..55a0764 100644
      )?;
  
      run_client_process(&local_socket, &reattach_command, remote.keybindings)
-@@ -453,10 +455,11 @@ impl Drop for ManagedSshConfig {
+@@ -420,10 +422,11 @@ impl Drop for ManagedSshConfig {
  struct RemoteSsh {
      target: String,
      managed_config: Option<ManagedSshConfig>,
@@ -105,7 +105,7 @@ index 6fe927c..55a0764 100644
          let managed_config = if manage_ssh_config {
              write_managed_ssh_config()
                  .inspect_err(|err| {
-@@ -470,6 +473,7 @@ impl RemoteSsh {
+@@ -437,6 +440,7 @@ impl RemoteSsh {
          Self {
              target,
              managed_config,
@@ -113,7 +113,7 @@ index 6fe927c..55a0764 100644
          }
      }
  
-@@ -488,7 +492,7 @@ impl RemoteSsh {
+@@ -455,7 +459,7 @@ impl RemoteSsh {
      }
  
      fn base_command(&self) -> Command {
@@ -122,26 +122,26 @@ index 6fe927c..55a0764 100644
          apply_managed_ssh_options(&mut command, self.options());
          command
      }
-@@ -1706,6 +1710,7 @@ impl SshStdioBridge {
+@@ -1672,6 +1676,7 @@ impl SshStdioBridge {
          local_socket: PathBuf,
          session_name: String,
          ssh_options: Option<&ManagedSshOptions>,
 +        ssh_program: String,
      ) -> io::Result<Self> {
-         let _ = std::fs::remove_file(&local_socket);
-         let listener = UnixListener::bind(&local_socket)?;
-@@ -1731,6 +1736,7 @@ impl SshStdioBridge {
-                             &remote_herdr,
+         crate::ipc::prepare_socket_path(&local_socket, |path| {
+             format!("remote bridge is already listening at {}", path.display())
+@@ -1713,6 +1718,7 @@ impl SshStdioBridge {
                              &session_name,
                              thread_ssh_options.as_ref(),
+                             &thread_stop,
 +                            &ssh_program,
                          ) {
                              eprintln!("herdr: remote bridge failed: {err}");
                          }
-@@ -1865,8 +1871,9 @@ fn bridge_connection(
-     remote_herdr: &RemoteHerdr,
+@@ -1821,8 +1827,9 @@ fn bridge_connection(
      session_name: &str,
      ssh_options: Option<&ManagedSshOptions>,
+     _bridge_stop: &Arc<AtomicBool>,
 +    ssh_program: &str,
  ) -> io::Result<()> {
 -    let mut command = Command::new("ssh");
@@ -149,7 +149,18 @@ index 6fe927c..55a0764 100644
      apply_managed_ssh_options(&mut command, ssh_options);
      command
          .arg("-T")
-@@ -2046,6 +2053,7 @@ mod tests {
+@@ -1876,8 +1883,9 @@ fn bridge_connection(
+     session_name: &str,
+     ssh_options: Option<&ManagedSshOptions>,
+     bridge_stop: &Arc<AtomicBool>,
++    ssh_program: &str,
+ ) -> io::Result<()> {
+-    let mut command = Command::new("ssh");
++    let mut command = Command::new(ssh_program);
+     apply_managed_ssh_options(&mut command, ssh_options);
+     command
+         .arg("-T")
+@@ -2208,6 +2216,7 @@ mod tests {
              socket.clone(),
              "default".to_string(),
              None,
@@ -157,7 +168,15 @@ index 6fe927c..55a0764 100644
          )
          .expect("start bridge listener");
  
-@@ -2132,6 +2140,7 @@ mod tests {
+@@ -2268,6 +2277,7 @@ mod tests {
+             socket.clone(),
+             "default".to_string(),
+             None,
++            "ssh".to_string(),
+         )
+         .expect("start bridge listener");
+         let started = Instant::now();
+@@ -2364,6 +2374,7 @@ mod tests {
          let ssh = RemoteSsh {
              target: "example".to_string(),
              managed_config: Some(managed_config),
@@ -165,7 +184,15 @@ index 6fe927c..55a0764 100644
          };
  
          let command = ssh.command();
-@@ -2162,6 +2171,7 @@ mod tests {
+@@ -2402,6 +2413,7 @@ mod tests {
+         let ssh = RemoteSsh {
+             target: "example".to_string(),
+             managed_config: Some(managed_config),
++            program: "ssh".to_string(),
+         };
+         let args = ssh
+             .command()
+@@ -2433,6 +2445,7 @@ mod tests {
          let ssh = RemoteSsh {
              target: "example".to_string(),
              managed_config: None,
@@ -173,7 +200,7 @@ index 6fe927c..55a0764 100644
          };
  
          let command = ssh.command();
-@@ -2173,6 +2183,21 @@ mod tests {
+@@ -2444,6 +2457,21 @@ mod tests {
          assert_eq!(args, vec!["-T".to_string(), "example".to_string()]);
      }
  

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -23,9 +23,25 @@
     "padding": 0
   },
   "alwaysThinkingEnabled": true,
+  "effortLevel": "low",
   "autoUpdatesChannel": "latest",
+  "tui": "fullscreen",
   "theme": "light-daltonized",
   "autoCompactEnabled": false,
+  "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "effortLevel": "low"
+  "autoMode": {
+    "allow": [
+      "$defaults",
+      "Bash(gh run view:*)",
+      "Bash(nix-locate:*)",
+      "Bash(pueue status:*)"
+    ],
+    "soft_deny": [
+      "$defaults",
+      "Bash(gh cache delete:*)"
+    ],
+    "environment": []
+  },
+  "skipWorkflowUsageWarning": true
 }

--- a/home/.pi/agent/extensions/python/index.ts
+++ b/home/.pi/agent/extensions/python/index.ts
@@ -55,7 +55,7 @@ export default function (pi: ExtensionAPI) {
     description:
       "Execute Python code in a persistent interpreter: variables, imports and open files survive between calls for the whole session. " +
       "The value of a trailing expression is echoed like in a REPL; use print() for anything else. " +
-      "matplotlib figures are returned as images. Available: polars, matplotlib, requests, pexpect, pyelftools + stdlib. " +
+      "matplotlib figures are returned as images. Available: polars, matplotlib, requests, plumbum, pexpect, pyelftools + stdlib. " +
       `Output is truncated to the last ${DEFAULT_MAX_LINES} lines / ${
         formatSize(DEFAULT_MAX_BYTES)
       }.`,

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -494,6 +494,7 @@ alias gdb='gdb --quiet --args'
 alias readelf='readelf -W'
 xalias xclip="xclip -selection clipboard"
 xalias cloc=scc
+xalias pi='pi --exclude-tools bash'
 
 nix-call-package() {
     if [ $# -lt 1 ]; then

--- a/machines/eve/configuration.nix
+++ b/machines/eve/configuration.nix
@@ -22,7 +22,6 @@
     self.inputs.srvos.nixosModules.server
     self.inputs.srvos.nixosModules.mixins-nginx
     self.inputs.srvos.nixosModules.hardware-hetzner-online-amd
-    self.inputs.flakelet.nixosModules.flakelet
     self.inputs.flakelet-nginx.nixosModules.provider
     self.inputs.flakelet-postgres.nixosModules.provider
     self.inputs.disko.nixosModules.disko

--- a/machines/eve/modules/disko.nix
+++ b/machines/eve/modules/disko.nix
@@ -72,8 +72,15 @@ in
           };
           "root/nixos" = {
             type = "zfs_fs";
-            options.mountpoint = "/";
             mountpoint = "/";
+            options = {
+              mountpoint = "/";
+              # nix-store/postgres churn is several 100G/day; long-lived
+              # snapshots filled the pool. Keep only frequent+hourly (24h).
+              "com.sun:auto-snapshot:daily" = "false";
+              "com.sun:auto-snapshot:weekly" = "false";
+              "com.sun:auto-snapshot:monthly" = "false";
+            };
           };
           "root/home" = {
             type = "zfs_fs";
@@ -86,6 +93,7 @@ in
             options = {
               mountpoint = "/tmp";
               sync = "disabled";
+              "com.sun:auto-snapshot" = "false";
             };
           };
           "root/docker" = {

--- a/machines/eve/modules/flakelet-relay.nix
+++ b/machines/eve/modules/flakelet-relay.nix
@@ -1,33 +1,13 @@
-{ config, self, ... }:
+{ ... }:
 {
-  imports = [
-    ../../../nixosModules/flakelet-relay
-    self.inputs.flakelet-relay.nixosModules.agent
-  ];
+  imports = [ ../../../nixosModules/flakelet-relay ];
 
   services.flakelet-relay.acmeHost = "thalheim.io";
 
-  # Agent identity: ACME cert for eve.r from step-ca (ca.r).
-  security.acme.certs."eve.r" = {
-    server = config.retiolum.ca.acmeURL;
-    reloadServices = [ "flakelet-agent.service" ];
-  };
-  services.nginx.virtualHosts."eve.r".enableACME = true;
-
-  systemd.services.flakelet-agent = rec {
-    wants = [ "acme-eve.r.service" ];
-    after = wants;
-  };
-  services.flakelet-agent = {
-    enable = true;
-    relaySrv = "thalheim.io";
-    certFile = "/var/lib/acme/eve.r/fullchain.pem";
-    keyFile = "/var/lib/acme/eve.r/key.pem";
-    flakelets = [
-      "tribuchet-hub"
-      "nixbot"
-    ];
-  };
+  services.flakelet-agent.flakelets = [
+    "tribuchet-hub"
+    "nixbot"
+  ];
 
   # `flakelet-push login --issuer https://auth.thalheim.io`
   services.authelia.instances.main.settings.identity_providers.oidc = {

--- a/machines/eve/modules/nixbot.nix
+++ b/machines/eve/modules/nixbot.nix
@@ -54,7 +54,7 @@ in
   clan.core.vars.generators.buildbot-gitea = {
     files.token = { };
     files.oauth-secret = { };
-    prompts.token.description = "Gitea access token (write:repository, read:user)";
+    prompts.token.description = "Gitea access token (write:repository, write:issue, read:user)";
     prompts.oauth-secret.description = "Gitea OAuth client secret";
     script = ''
       cp $prompts/token $out/token

--- a/nixosModules/flakelet-relay/default.nix
+++ b/nixosModules/flakelet-relay/default.nix
@@ -2,6 +2,9 @@
 # device login or step-ca client cert) ask it to run `flakelet update`
 # on agents that dial in with step-ca ACME certs over retiolum. Both
 # relays are listed under _flakelet-relay._tcp.thalheim.io.
+#
+# The relay itself runs as a flakelet so CI can redeploy it through the
+# agents; a restart drops streams but `push` fails over to the other relay.
 {
   config,
   lib,
@@ -17,9 +20,14 @@ let
     ${config.retiolum.ca.intermediateCA}
   '';
   cert = config.security.acme.certs.${config.services.flakelet-relay.acmeHost};
+  # Agent identity: ACME cert for <host>.r from step-ca (ca.r).
+  agentHost = "${config.networking.hostName}.r";
 in
 {
-  imports = [ self.inputs.flakelet-relay.nixosModules.relay ];
+  imports = [
+    self.inputs.flakelet.nixosModules.flakelet
+    self.inputs.flakelet-relay.nixosModules.agent
+  ];
 
   options.services.flakelet-relay.acmeHost = lib.mkOption {
     type = lib.types.str;
@@ -27,90 +35,129 @@ in
   };
 
   config = {
-    services.flakelet-relay = {
+    services.flakelets = {
       enable = true;
-      tls = {
-        certFile = "${cert.directory}/fullchain.pem";
-        keyFile = "${cert.directory}/key.pem";
-        clientCAFiles = [ clientCa ];
-      };
-      settings = {
-        listenHttp = "127.0.0.1:7400";
-        listenTls = "[::]:7443";
-        issuers = {
-          nixbot = {
-            url = "https://nixbot.thalheim.io";
-            audience = "flakelet-relay";
-          };
-          # Authelia's sub is opaque, match on email and groups instead.
-          authelia = {
-            url = "https://auth.thalheim.io";
-            audience = "flakelet-push";
-            principalClaims = [
-              "email"
-              "groups"
+      services.flakelet-relay = {
+        flake = "github:Mic92/flakelet-relay";
+        autoUpdate.enable = true;
+        settings = {
+          certFile = "${cert.directory}/fullchain.pem";
+          keyFile = "${cert.directory}/key.pem";
+          clientCAFiles = [ "${clientCa}" ];
+          settings = {
+            name = config.networking.hostName;
+            listenHttp = "127.0.0.1:7400";
+            listenTls = "[::]:7443";
+            issuers = {
+              nixbot = {
+                url = "https://nixbot.thalheim.io";
+                audience = "flakelet-relay";
+              };
+              # Authelia's sub is opaque, match on email and groups instead.
+              authelia = {
+                url = "https://auth.thalheim.io";
+                audience = "flakelet-push";
+                principalClaims = [
+                  "email"
+                  "groups"
+                ];
+              };
+            };
+            agents = {
+              eve = [ "x509:dns:eve.r" ];
+              eva = [ "x509:dns:eva.r" ];
+              eliza = [ "x509:dns:eliza.r" ];
+              jamie = [ "x509:dns:jamie.r" ];
+            };
+            groups.tum = [
+              "eliza"
+              "jamie"
             ];
-          };
-        };
-        agents = {
-          eve = [ "x509:dns:eve.r" ];
-          eliza = [ "x509:dns:eliza.r" ];
-          jamie = [ "x509:dns:jamie.r" ];
-        };
-        groups.tum = [
-          "eliza"
-          "jamie"
-        ];
-        rules = {
-          tribuchet = {
-            principals = [ "oidc:nixbot:repo:github:Mic92/tribuchet:ref:refs/heads/main" ];
-            targets = [
-              "eve/tribuchet-hub"
-              "@tum/tribuchet-worker"
+            groups.relays = [
+              "eve"
+              "eva"
             ];
+            rules = {
+              tribuchet = {
+                principals = [ "oidc:nixbot:repo:github:Mic92/tribuchet:ref:refs/heads/main" ];
+                targets = [
+                  "eve/tribuchet-hub"
+                  "@tum/tribuchet-worker"
+                ];
+              };
+              nixbot = {
+                principals = [ "oidc:nixbot:repo:github:Mic92/nixbot:ref:refs/heads/main" ];
+                targets = [ "eve/nixbot" ];
+              };
+              flakelet-relay = {
+                principals = [ "oidc:nixbot:repo:github:Mic92/flakelet-relay:ref:refs/heads/main" ];
+                targets = [ "@relays/flakelet-relay" ];
+              };
+              admin = {
+                principals = [
+                  "x509:email:joerg@thalheim.io"
+                  "oidc:authelia:email:joerg@thalheim.io"
+                ];
+                targets = [ "*/*" ];
+              };
+            };
           };
-          nixbot = {
-            principals = [ "oidc:nixbot:repo:github:Mic92/nixbot:ref:refs/heads/main" ];
-            targets = [ "eve/nixbot" ];
-          };
-          admin = {
-            principals = [
-              "x509:email:joerg@thalheim.io"
-              "oidc:authelia:email:joerg@thalheim.io"
-            ];
-            targets = [ "*/*" ];
-          };
-        };
-      };
-      policyChecks = [
-        {
-          principals = [ "oidc:nixbot:repo:github:Mic92/tribuchet:ref:refs/heads/main" ];
-          targets = [
-            "eve/tribuchet-hub"
-            "eliza/tribuchet-worker"
-            "jamie/tribuchet-worker"
+          policyChecks = [
+            {
+              principals = [ "oidc:nixbot:repo:github:Mic92/tribuchet:ref:refs/heads/main" ];
+              targets = [
+                "eve/tribuchet-hub"
+                "eliza/tribuchet-worker"
+                "jamie/tribuchet-worker"
+              ];
+            }
+            {
+              principals = [ "oidc:nixbot:repo:github:Mic92/flakelet-relay:ref:refs/heads/main" ];
+              targets = [
+                "eve/flakelet-relay"
+                "eva/flakelet-relay"
+              ];
+            }
+            {
+              principals = [ "oidc:nixbot:repo:github:Mic92/tribuchet:ref:refs/pull/1/merge" ];
+              targets = [ "eve/tribuchet-hub" ];
+              allow = false;
+            }
+            {
+              principals = [ "oidc:nixbot:repo:github:Mic92/nixbot:ref:refs/heads/main" ];
+              targets = [ "eve/tribuchet-hub" ];
+              allow = false;
+            }
+            {
+              principals = [ "oidc:authelia:email:joerg@thalheim.io" ];
+              targets = [ "jamie/anything" ];
+            }
           ];
-        }
-        {
-          principals = [ "oidc:nixbot:repo:github:Mic92/tribuchet:ref:refs/pull/1/merge" ];
-          targets = [ "eve/tribuchet-hub" ];
-          allow = false;
-        }
-        {
-          principals = [ "oidc:nixbot:repo:github:Mic92/nixbot:ref:refs/heads/main" ];
-          targets = [ "eve/tribuchet-hub" ];
-          allow = false;
-        }
-        {
-          principals = [ "oidc:authelia:email:joerg@thalheim.io" ];
-          targets = [ "jamie/anything" ];
-        }
-      ];
+        };
+      };
     };
 
     security.acme.certs.${config.services.flakelet-relay.acmeHost}.reloadServices = [
       "flakelet-relay.service"
     ];
+
+    # So the relay flakelet above can be pushed here.
+    security.acme.certs.${agentHost} = {
+      server = config.retiolum.ca.acmeURL;
+      reloadServices = [ "flakelet-agent.service" ];
+    };
+    services.nginx.virtualHosts.${agentHost}.enableACME = true;
+    systemd.services.flakelet-agent = rec {
+      wants = [ "acme-${agentHost}.service" ];
+      after = wants;
+    };
+    services.flakelet-agent = {
+      enable = true;
+      relaySrv = "thalheim.io";
+      certFile = "/var/lib/acme/${agentHost}/fullchain.pem";
+      keyFile = "/var/lib/acme/${agentHost}/key.pem";
+      flakelets = [ "flakelet-relay" ];
+    };
 
     networking.firewall.allowedTCPPorts = [ 7443 ];
   };

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -40,6 +40,8 @@ in
     herdr-sesh = pkgs.callPackage ./herdr-sesh { };
     # herdr plugin: tmux-like automatic tab names
     herdr-autoname = pkgs.callPackage ./herdr-autoname { };
+    # herdr plugin: sort tabs into per-project workspaces
+    herdr-autospace = pkgs.callPackage ./herdr-autospace { };
     ghidra-cli = pkgs.callPackage ./ghidra-cli { };
     # Cross-platform secure pinentry (works on macOS and Linux)
     rbw-pinentry = pkgs.callPackage ./rbw_pinentry { };

--- a/pkgs/herdr-autospace/default.nix
+++ b/pkgs/herdr-autospace/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenvNoCC,
+  python3,
+  git,
+  makeWrapper,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "herdr-autospace";
+  version = "0.1.0";
+
+  src = lib.cleanSource ./.;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ python3 ];
+
+  # Ship as a herdr plugin directory: manifest at the root, script under bin/.
+  # herdr itself comes from the calling environment (the running server's CLI).
+  installPhase = ''
+    install -Dm755 herdr_autospace.py $out/bin/herdr-autospace
+    patchShebangs $out/bin
+    wrapProgram $out/bin/herdr-autospace --prefix PATH : ${lib.makeBinPath [ git ]}
+    cp herdr-plugin.toml $out/
+  '';
+
+  meta = {
+    description = "Sort herdr tabs into workspaces by project directory";
+    license = lib.licenses.mit;
+    mainProgram = "herdr-autospace";
+  };
+}

--- a/pkgs/herdr-autospace/herdr-plugin.toml
+++ b/pkgs/herdr-autospace/herdr-plugin.toml
@@ -1,0 +1,12 @@
+id = "herdr-autospace"
+name = "Herdr Autospace"
+version = "0.1.0"
+min_herdr_version = "0.8.0"
+description = "Sort tabs into workspaces named after their project directory"
+platforms = ["linux", "macos"]
+
+[[actions]]
+id = "sort"
+title = "Sort Tabs into Workspaces by Directory"
+contexts = ["workspace", "pane"]
+command = ["bin/herdr-autospace"]

--- a/pkgs/herdr-autospace/herdr_autospace.py
+++ b/pkgs/herdr-autospace/herdr_autospace.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Sort herdr tabs into workspaces named after their project directory.
+
+A tab's project is the git toplevel of its active pane's cwd (or the cwd
+itself outside git). The workspace for a project is the one labelled with the
+project's basename -- the naming herdr-sesh uses -- and is created on demand.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+def herdr(*args: str) -> dict[str, Any]:
+    out = subprocess.run(
+        ["herdr", *args], check=True, capture_output=True, text=True
+    ).stdout
+    result: dict[str, Any] = json.loads(out)["result"]
+    return result
+
+
+def project_dir(cwd: str) -> Path:
+    proc = subprocess.run(
+        ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    top = proc.stdout.strip()
+    return Path(top) if proc.returncode == 0 and top else Path(cwd)
+
+
+@dataclass
+class Pane:
+    pane_id: str
+    tab_id: str
+    workspace_id: str
+    cwd: str
+    focused: bool
+
+
+@dataclass
+class Move:
+    tab_id: str
+    tab_label: str
+    pane_ids: list[str]  # active pane first
+    project: Path
+
+
+def active_pane(panes: list[Pane]) -> Pane:
+    return next((p for p in panes if p.focused), panes[0])
+
+
+def plan(
+    tabs: list[dict[str, Any]],
+    panes: list[Pane],
+    workspace_labels: dict[str, str],
+) -> list[Move]:
+    """Tabs whose project basename differs from their workspace's label."""
+    moves = []
+    for tab in tabs:
+        in_tab = [p for p in panes if p.tab_id == tab["tab_id"]]
+        if not in_tab:
+            continue
+        lead = active_pane(in_tab)
+        if not lead.cwd:
+            continue
+        project = project_dir(lead.cwd)
+        if workspace_labels.get(tab["workspace_id"]) == project.name:
+            continue
+        rest = [p.pane_id for p in in_tab if p is not lead]
+        moves.append(
+            Move(tab["tab_id"], tab.get("label", ""), [lead.pane_id, *rest], project)
+        )
+    return moves
+
+
+def apply(move: Move, by_label: dict[str, str]) -> None:
+    lead, *rest = move.pane_ids
+    target = by_label.get(move.project.name)
+    if target is None:
+        res = herdr(
+            "pane", "move", lead,
+            "--new-workspace", "--label", move.project.name,
+            "--tab-label", move.tab_label, "--no-focus",
+        )["move_result"]  # fmt: skip
+        by_label[move.project.name] = res["created_workspace"]["workspace_id"]
+    else:
+        res = herdr(
+            "pane", "move", lead,
+            "--new-tab", "--workspace", target,
+            "--label", move.tab_label, "--no-focus",
+        )["move_result"]  # fmt: skip
+    new_tab = res["pane"]["tab_id"]
+    # Remaining panes lose their layout but stay together in the tab. Their
+    # ids are workspace-scoped and unchanged until they themselves move.
+    for pane_id in rest:
+        herdr(
+            "pane", "move", pane_id, "--tab", new_tab, "--split", "right", "--no-focus"
+        )
+
+
+def main() -> None:
+    workspaces = herdr("workspace", "list")["workspaces"]
+    tabs = herdr("tab", "list")["tabs"]
+    panes = [
+        Pane(
+            p["pane_id"],
+            p["tab_id"],
+            p["workspace_id"],
+            p.get("foreground_cwd") or p.get("cwd") or "",
+            bool(p.get("focused")),
+        )
+        for p in herdr("pane", "list")["panes"]
+    ]
+    labels = {w["workspace_id"]: w.get("label", "") for w in workspaces}
+    by_label = {label: wid for wid, label in labels.items() if label}
+    # Move the focused tab last so focus stays where the user is looking.
+    current = os.environ.get("HERDR_TAB_ID")
+    moves = sorted(plan(tabs, panes, labels), key=lambda m: m.tab_id == current)
+    for move in moves:
+        try:
+            apply(move, by_label)
+        except (subprocess.CalledProcessError, KeyError) as err:
+            print(f"herdr-autospace: {move.tab_id}: {err}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

The relay no longer ships a NixOS module (Mic92/flakelet-relay#4); CI
redeploys it through the agents instead of waiting for a NixOS rebuild.
eva gets an agent with an eva.r step-ca cert so it can receive that push,
and the policy gains a rule for the flakelet-relay repo targeting both
relays.

Change-Id: Ia4f7e1f128715f50b5349db5a1430ba13c7c1fac


