### PR TITLE
pi python: detach user code and children from the request pipe

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -26,6 +26,7 @@
   "effortLevel": "low",
   "autoUpdatesChannel": "latest",
   "tui": "fullscreen",
+  "skipWorkflowUsageWarning": true,
   "theme": "light-daltonized",
   "autoCompactEnabled": false,
   "agentPushNotifEnabled": true,
@@ -35,13 +36,39 @@
       "$defaults",
       "Bash(gh run view:*)",
       "Bash(nix-locate:*)",
-      "Bash(pueue status:*)"
+      "Bash(pueue status:*)",
+      "Bash(systemd-inhibit:*)"
     ],
     "soft_deny": [
       "$defaults",
-      "Bash(gh cache delete:*)"
+      "Bash(gh cache delete:*)",
+      "Bash(pueue reset:*)"
     ],
-    "environment": []
-  },
-  "skipWorkflowUsageWarning": true
+    "environment": [
+      "### Org-wide",
+      "**Organization**: None configured",
+      "**Cloud provider(s)**: None configured",
+      "**Repository visibility**: assume private unless the remote host and repo name indicate otherwise, or a visibility check in the transcript shows public — this repo (/home/joerg/git/deptrace) has no configured git remote, so it is local-only and not published anywhere",
+      "**Internal sharing / snippet hosting**: None configured — treat public paste/gist services as outside the trust boundary",
+      "**Secrets management**: None configured",
+      "**Default / protected branches**: unknown — origin/HEAD is unset and the repo has no remote, so no branch protection or ruleset information is available",
+      "**CI/CD deploy targets**: None configured",
+      "**Network posture**: None configured",
+      "**Source control**: The trusted repo and its remote(s) only (no additional orgs configured) — as scoped by the Trusted repo and Repository visibility entries above; this checkout currently has no remote at all",
+      "**Trusted internal domains**: None configured",
+      "**Trusted cloud buckets**: None configured",
+      "**Key internal services**: None configured",
+      "**Internal package registry**: None configured",
+      "**Sensitive data locations & audiences**: any file or store holding personal data, confidential business data, credentials, regulated data, or similarly sensitive material; preserve exact handles when known and share only with audiences cleared at the [named+specifics] bar. In this checkout, .envrc is a sensitive-looking path and should be treated as potentially credential-bearing",
+      "**Data retention / declassification**: None configured",
+      "**Sensitive remote targets**: any namespace, host, or container whose name carries `prod` or `production` as a whole word or name segment (hyphen/underscore/dot-delimited — e.g. matches `prod-db`, not `producer`)",
+      "**Protected deployment namespaces / environments**: None configured — fall back to the Sensitive remote targets heuristic",
+      "**Protected IaC scopes**: IAM, RBAC, networking, quota, and node-pool resources; anything whose name or tag carries `prod` or `production` as a whole word or name segment",
+      "### User-specific",
+      "**Primary use of Claude Code**: software development — Nix/NixOS packaging and flake work, Rust and Python development, and kernel/tracing-adjacent work in this local `deptrace` checkout",
+      "**Trusted repo**: /home/joerg/git/deptrace (the git repository the agent started in). It has no configured remote, so it is a local-only, effectively private repo: confidential material is fine there, but secrets and sensitive data are never cleared into it by visibility alone. Pushing or repointing it to any new remote is a publication decision, not routine work",
+      "**Org-specific CLIs**: None configured — observed personal tooling in shell history includes `nix`, `nix-build`, `nix-review`, `nix-locate`, `homeshick`, `pueue`, `merge-when-green`, `clan`, `jj`, `rbw`, `sops`, `inv`, and `tea`; `rbw` and `sops` are credential/secret tools and stay outside routine automation",
+      "**Routine under user prefix**: no `<user>/` namespace qualifier was observed; work is scoped to this single local checkout under /home/joerg/git/"
+    ]
+  }
 }

--- a/home/.pi/agent/extensions/python/driver.py
+++ b/home/.pi/agent/extensions/python/driver.py
@@ -4,8 +4,10 @@ Request:  {"code": str}
 Response: {"stdout": str, "stderr": str, "result": str|null,
            "error": str|null, "images": [base64 png, ...]}
 
