### PR TITLE
eva/telegraf: probe wiki ssh on he1 origin

### DIFF
--- a/machines/eva/modules/telegraf/nixos-wiki-infra.nix
+++ b/machines/eva/modules/telegraf/nixos-wiki-infra.nix
@@ -1,5 +1,6 @@
 let
-  hosts = [ "wiki.nixos.org" ];
+  # wiki.nixos.org itself resolves to Fastly; SSH lives on the origin host
+  hosts = [ "he1.wiki.nixos.org" ];
 in
 {
   services.telegraf.extraConfig.inputs = {


### PR DESCRIPTION

wiki.nixos.org now resolves to Fastly, which does not serve port 22,
causing flapping ConnectionFailed alerts.

Change-Id: I1373252008039ff14f423941be3c7444dd1092ec
