### PR TITLE
herdr: bind prefix+S to herdr-autospace sort

### DIFF
--- a/home/.config/herdr/config.toml
+++ b/home/.config/herdr/config.toml
@@ -53,6 +53,13 @@ type = "plugin_action"
 command = "rmarganti.herdr-pluck.pluck"
 description = "pluck visible token"
 
+# sort tabs into per-project workspaces (herdr-autospace)
+[[keys.command]]
+key = "prefix+shift+s"
+type = "plugin_action"
+command = "herdr-autospace.sort"
+description = "sort tabs into workspaces"
+
 # code review of the current repo with tuicr
 [[keys.command]]
 key = "prefix+shift+r"

--- a/home/.config/herdr/config.toml
+++ b/home/.config/herdr/config.toml
@@ -80,10 +80,10 @@ height = "70%"
 
 [theme]
 # tmux status bar uses folke tokyonight (night) palette
+# ghostty is pinned to "TokyoNight Night"
 name = "tokyo-night"
-auto_switch = true
-dark_name = "tokyo-night"
-light_name = "tokyo-night-day"
+# auto_switch misdetects it as light
+auto_switch = false
 
 [ui]
 # tabs are auto-named by the herdr-autoname plugin

--- a/home/.pi/agent/extensions/python/index.ts
+++ b/home/.pi/agent/extensions/python/index.ts
@@ -118,12 +118,22 @@ export default function (pi: ExtensionAPI) {
       kernel ??= new Kernel(python, ctx.cwd);
       const ac = new AbortController();
       signal?.addEventListener("abort", () => ac.abort(), { once: true });
+      let timedOut = false;
       const timer = params.timeout
-        ? setTimeout(() => ac.abort(), params.timeout * 1000)
+        ? setTimeout(() => {
+          timedOut = true;
+          ac.abort();
+        }, params.timeout * 1000)
         : undefined;
       const r = await kernel.exec(params.code, ac.signal).finally(() =>
         clearTimeout(timer)
       );
+      // Throw like bash so pi ends the run as "aborted" and sends queued prompts.
+      if (signal?.aborted) throw new Error("Command aborted");
+      if (timedOut && r.error?.startsWith("KeyboardInterrupt")) {
+        r.error =
+          `Timed out after ${params.timeout}s (cell interrupted, interpreter state kept)`;
+      }
 
       let text = r.stdout;
       if (r.stderr) {

--- a/machines/eve/modules/disko.nix
+++ b/machines/eve/modules/disko.nix
@@ -96,6 +96,22 @@ in
               "com.sun:auto-snapshot" = "false";
             };
           };
+          # Own dataset so a full root fs cannot take postgres down
+          # (reservation), and 16k records match its page-sized I/O.
+          "root/postgres" = {
+            type = "zfs_fs";
+            mountpoint = "/var/lib/postgresql/18";
+            options = {
+              mountpoint = "legacy";
+              reservation = "60G";
+              recordsize = "16k";
+              compression = "zstd";
+              logbias = "throughput";
+              "com.sun:auto-snapshot:daily" = "false";
+              "com.sun:auto-snapshot:weekly" = "false";
+              "com.sun:auto-snapshot:monthly" = "false";
+            };
+          };
           "root/docker" = {
             type = "zfs_fs";
             options.mountpoint = "none";

--- a/machines/eve/modules/disko.nix
+++ b/machines/eve/modules/disko.nix
@@ -107,9 +107,6 @@ in
               recordsize = "16k";
               compression = "zstd";
               logbias = "throughput";
-              "com.sun:auto-snapshot:daily" = "false";
-              "com.sun:auto-snapshot:weekly" = "false";
-              "com.sun:auto-snapshot:monthly" = "false";
             };
           };
           "root/docker" = {

--- a/machines/eve/modules/postgresql.nix
+++ b/machines/eve/modules/postgresql.nix
@@ -20,9 +20,7 @@
       let
         # XXX specify the postgresql package you'd like to upgrade to.
         # Do not forget to list the extensions you need.
-        newPostgres = pkgs.postgresql_15.withPackages (_pp: [
-          # pp.plv8
-        ]);
+        newPostgres = pkgs.postgresql_18;
         cfg = config.services.postgresql;
       in
       pkgs.writeScriptBin "upgrade-pg-cluster" ''

--- a/machines/eve/modules/postgresql.nix
+++ b/machines/eve/modules/postgresql.nix
@@ -6,7 +6,7 @@
 }:
 {
   services.postgresql.enable = true;
-  services.postgresql.package = pkgs.postgresql_14;
+  services.postgresql.package = pkgs.postgresql_18;
   services.postgresql.settings = {
     max_connections = "300";
     shared_buffers = "80MB";

--- a/machines/eve/modules/snappymail.nix
+++ b/machines/eve/modules/snappymail.nix
@@ -16,6 +16,11 @@ in
       upload_max_filesize = maxUploadSize;
       post_max_size = maxUploadSize;
       memory_limit = maxUploadSize;
+      # MailSo\Log\Logger installs a pcntl handler for SIGQUIT that
+      # persists in the FPM worker; the master's idle-reap SIGQUIT then
+      # hits zend_signal_handler in accept() and the worker dumps core
+      # (~1500 coredumps/day with pm=ondemand).
+      disable_functions = "pcntl_signal,pcntl_async_signals";
     };
 
     settings = {

--- a/machines/turingmachine/configuration.nix
+++ b/machines/turingmachine/configuration.nix
@@ -48,6 +48,8 @@
 
   hardware.graphics.enable32Bit = config.hardware.graphics.enable;
 
+  programs.steam.enable = true;
+
   nixpkgs.pkgs = self.inputs.nixpkgs.legacyPackages.x86_64-linux;
 
   services.rustdesk-client.users = [ "joerg" ];

--- a/nixosModules/niri/default.nix
+++ b/nixosModules/niri/default.nix
@@ -142,6 +142,9 @@ in
     cliphist
     wtype
 
+    # x11 support for niri has no built-in Xwayland
+    xwayland-satellite
+
     # App launcher, display config
     fuzzel
     libnotify


### PR DESCRIPTION

Plugin actions are only reachable through key bindings.

Change-Id: Ic92b918875c2623df1281e2904f65200cbadcaf1



pi python: throw on user abort like bash

pi only ends the run as "aborted" (and sends queued prompts) when the
tool throws; a normal return surfaced as a generic error instead.
Also label timeouts distinctly from user interrupts.

Change-Id: Ib5c9aff42cb5b371e7d489ac78fd18feca688204