-fd 1 is reserved for the protocol; stray writes from child processes or C
-extensions are diverted to stderr so they cannot corrupt the stream.
+fd 0/1 carry the protocol and are moved to private descriptors: stray writes
+from child processes or C extensions go to stderr, and anything reading stdin
+(user code, spawned git/gh/ssh prompting for input) sees EOF instead of
+blocking forever on - or consuming - the request stream.
 """
 # ruff: noqa: INP001, S102, S307 - standalone script whose job is exec/eval
 
@@ -22,8 +24,13 @@ from typing import Any
 
 os.environ.setdefault("MPLBACKEND", "Agg")
 
+requests = os.fdopen(os.dup(0), "r")
 proto = os.fdopen(os.dup(1), "w", buffering=1)
+devnull = os.open(os.devnull, os.O_RDONLY)
+os.dup2(devnull, 0)
+os.close(devnull)
 os.dup2(2, 1)
+sys.stdin = os.fdopen(0, "r", closefd=False)
 
 ns: dict[str, Any] = {"__name__": "__main__"}
 
@@ -82,7 +89,7 @@ def main() -> None:
         # SIGINT is only meaningful while user code runs; ignore it when idle
         # so a late interrupt does not kill the session.
         signal.signal(signal.SIGINT, signal.SIG_IGN)
-        line = sys.stdin.readline()
+        line = requests.readline()
         if not line:
             return
         req = json.loads(line)

--- a/home/.pi/agent/extensions/python/kernel.test.ts
+++ b/home/.pi/agent/extensions/python/kernel.test.ts
@@ -52,6 +52,15 @@ describe.skipIf(!hasPython)("python kernel", () => {
     expect(r.stderr).toContain("raw");
   });
 
+  test("stdin readers get EOF instead of hanging on the request stream", async () => {
+    const r = await k.exec(
+      "import subprocess, sys\n(subprocess.run(['cat'], capture_output=True, timeout=5).stdout, sys.stdin.read())",
+    );
+    expect(r.error).toBeNull();
+    expect(r.result).toBe("(b'', '')");
+    expect((await k.exec("1")).result).toBe("1");
+  });
+
   test("abort interrupts running code but keeps state", async () => {
     const ac = new AbortController();
     const p = k.exec(

--- a/machines/eva/modules/flakelet-relay.nix
+++ b/machines/eva/modules/flakelet-relay.nix
@@ -2,10 +2,9 @@
 {
   imports = [ ../../../nixosModules/flakelet-relay ];
 
-  services.flakelet-relay.acmeHost = "eva.thalheim.io";
-  services.nginx.virtualHosts."eva.thalheim.io" = {
-    enableACME = true;
-    forceSSL = true;
-    locations."/".return = "404";
+  services.flakelet-relay = {
+    acmeHost = "eva.thalheim.io";
+    domain = "eva.thalheim.io";
   };
+  services.nginx.virtualHosts."eva.thalheim.io".enableACME = true;
 }

--- a/machines/eve/modules/flakelet-relay.nix
+++ b/machines/eve/modules/flakelet-relay.nix
@@ -2,14 +2,20 @@
 {
   imports = [ ../../../nixosModules/flakelet-relay ];
 
-  services.flakelet-relay.acmeHost = "thalheim.io";
+  services.flakelet-relay = {
+    acmeHost = "thalheim.io";
+    domain = "flakelet.thalheim.io";
+  };
+  services.nginx.virtualHosts."flakelet.thalheim.io".useACMEHost = "thalheim.io";
 
   services.flakelet-agent.flakelets = [
     "tribuchet-hub"
     "nixbot"
   ];
 
-  # `flakelet-push login --issuer https://auth.thalheim.io`
+  # One public client for both `flakelet-push login` (device flow) and the
+  # dashboard on either relay (authorization code + PKCE); the relay checks
+  # the id_token audience, so they must share the client_id.
   services.authelia.instances.main.settings.identity_providers.oidc = {
     claims_policies.flakelet-push.id_token = [
       "email"
@@ -19,26 +25,44 @@
       id_token = "1 hour";
       refresh_token = "1 month";
     };
+    authorization_policies.flakelet = {
+      default_policy = "deny";
+      rules = [
+        {
+          policy = "one_factor";
+          subject = [ "group:flakelet" ];
+        }
+      ];
+    };
     clients = [
       {
         client_id = "flakelet-push";
-        client_name = "flakelet-push";
+        client_name = "flakelet";
         public = true;
         token_endpoint_auth_method = "none";
+        require_pkce = true;
+        pkce_challenge_method = "S256";
         grant_types = [
+          "authorization_code"
           "urn:ietf:params:oauth:grant-type:device_code"
           "refresh_token"
+        ];
+        redirect_uris = [
+          "https://flakelet.thalheim.io/ui/callback"
+          "https://eva.thalheim.io/ui/callback"
         ];
         scopes = [
           "openid"
           "offline_access"
           "email"
+          "profile"
           "groups"
         ];
         claims_policy = "flakelet-push";
         lifespan = "flakelet-push";
-        authorization_policy = "one_factor";
+        authorization_policy = "flakelet";
       }
     ];
   };
+  services.lldap.ensureGroups = [ "flakelet" ];
 }

--- a/nixosModules/flakelet-relay/default.nix
+++ b/nixosModules/flakelet-relay/default.nix
@@ -29,9 +29,15 @@ in
     self.inputs.flakelet-relay.nixosModules.agent
   ];
 
-  options.services.flakelet-relay.acmeHost = lib.mkOption {
-    type = lib.types.str;
-    description = "security.acme.certs entry served on :7443. Must cover <host>.thalheim.io, the SRV target.";
+  options.services.flakelet-relay = {
+    acmeHost = lib.mkOption {
+      type = lib.types.str;
+      description = "security.acme.certs entry served on :7443. Must cover <host>.thalheim.io, the SRV target.";
+    };
+    domain = lib.mkOption {
+      type = lib.types.str;
+      description = "nginx vhost (TLS configured by the machine) for the dashboard and client API. Must be a redirect_uri of the flakelet-push Authelia client on eve.";
+    };
   };
 
   config = {
@@ -61,6 +67,8 @@ in
                   "email"
                   "groups"
                 ];
+                # Dashboard login; public client with PKCE.
+                login.clientId = "flakelet-push";
               };
             };
             agents = {
@@ -96,7 +104,7 @@ in
               admin = {
                 principals = [
                   "x509:email:joerg@thalheim.io"
-                  "oidc:authelia:email:joerg@thalheim.io"
+                  "oidc:authelia:groups:flakelet"
                 ];
                 targets = [ "*/*" ];
               };
@@ -129,8 +137,13 @@ in
               allow = false;
             }
             {
-              principals = [ "oidc:authelia:email:joerg@thalheim.io" ];
+              principals = [ "oidc:authelia:groups:flakelet" ];
               targets = [ "jamie/anything" ];
+            }
+            {
+              principals = [ "oidc:authelia:email:someone@thalheim.io" ];
+              targets = [ "eve/nixbot" ];
+              allow = false;
             }
           ];
         };
@@ -157,6 +170,18 @@ in
       certFile = "/var/lib/acme/${agentHost}/fullchain.pem";
       keyFile = "/var/lib/acme/${agentHost}/key.pem";
       flakelets = [ "flakelet-relay" ];
+    };
+
+    services.nginx.virtualHosts.${config.services.flakelet-relay.domain} = {
+      forceSSL = true;
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:7400";
+        # SSE deploy/log streams.
+        extraConfig = ''
+          proxy_buffering off;
+          proxy_read_timeout 3600s;
+        '';
+      };
     };
 
     networking.firewall.allowedTCPPorts = [ 7443 ];

--- a/pkgs/herdr-autospace/herdr_autospace.py
+++ b/pkgs/herdr-autospace/herdr_autospace.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 """Sort herdr tabs into workspaces named after their project directory.
 
-A tab's project is the git toplevel of its active pane's cwd (or the cwd
-itself outside git). The workspace for a project is the one labelled with the
-project's basename -- the naming herdr-sesh uses -- and is created on demand.
+The workspace for a tab is the one labelled like herdr-sesh would name the
+active pane's cwd (origin repo name, else git toplevel basename, else cwd
+basename), created on demand. Tab labels set by herdr-autoname are not carried
+over so autoname keeps managing the moved tab under its new id.
 """
 
 import json
 import os
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -23,15 +25,47 @@ def herdr(*args: str) -> dict[str, Any]:
     return result
 
 
-def project_dir(cwd: str) -> Path:
+def git(cwd: str, *args: str) -> str | None:
     proc = subprocess.run(
-        ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
-        capture_output=True,
-        text=True,
-        check=False,
+        ["git", "-C", cwd, *args], capture_output=True, text=True, check=False
     )
-    top = proc.stdout.strip()
-    return Path(top) if proc.returncode == 0 and top else Path(cwd)
+    out = proc.stdout.strip()
+    return out if proc.returncode == 0 and out else None
+
+
+def repo_name(remote: str) -> str:
+    """Repository name of a git remote URL, as herdr-sesh derives it."""
+    remote = remote.removesuffix(".git")
+    if ":" in remote and "://" not in remote:
+        remote = remote.rsplit(":", 1)[1]
+    name = remote.rstrip("/").rsplit("/", 1)[-1]
+    return re.sub(r"[^A-Za-z0-9._/-]+", "-", name)
+
+
+def project_name(cwd: str) -> str:
+    """Workspace label for a directory; must match herdr-sesh's Namer."""
+    top = git(cwd, "rev-parse", "--show-toplevel")
+    if top is None:
+        return Path(cwd).name
+    remote = git(cwd, "config", "--get", "remote.origin.url")
+    return repo_name(remote) if remote else Path(top).name
+
+
+def autoname_state() -> dict[str, str]:
+    """tab_id -> label last set by herdr-autoname."""
+    base = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local/state")
+    try:
+        text = (Path(base) / "herdr-autoname/tabs").read_text()
+    except OSError:
+        return {}
+    return dict(line.split("\t", 1) for line in text.splitlines() if "\t" in line)
+
+
+def user_label(tab_id: str, label: str, autonamed: dict[str, str]) -> str | None:
+    """The label if the user chose it, None for placeholders/autoname labels."""
+    if label.isdigit() or not label or autonamed.get(tab_id) == label:
+        return None
+    return label
 
 
 @dataclass
@@ -46,9 +80,9 @@ class Pane:
 @dataclass
 class Move:
     tab_id: str
-    tab_label: str
+    tab_label: str | None
     pane_ids: list[str]  # active pane first
-    project: Path
+    project: str
 
 
 def active_pane(panes: list[Pane]) -> Pane:
@@ -59,8 +93,9 @@ def plan(
     tabs: list[dict[str, Any]],
     panes: list[Pane],
     workspace_labels: dict[str, str],
+    autonamed: dict[str, str],
 ) -> list[Move]:
-    """Tabs whose project basename differs from their workspace's label."""
+    """Tabs whose project name differs from their workspace's label."""
     moves = []
     for tab in tabs:
         in_tab = [p for p in panes if p.tab_id == tab["tab_id"]]
@@ -69,32 +104,29 @@ def plan(
         lead = active_pane(in_tab)
         if not lead.cwd:
             continue
-        project = project_dir(lead.cwd)
-        if workspace_labels.get(tab["workspace_id"]) == project.name:
+        project = project_name(lead.cwd)
+        if workspace_labels.get(tab["workspace_id"]) == project:
             continue
         rest = [p.pane_id for p in in_tab if p is not lead]
-        moves.append(
-            Move(tab["tab_id"], tab.get("label", ""), [lead.pane_id, *rest], project)
-        )
+        label = user_label(tab["tab_id"], tab.get("label", ""), autonamed)
+        moves.append(Move(tab["tab_id"], label, [lead.pane_id, *rest], project))
     return moves
 
 
 def apply(move: Move, by_label: dict[str, str]) -> None:
     lead, *rest = move.pane_ids
-    target = by_label.get(move.project.name)
+    target = by_label.get(move.project)
     if target is None:
-        res = herdr(
-            "pane", "move", lead,
-            "--new-workspace", "--label", move.project.name,
-            "--tab-label", move.tab_label, "--no-focus",
-        )["move_result"]  # fmt: skip
-        by_label[move.project.name] = res["created_workspace"]["workspace_id"]
+        args = ["--new-workspace", "--label", move.project]
+        if move.tab_label:
+            args += ["--tab-label", move.tab_label]
     else:
-        res = herdr(
-            "pane", "move", lead,
-            "--new-tab", "--workspace", target,
-            "--label", move.tab_label, "--no-focus",
-        )["move_result"]  # fmt: skip
+        args = ["--new-tab", "--workspace", target]
+        if move.tab_label:
+            args += ["--label", move.tab_label]
+    res = herdr("pane", "move", lead, *args, "--no-focus")["move_result"]
+    if target is None:
+        by_label[move.project] = res["created_workspace"]["workspace_id"]
     new_tab = res["pane"]["tab_id"]
     # Remaining panes lose their layout but stay together in the tab. Their
     # ids are workspace-scoped and unchanged until they themselves move.
@@ -121,7 +153,10 @@ def main() -> None:
     by_label = {label: wid for wid, label in labels.items() if label}
     # Move the focused tab last so focus stays where the user is looking.
     current = os.environ.get("HERDR_TAB_ID")
-    moves = sorted(plan(tabs, panes, labels), key=lambda m: m.tab_id == current)
+    moves = sorted(
+        plan(tabs, panes, labels, autoname_state()),
+        key=lambda m: m.tab_id == current,
+    )
     for move in moves:
         try:
             apply(move, by_label)


### PR DESCRIPTION

fd 0 was the JSON request stream, so anything reading stdin - user
code or spawned git/gh/ssh prompting for input - blocked forever and
could swallow the next request. Keep the protocol on a private dup'd
fd and point fd 0/sys.stdin at /dev/null so readers get EOF.

Change-Id: Ib6a08032591693ab16d1ba2163d58419e8bb4ab7
